### PR TITLE
Add optical frame publisher

### DIFF
--- a/mbzirc_ign/launch/spawn.launch.py
+++ b/mbzirc_ign/launch/spawn.launch.py
@@ -114,6 +114,18 @@ def spawn_uav(context, model_path, world_name, model_name, link_name):
                   (sensor_prefix + '/camera_front/camera_info', 'front/camera_info')]
   )
 
+  # camera optical frame publisher
+  ros2_camera_optical_frame_publisher = Node(
+      package='mbzirc_ros',
+      executable='optical_frame_publisher',
+      arguments=['1'],
+      remappings=[('input/image', 'front/image_raw'),
+                  ('output/image', 'front/optical/image_raw'),
+                  ('input/camera_info', 'front/camera_info'),
+                  ('output/camera_info', 'front/optical/camera_info'),
+                 ]
+  )
+
   # lidar
   ros2_ign_lidar_bridge = Node(
       package='ros_ign_bridge',
@@ -163,6 +175,7 @@ def spawn_uav(context, model_path, world_name, model_name, link_name):
         ros2_ign_magnetometer_bridge,
         ros2_ign_air_pressure_bridge,
         ros2_ign_camera_bridge,
+        ros2_camera_optical_frame_publisher,
         ros2_ign_lidar_bridge,
         ros2_ign_twist_bridge,
         ros2_ign_pose_bridge,

--- a/mbzirc_ros/CMakeLists.txt
+++ b/mbzirc_ros/CMakeLists.txt
@@ -9,19 +9,29 @@ find_package(rclcpp REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(tf2_msgs REQUIRED)
+find_package(sensor_msgs REQUIRED)
 
+add_executable(optical_frame_publisher src/optical_frame_publisher.cc)
+ament_target_dependencies(optical_frame_publisher
+  geometry_msgs
+  rclcpp
+  tf2
+  tf2_ros
+  sensor_msgs
+)
 
 add_executable(pose_tf_broadcaster src/pose_tf_broadcaster.cc)
 ament_target_dependencies(pose_tf_broadcaster
-   geometry_msgs
-   rclcpp
-   tf2
-   tf2_ros
-   tf2_msgs
+  geometry_msgs
+  rclcpp
+  tf2
+  tf2_ros
+  tf2_msgs
 )
 
 # Resources
 install(TARGETS
+  optical_frame_publisher
   pose_tf_broadcaster
   DESTINATION lib/${PROJECT_NAME})
 

--- a/mbzirc_ros/package.xml
+++ b/mbzirc_ros/package.xml
@@ -14,6 +14,7 @@
 
   <depend>geometry_msgs</depend>
   <depend>rclcpp</depend>
+  <depend>sensor_msgs</depend>
   <depend>tf2</depend>
   <depend>tf2_ros</depend>
 

--- a/mbzirc_ros/src/optical_frame_publisher.cc
+++ b/mbzirc_ros/src/optical_frame_publisher.cc
@@ -1,0 +1,200 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include <geometry_msgs/msg/transform_stamped.hpp>
+#include <sensor_msgs/msg/image.hpp>
+#include <sensor_msgs/msg/camera_info.hpp>
+
+#include <rclcpp/rclcpp.hpp>
+#include <tf2/LinearMath/Quaternion.h>
+#include <tf2_ros/transform_broadcaster.h>
+#include <tf2_ros/static_transform_broadcaster.h>
+
+#include <memory>
+#include <string>
+
+using std::placeholders::_1;
+using namespace std::chrono_literals;
+
+/// \brief A class that converts data from robot frame to optical frame
+/// It subscribes to existing topic, modifies the frame_id of the message to
+/// a new optical frame, then republishes the updated data to a new topic.
+class OpticalFramePublisher : public rclcpp::Node
+{
+  /// \brief Constructor
+  /// \param[in] _info True to publish camera info data in optical frame. False
+  /// to publish only image data in optical frame
+  public: OpticalFramePublisher(bool _info) : Node("optical_frame_publisher")
+  {
+    this->tfBroadcasterStatic =
+      std::make_unique<tf2_ros::StaticTransformBroadcaster>(*this);
+
+    this->pub = this->create_publisher<sensor_msgs::msg::Image>(
+        "output/image", 10);
+
+    this->pubInfo = _info;
+    if (this->pubInfo)
+    {
+      this->pubCi = this->create_publisher<sensor_msgs::msg::CameraInfo>(
+          "output/camera_info", 10);
+    }
+
+    this->timer = this->create_wall_timer(100ms,
+        std::bind(&OpticalFramePublisher::CheckSubscribers, this));
+  }
+
+
+  /// \brief Periodically check subcription count of the optical frame topics.
+  /// If subscribers are present, we initiate subscription to the original image
+  /// and camera_info topics, convert the frames, then republish the data these
+  /// subscribers.
+  private: void CheckSubscribers()
+  {
+    if (this->pub->get_subscription_count() > 0u)
+      this->ImageConnect();
+    if (this->pubCi && this->pubCi->get_subscription_count() > 0u)
+      this->CameraInfoConnect();
+  }
+
+  /// \brief Callback when subscriber connects to the image topic
+  private: void ImageConnect()
+  {
+    if (this->sub)
+      return;
+    this->sub =
+        this->create_subscription<sensor_msgs::msg::Image>(
+        "input/image", 10,
+        std::bind(&OpticalFramePublisher::UpdateImageFrame, this, _1));
+  }
+
+  /// \brief Callback when subscriber connects to the camera_info topic
+  private: void CameraInfoConnect()
+  {
+    if (this->subCi)
+      return;
+    this->subCi =
+        this->create_subscription<sensor_msgs::msg::CameraInfo>(
+        "input/camera_info", 10,
+        std::bind(&OpticalFramePublisher::UpdateCameraInfoFrame, this, _1));
+  }
+
+  /// \brief Subscriber callback which updates the frame id of the message
+  /// and republishes the message.
+  /// \param[in] _msg Message whose frame id is to be updated
+  private: void UpdateImageFrame(
+      const std::shared_ptr<sensor_msgs::msg::Image> _msg)
+  {
+    if (this->pub->get_subscription_count() == 0u && this->sub)
+    {
+      this->sub.reset();
+      return;
+    }
+    if (this->newFrameId.empty())
+    {
+      this->newFrameId = _msg->header.frame_id + "_optical";
+      this->PublishTF(_msg->header.frame_id, this->newFrameId);
+    }
+    auto m = *_msg.get();
+    m.header.frame_id = this->newFrameId;
+    this->pub->publish(m);
+  }
+
+  /// \brief Subscriber callback which updates the frame id of the message
+  /// and republishes the message.
+  /// \param[in] _msg Message whose frame id is to be updated
+  private: void UpdateCameraInfoFrame(
+      const std::shared_ptr<sensor_msgs::msg::CameraInfo> _msg)
+  {
+    if (this->pubCi->get_subscription_count() == 0u && this->subCi)
+    {
+      this->subCi.reset();
+      return;
+    }
+    if (this->newFrameId.empty())
+    {
+      this->newFrameId = _msg->header.frame_id + "_optical";
+      this->PublishTF(_msg->header.frame_id, this->newFrameId);
+    }
+    auto m = *_msg.get();
+    m.header.frame_id = this->newFrameId;
+    this->pubCi->publish(m);
+  }
+
+  /// \brief Publish static tf data between the original frame of the msg
+  /// and the new optical frame
+  /// \param[in] _frame Original message frame id
+  /// \param[in] _childFrame Optical frame id
+  private: void PublishTF(const std::string &_frame,
+    const std::string &_childFrame)
+  {
+    geometry_msgs::msg::TransformStamped tfStamped;
+    tfStamped.header.frame_id = _frame;
+    tfStamped.child_frame_id = _childFrame;
+    tfStamped.transform.translation.x = 0.0;
+    tfStamped.transform.translation.y = 0.0;
+    tfStamped.transform.translation.z = 0.0;
+    tf2::Quaternion q;
+    // converts x forward to z forward
+    q.setRPY(-M_PI/2.0, 0, -M_PI/2.0);
+    tfStamped.transform.rotation.x = q.x();
+    tfStamped.transform.rotation.y = q.y();
+    tfStamped.transform.rotation.z = q.z();
+    tfStamped.transform.rotation.w = q.w();
+    this->tfBroadcasterStatic->sendTransform(tfStamped);
+  }
+
+
+  /// \brief timer with callback to check for publisher subscription count
+  private: rclcpp::TimerBase::SharedPtr timer;
+
+  /// \brief True to publish camera info in optical frame
+  private: bool pubInfo = false;
+
+  /// \brief Subscriber for the original image topic
+  private: rclcpp::Subscription<sensor_msgs::msg::Image>::SharedPtr sub;
+
+  /// \brief Subscriber for the original camera_info topic
+  private: rclcpp::Subscription<sensor_msgs::msg::CameraInfo>::SharedPtr
+               subCi;
+
+  /// \brief Publisher for the image optical frame topic
+  private: rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr pub;
+
+  /// \brief Publisher for the camera info optical frame topic
+  private: rclcpp::Publisher<sensor_msgs::msg::CameraInfo>::SharedPtr pubCi;
+
+  /// \brief Static transform broadcaster that broadcasts the optical frame id
+  private: std::unique_ptr<tf2_ros::StaticTransformBroadcaster>
+               tfBroadcasterStatic;
+
+  /// \brief New of the new optical frame id
+  private: std::string newFrameId;
+};
+
+int main(int argc, char * argv[])
+{
+  rclcpp::init(argc, argv);
+
+  // first arg is bool variable that specifies whether to re-publish camera info
+  // in optical frame
+  bool info = false;
+  std::istringstream(argv[1]) >> info;
+
+  rclcpp::spin(std::make_shared<OpticalFramePublisher>(info));
+  rclcpp::shutdown();
+  return 0;
+}


### PR DESCRIPTION
Code adapted from [here](https://github.com/osrf/subt/blob/master/subt_ros/src/OpticalFramePublisher.cc) for ROS2.

Image data published by Ignition is in robot body frame (x forward, y left, z up) so added a `optical_frame_publisher` node that takes the existing msg data, convert it to optical frame (x right, y down, z forward) by broadcasting a new frame id with `_optical` suffix, and republishing the msg with updated `frame_id`.

To test, spawn the UAV as usual, and list the topics to see the new `*/optical/image_raw` and `*/optical/camera_info` topics. You can also echo the `*/optical/camera_info` topic to see that the its `frame_id` has the `_optical` suffix.

Signed-off-by: Ian Chen <ichen@openrobotics.org>