### PR TITLE
Bridge thruster topics

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,14 +122,27 @@ See Installation instructions for:
 
 1. To move the propeller
     ```
+    ros2 topic pub --once /usv/left/thrust std_msgs/msg/Float64 'data: -1'
+    ros2 topic pub --once /usv/right/thrust std_msgs/msg/Float64 'data: 1'
+    ```
+
+    This is equivalent to:
+
+    ```
     ign topic -t /model/usv/joint/left_engine_propeller_joint/cmd_thrust -m ignition.msgs.Double -p 'data: -1'
     ign topic -t /model/usv/joint/right_engine_propeller_joint/cmd_thrust -m ignition.msgs.Double -p 'data: 1'
     ```
 
 1. To rotate the thruster
+
     ```
-    ign topic -t /model/usv/joint/left_chasis_engine_joint/0/cmd_pos -m ignition.msgs.Double -p 'data: -1'
-    ign topic -t /model/usv/joint/right_chasis_engine_joint/0/cmd_pos -m ignition.msgs.Double -p 'data: -1'
+    ros2 topic pub --once /usv/left/thrust/joint/cmd_pos std_msgs/msg/Float64 'data: -1'
+    ros2 topic pub --once /usv/right/thrust/joint/cmd_pos std_msgs/msg/Float64 'data: 1'
+    ```
+
+    ```
+    ign topic -t /usv/left/thruster/joint/cmd_pos -m ignition.msgs.Double -p 'data: -1'
+    ign topic -t /usv/right/thruster/joint/cmd_pos -m ignition.msgs.Double -p 'data: -1'
     ```
 
 ### Build a Docker image

--- a/README.md
+++ b/README.md
@@ -122,8 +122,8 @@ See Installation instructions for:
 
 1. To move the propeller
     ```
-    ros2 topic pub --once /usv/left/thrust std_msgs/msg/Float64 'data: -1'
-    ros2 topic pub --once /usv/right/thrust std_msgs/msg/Float64 'data: 1'
+    ros2 topic pub --once /usv/left/thrust/cmd_thrust std_msgs/msg/Float64 'data: -1'
+    ros2 topic pub --once /usv/right/thrust/cmd_thrust std_msgs/msg/Float64 'data: 1'
     ```
 
     This is equivalent to:

--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ See Installation instructions for:
     ros2 topic pub --once /usv/right/thrust/joint/cmd_pos std_msgs/msg/Float64 'data: 1'
     ```
 
+    This is equivalent to:
+
     ```
     ign topic -t /usv/left/thruster/joint/cmd_pos -m ignition.msgs.Double -p 'data: -1'
     ign topic -t /usv/right/thruster/joint/cmd_pos -m ignition.msgs.Double -p 'data: -1'

--- a/mbzirc_ign/launch/spawn.launch.py
+++ b/mbzirc_ign/launch/spawn.launch.py
@@ -206,7 +206,49 @@ def spawn_usv(context, model_path, model_name):
                  '-Y', y_rot,
                 ],
   )
-  return [ignition_spawn_entity]
+
+  # thrust cmd
+  left_thrust_topic = '/model/' + model_name + '/joint/left_engine_propeller_joint/cmd_thrust'
+  right_thrust_topic = '/model/' + model_name + '/joint/right_engine_propeller_joint/cmd_thrust'
+  ros2_ign_thrust_bridge = Node(
+      package='ros_ign_bridge',
+      executable='parameter_bridge',
+      output='screen',
+      arguments=[left_thrust_topic + '@std_msgs/msg/Float64@ignition.msgs.Double',
+                 right_thrust_topic + '@std_msgs/msg/Float64@ignition.msgs.Double'],
+      remappings=[(left_thrust_topic, 'left/thrust/cmd_thrust'),
+                  (right_thrust_topic, 'right/thrust/cmd_thrust')]
+  )
+
+  # thrust joint pos cmd
+  # left_joint_topic = '/model/' + model_name + '/joint/left_chasis_engine_joint/0/cmd_pos'
+  # right_joint_topic = '/model/' + model_name + '/joint/right_chasis_engine_joint/0/cmd_pos'
+  left_joint_topic = '/usv/left/thruster/joint/cmd_pos'
+  right_joint_topic = '/usv/right/thruster/joint/cmd_pos'
+
+  ros2_ign_thrust_joint_bridge = Node(
+      package='ros_ign_bridge',
+      executable='parameter_bridge',
+      output='screen',
+      arguments=[left_joint_topic + '@std_msgs/msg/Float64@ignition.msgs.Double',
+                 right_joint_topic + '@std_msgs/msg/Float64@ignition.msgs.Double'],
+      remappings=[(left_joint_topic, 'left/thrust/joint/cmd_pos'),
+                  (right_joint_topic, 'right/thrust/joint/cmd_pos')]
+  )
+
+  group_action = GroupAction([
+        PushRosNamespace(model_name),
+        ros2_ign_thrust_bridge,
+        ros2_ign_thrust_joint_bridge,
+  ])
+
+  handler = RegisterEventHandler(
+      event_handler=OnProcessExit(
+          target_action=ignition_spawn_entity,
+          on_exit=[group_action],
+      ))
+
+  return [ignition_spawn_entity, handler]
 
 
 def launch(context, *args, **kwargs):

--- a/mbzirc_ign/models/wam-v/model.sdf
+++ b/mbzirc_ign/models/wam-v/model.sdf
@@ -264,6 +264,7 @@
     name="ignition::gazebo::systems::JointPositionController">
     <joint_name>left_chasis_engine_joint</joint_name>
     <use_velocity_commands>true</use_velocity_commands>
+    <topic>usv/left/thruster/joint/cmd_pos</topic>
   </plugin>
 
   <plugin
@@ -282,6 +283,7 @@
     name="ignition::gazebo::systems::JointPositionController">
     <joint_name>right_chasis_engine_joint</joint_name>
     <use_velocity_commands>true</use_velocity_commands>
+    <topic>usv/right/thruster/joint/cmd_pos</topic>
   </plugin>
 
 </model>


### PR DESCRIPTION
Bridged topics for applying thruster cmd and joint pos cmd.

Note that the default ign topic name generated by `JointPositionController` (`/model/usv/joint/left_chasis_engine_joint/0/cmd_pos`) is actually an invalid name for a ROS topic. One of the name tokens starts with a numeric number, i.e. the joint index number `0`, which is not allowed in ROS as described in https://design.ros2.org/articles/topic_and_service_names.html. So the `ros_ign bridge` fails to create the ROS topic.

To workaround this issue, I had to specify a hardcoded `<topic>` for the `JointPositionController`. The downside of the hardcoded topic workaround is that there is no model namespacing so only one USV can subscribe to the joint pos cmd. For the case of MBZIRC, this is fine because there should only be one USV in simulation.

The proper fix is to either:
1. Update the `JointPositionController` in ign gazebo to not have a topic name with a name token that starts with a number, or
2. Update `ros_ign_bridge` to check for invalid name tokens in topics and substitute the invalid name token with a valid one, e.g. `/0/` -> `/_0/` 

Signed-off-by: Ian Chen <ichen@openrobotics.org>