### PR TITLE
Add heightmap collision boundary

### DIFF
--- a/mbzirc_ign/worlds/simple_demo.sdf
+++ b/mbzirc_ign/worlds/simple_demo.sdf
@@ -103,6 +103,53 @@
       </uri>
     </include>
 
+    <model name="heightmap_bounds">
+      <static>true</static>
+      <link name="link">
+        <pose>0 0 -25 0 0 0</pose>
+        <collision name="x">
+          <pose>75 0 12.5 0 0 0</pose>
+          <geometry>
+            <box>
+              <size>1 150 25</size>
+            </box>
+          </geometry>
+        </collision>
+        <collision name="y">
+          <pose>0 75 12.5 0 0 0</pose>
+          <geometry>
+            <box>
+              <size>150 1 25</size>
+            </box>
+          </geometry>
+        </collision>
+        <collision name="-x">
+          <pose>-75 0 12.5 0 0 0</pose>
+          <geometry>
+            <box>
+              <size>1 150 25</size>
+            </box>
+          </geometry>
+        </collision>
+        <collision name="-y">
+          <pose>0 -75 12.5 0 0 0</pose>
+          <geometry>
+            <box>
+              <size>150 1 25</size>
+            </box>
+          </geometry>
+        </collision>
+        <collision name="base">
+          <pose>0 0 0 0 0 0</pose>
+          <geometry>
+            <box>
+              <size>5000 5000 1</size>
+            </box>
+          </geometry>
+        </collision>
+      </link>
+    </model>
+
     <include>
       <pose>0 0 -1 0 0 0</pose>
       <uri>

--- a/mbzirc_ign/worlds/simple_demo.sdf
+++ b/mbzirc_ign/worlds/simple_demo.sdf
@@ -108,34 +108,34 @@
       <link name="link">
         <pose>0 0 -25 0 0 0</pose>
         <collision name="x">
-          <pose>75 0 12.5 0 0 0</pose>
+          <pose>75 0 14 0 0 0</pose>
           <geometry>
             <box>
-              <size>1 150 25</size>
+              <size>1 150 28</size>
             </box>
           </geometry>
         </collision>
         <collision name="y">
-          <pose>0 75 12.5 0 0 0</pose>
+          <pose>0 75 14 0 0 0</pose>
           <geometry>
             <box>
-              <size>150 1 25</size>
+              <size>150 1 28</size>
             </box>
           </geometry>
         </collision>
         <collision name="-x">
-          <pose>-75 0 12.5 0 0 0</pose>
+          <pose>-75 0 14 0 0 0</pose>
           <geometry>
             <box>
-              <size>1 150 25</size>
+              <size>1 150 28</size>
             </box>
           </geometry>
         </collision>
         <collision name="-y">
-          <pose>0 -75 12.5 0 0 0</pose>
+          <pose>0 -75 14 0 0 0</pose>
           <geometry>
             <box>
-              <size>150 1 25</size>
+              <size>150 1 28</size>
             </box>
           </geometry>
         </collision>


### PR DESCRIPTION
Added heightmap boundary using simple collision shapes so the USV does not go outside the heightmap.

To see the collisions, right click on the `heightmap_bounds` model, and select `View > Collisions` 

![heightmap_bounds](https://user-images.githubusercontent.com/4000684/146610383-12d6f43b-b034-4452-b5ac-2264a23a23c7.png)


Signed-off-by: Ian Chen <ichen@openrobotics.org>