### PR TITLE
Battery calculation

### DIFF
--- a/mbzirc_ign/launch/spawn.launch.py
+++ b/mbzirc_ign/launch/spawn.launch.py
@@ -331,6 +331,11 @@ def generate_launch_description():
             'Y',
             default_value='0',
             description='Y rotation to spawn'),
+        DeclareLaunchArgument(
+            'flightTime',
+            default_value='10',
+            description='Battery flight time in minutes (only for UAVs)'
+        )
         # launch setup
         OpaqueFunction(function = launch)
     ])

--- a/mbzirc_ign/launch/spawn.launch.py
+++ b/mbzirc_ign/launch/spawn.launch.py
@@ -40,13 +40,22 @@ def spawn_uav(context, model_path, world_name, model_name, link_name):
   r_rot = LaunchConfiguration('R').perform(context)
   p_rot = LaunchConfiguration('P').perform(context)
   y_rot = LaunchConfiguration('Y').perform(context)
+  # take flight time in minutes
+  flight_time = LaunchConfiguration('flightTime').perform(context)
+
+  # calculate battery capacity from time
+  # capacity (Ah) = flight time (in hours) * load (watts) / voltage
+  # assume constant voltage for battery to keep things simple for now.
+  battery_capacity = (flight_time / 60) *  6.6 / 12.694
 
   model_file = os.path.join(
       get_package_share_directory('mbzirc_ign'), 'models', model_path, 'model.sdf.erb')
   print("spawning UAV file: " + model_file)
 
   # run erb
-  process = subprocess.Popen(['erb', 'name=' + model_name, model_file], stdout=subprocess.PIPE)
+  process = subprocess.Popen(['erb',
+    'name=' + model_name,
+    'flight_time='+str(battery_capacity) model_file], stdout=subprocess.PIPE)
   stdout = process.communicate()[0]
   str_output = codecs.getdecoder("unicode_escape")(stdout)[0]
 

--- a/mbzirc_ign/launch/spawn.launch.py
+++ b/mbzirc_ign/launch/spawn.launch.py
@@ -55,7 +55,7 @@ def spawn_uav(context, model_path, world_name, model_name, link_name):
   # run erb
   process = subprocess.Popen(['erb',
     'name=' + model_name,
-    'flight_time='+str(battery_capacity),
+    'capacity='+str(battery_capacity),
     model_file], stdout=subprocess.PIPE)
   stdout = process.communicate()[0]
   str_output = codecs.getdecoder("unicode_escape")(stdout)[0]
@@ -335,7 +335,7 @@ def generate_launch_description():
             'flightTime',
             default_value='10',
             description='Battery flight time in minutes (only for UAVs)'
-        )
+        ),
         # launch setup
         OpaqueFunction(function = launch)
     ])

--- a/mbzirc_ign/launch/spawn.launch.py
+++ b/mbzirc_ign/launch/spawn.launch.py
@@ -46,7 +46,7 @@ def spawn_uav(context, model_path, world_name, model_name, link_name):
   # calculate battery capacity from time
   # capacity (Ah) = flight time (in hours) * load (watts) / voltage
   # assume constant voltage for battery to keep things simple for now.
-  battery_capacity = (flight_time / 60) *  6.6 / 12.694
+  battery_capacity = (float(flight_time) / 60) *  6.6 / 12.694
 
   model_file = os.path.join(
       get_package_share_directory('mbzirc_ign'), 'models', model_path, 'model.sdf.erb')
@@ -55,7 +55,8 @@ def spawn_uav(context, model_path, world_name, model_name, link_name):
   # run erb
   process = subprocess.Popen(['erb',
     'name=' + model_name,
-    'flight_time='+str(battery_capacity) model_file], stdout=subprocess.PIPE)
+    'flight_time='+str(battery_capacity),
+    model_file], stdout=subprocess.PIPE)
   stdout = process.communicate()[0]
   str_output = codecs.getdecoder("unicode_escape")(stdout)[0]
 

--- a/mbzirc_ign/models/x3_c2/model.sdf.erb
+++ b/mbzirc_ign/models/x3_c2/model.sdf.erb
@@ -152,14 +152,15 @@ end
      </rotorConfiguration>
    </plugin>
    <!-- Battery plugin -->
+   <!-- Since we are interested in using time as the limiting factor -->
    <plugin filename="libignition-gazebo-linearbatteryplugin-system.so"
      name="ignition::gazebo::systems::LinearBatteryPlugin">
      <battery_name>linear_battery</battery_name>
      <voltage>12.694</voltage>
      <open_circuit_voltage_constant_coef>12.694</open_circuit_voltage_constant_coef>
-     <open_circuit_voltage_linear_coef>-3.1424</open_circuit_voltage_linear_coef>
-     <initial_charge>18.0</initial_charge>
-     <capacity>18.0</capacity>
+     <open_circuit_voltage_linear_coef>0</open_circuit_voltage_linear_coef>
+     <initial_charge><%= $capacity%></initial_charge>
+     <capacity><%= $capacity%></capacity>
      <resistance>0.061523</resistance>
      <smooth_current_tau>1.9499</smooth_current_tau>
      <power_load>6.6</power_load>

--- a/mbzirc_ign/models/x3_c2/model.sdf.erb
+++ b/mbzirc_ign/models/x3_c2/model.sdf.erb
@@ -159,8 +159,8 @@ end
      <voltage>12.694</voltage>
      <open_circuit_voltage_constant_coef>12.694</open_circuit_voltage_constant_coef>
      <open_circuit_voltage_linear_coef>0</open_circuit_voltage_linear_coef>
-     <initial_charge><%= $capacity%></initial_charge>
-     <capacity><%= $capacity%></capacity>
+     <initial_charge><%= capacity%></initial_charge>
+     <capacity><%= capacity%></capacity>
      <resistance>0.061523</resistance>
      <smooth_current_tau>1.9499</smooth_current_tau>
      <power_load>6.6</power_load>

--- a/mbzirc_ign/models/x4_c4/model.sdf.erb
+++ b/mbzirc_ign/models/x4_c4/model.sdf.erb
@@ -207,9 +207,9 @@ end
     <battery_name>linear_battery</battery_name>
     <voltage>12.694</voltage>
     <open_circuit_voltage_constant_coef>12.694</open_circuit_voltage_constant_coef>
-    <open_circuit_voltage_linear_coef>-3.1424</open_circuit_voltage_linear_coef>
-    <initial_charge>18.0</initial_charge>
-    <capacity>18.0</capacity>
+    <open_circuit_voltage_linear_coef>0</open_circuit_voltage_linear_coef>
+    <initial_charge><%= $capacity%></initial_charge>
+    <capacity><%= $capacity%></capacity>
     <resistance>0.061523</resistance>
     <smooth_current_tau>1.9499</smooth_current_tau>
     <power_load>6.6</power_load>

--- a/mbzirc_ign/models/x4_c4/model.sdf.erb
+++ b/mbzirc_ign/models/x4_c4/model.sdf.erb
@@ -208,8 +208,8 @@ end
     <voltage>12.694</voltage>
     <open_circuit_voltage_constant_coef>12.694</open_circuit_voltage_constant_coef>
     <open_circuit_voltage_linear_coef>0</open_circuit_voltage_linear_coef>
-    <initial_charge><%= $capacity%></initial_charge>
-    <capacity><%= $capacity%></capacity>
+    <initial_charge><%= capacity%></initial_charge>
+    <capacity><%= capacity%></capacity>
     <resistance>0.061523</resistance>
     <smooth_current_tau>1.9499</smooth_current_tau>
     <power_load>6.6</power_load>


### PR DESCRIPTION
This PR adds a simple formula to limit the battery operation to a fixed amount of time. It does so by adding the `flightTime` argument to the `spawn.launch.py`. A second PR with the relevant unit tests is in the works.