### PR TITLE
Move Surface plugin to mbzirc

### DIFF
--- a/mbzirc_ign/CMakeLists.txt
+++ b/mbzirc_ign/CMakeLists.txt
@@ -27,6 +27,7 @@ configure_file(
 #============================================================================
 # Plugins
 list(APPEND MBZIRC_IGN_PLUGINS
+  SimpleHydrodynamics
   Surface
 )
 

--- a/mbzirc_ign/CMakeLists.txt
+++ b/mbzirc_ign/CMakeLists.txt
@@ -5,12 +5,15 @@ project(mbzirc_ign)
 find_package(ament_cmake REQUIRED)
 
 find_package(ignition-gazebo6 REQUIRED)
+set(IGN_GAZEBO_VER ${ignition-gazebo6_VERSION_MAJOR})
+
 find_package(ignition-common4 REQUIRED COMPONENTS graphics)
 find_package(ignition-fuel_tools7 REQUIRED)
 find_package(ignition-math6 REQUIRED)
 find_package(ignition-msgs8 REQUIRED)
 find_package(ignition-transport11 REQUIRED)
 find_package(ignition-plugin1 REQUIRED COMPONENTS loader register)
+set(IGN_PLUGIN_VER ${ignition-plugin1_VERSION_MAJOR})
 find_package(sdformat12 REQUIRED)
 
 #============================================================================
@@ -19,6 +22,25 @@ configure_file(
   "hooks/hook.dsv.in"
   "${CMAKE_CURRENT_BINARY_DIR}/hooks/hook.dsv" @ONLY
 )
+
+
+#============================================================================
+# Plugins
+list(APPEND MBZIRC_IGN_PLUGINS
+  Surface
+)
+
+foreach(PLUGIN ${MBZIRC_IGN_PLUGINS})
+  add_library(${PLUGIN} SHARED src/${PLUGIN}.cc)
+  target_link_libraries(${PLUGIN} PUBLIC
+     ignition-gazebo${IGN_GAZEBO_VER}::core
+     ignition-plugin${IGN_PLUGIN_VER}::ignition-plugin${IGN_PLUGIN_VER}
+  )
+endforeach()
+
+install(
+  TARGETS ${MBZIRC_IGN_PLUGINS}
+  DESTINATION lib)
 
 #============================================================================
 # Resources

--- a/mbzirc_ign/models/wam-v/model.sdf
+++ b/mbzirc_ign/models/wam-v/model.sdf
@@ -294,5 +294,25 @@
     <fluid_level>-1</fluid_level>
   </plugin>
 
+  <plugin
+    filename="libSimpleHydrodynamics.so"
+    name="ignition::gazebo::systems::SimpleHydrodynamics">
+    <link_name>base_link</link_name>
+    <!-- Added mass -->
+    <xDotU>0.0</xDotU>
+    <yDotV>0.0</yDotV>
+    <nDotR>0.0</nDotR>
+    <!-- Linear and quadratic drag -->
+    <xU>51.3</xU>
+    <xUU>72.4</xUU>
+    <yV>40.0</yV>
+    <yVV>0.0</yVV>
+    <zW>500.0</zW>
+    <kP>50.0</kP>
+    <mQ>50.0</mQ>
+    <nR>400.0</nR>
+    <nRR>0.0</nRR>
+  </plugin>
+
 </model>
 </sdf>

--- a/mbzirc_ign/models/wam-v/model.sdf
+++ b/mbzirc_ign/models/wam-v/model.sdf
@@ -285,7 +285,7 @@
   </plugin>
 
   <plugin
-    filename="ignition-gazebo-surface-system"
+    filename="libSurface.so"
     name="ignition::gazebo::systems::Surface">
     <link_name>base_link</link_name>
     <vehicle_length>4.9</vehicle_length>

--- a/mbzirc_ign/src/SimpleHydrodynamics.cc
+++ b/mbzirc_ign/src/SimpleHydrodynamics.cc
@@ -1,0 +1,290 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include <string>
+#include <Eigen/Eigen>
+#include <ignition/common/Profiler.hh>
+#include <ignition/math/Vector3.hh>
+#include <ignition/plugin/Register.hh>
+#include <sdf/sdf.hh>
+
+#include "ignition/gazebo/Link.hh"
+#include "ignition/gazebo/Model.hh"
+
+#include "SimpleHydrodynamics.hh"
+
+using namespace ignition;
+using namespace gazebo;
+using namespace systems;
+
+class ignition::gazebo::systems::SimpleHydrodynamicsPrivate
+{
+  /// \brief The link entity.
+  public: ignition::gazebo::Link link;
+
+  /// \brief Model interface.
+  public: Model model{kNullEntity};
+
+  /// \brief Added mass in surge, X_\dot{u}.
+  public: double paramXdotU{0.0};
+
+  /// \brief Added mass in sway, Y_\dot{v}.
+  public: double paramYdotV{0.0};
+
+  /// \brief Added mass in heave, Z_\dot{w}.
+  public: double paramZdotW{0.0};
+
+  /// \brief Added mass in roll, K_\dot{p}.
+  public: double paramKdotP{0.0};
+
+  /// \brief Added mass in pitch, M_\dot{q}.
+  public: double paramMdotQ{0.0};
+
+  /// \brief Added mass in yaw, N_\dot{r}.
+  public: double paramNdotR{0.0};
+
+  /// \brief Linear drag in surge.
+  public: double paramXu{0.0};
+
+  /// \brief Quadratic drag in surge.
+  public: double paramXuu{0.0};
+
+  /// \brief Linear drag in sway.
+  public: double paramYv{0.0};
+
+  /// \brief Quadratic drag in sway.
+  public: double paramYvv{0.0};
+
+  /// \brief Linear drag in heave.
+  public: double paramZw{0.0};
+
+  /// \brief Quadratic drag in heave.
+  public: double paramZww{0.0};
+
+  /// \brief Linear drag in roll.
+  public: double paramKp{0.0};
+
+  /// \brief Quadratic drag in roll.
+  public: double paramKpp{0.0};
+
+  /// \brief Linear drag in pitch.
+  public: double paramMq{0.0};
+
+  /// \brief Quadratic drag in pitch.
+  public: double paramMqq{0.0};
+
+  /// \brief Linear drag in yaw.
+  public: double paramNr{0.0};
+
+  /// \brief Quadratic drag in yaw.
+  public: double paramNrr{0.0};
+
+  /// \brief Added mass of vehicle.
+  /// See: https://en.wikipedia.org/wiki/Added_mass
+  public: Eigen::MatrixXd Ma;
+};
+
+
+//////////////////////////////////////////////////
+SimpleHydrodynamics::SimpleHydrodynamics()
+  : dataPtr(std::make_unique<SimpleHydrodynamicsPrivate>())
+{
+}
+
+//////////////////////////////////////////////////
+void SimpleHydrodynamics::Configure(const Entity &_entity,
+    const std::shared_ptr<const sdf::Element> &_sdf,
+    EntityComponentManager &_ecm,
+    EventManager &/*_eventMgr*/)
+{
+  this->dataPtr->model = Model(_entity);
+
+  // Parse required elements.
+  if (!_sdf->HasElement("link_name"))
+  {
+    ignerr << "No <link_name> specified" << std::endl;
+    return;
+  }
+
+  std::string linkName = _sdf->Get<std::string>("link_name");
+  this->dataPtr->link = Link(this->dataPtr->model.LinkByName(_ecm, linkName));
+  if (!this->dataPtr->link.Valid(_ecm))
+  {
+    ignerr << "Could not find link named [" << linkName
+           << "] in model" << std::endl;
+    return;
+  }
+
+  this->dataPtr->link.EnableVelocityChecks(_ecm);
+  this->dataPtr->link.EnableAccelerationChecks(_ecm);
+
+  this->dataPtr->paramXdotU       = _sdf->Get<double>("xDotU", 5  ).first;
+  this->dataPtr->paramYdotV       = _sdf->Get<double>("yDotV", 5  ).first;
+  this->dataPtr->paramZdotW       = _sdf->Get<double>("zDotW", 0.1).first;
+  this->dataPtr->paramKdotP       = _sdf->Get<double>("kDotP", 0.1).first;
+  this->dataPtr->paramMdotQ       = _sdf->Get<double>("mDotQ", 0.1).first;
+  this->dataPtr->paramNdotR       = _sdf->Get<double>("nDotR", 1  ).first;
+  this->dataPtr->paramXu          = _sdf->Get<double>("xU",   20  ).first;
+  this->dataPtr->paramXuu         = _sdf->Get<double>("xUU",   0  ).first;
+  this->dataPtr->paramYv          = _sdf->Get<double>("yV",   20  ).first;
+  this->dataPtr->paramYvv         = _sdf->Get<double>("yVV",   0  ).first;
+  this->dataPtr->paramZw          = _sdf->Get<double>("zW",   20  ).first;
+  this->dataPtr->paramZww         = _sdf->Get<double>("zWW",   0  ).first;
+  this->dataPtr->paramKp          = _sdf->Get<double>("kP",   20  ).first;
+  this->dataPtr->paramKpp         = _sdf->Get<double>("kPP",   0  ).first;
+  this->dataPtr->paramMq          = _sdf->Get<double>("mQ",   20  ).first;
+  this->dataPtr->paramMqq         = _sdf->Get<double>("mQQ",   0  ).first;
+  this->dataPtr->paramNr          = _sdf->Get<double>("nR",   20  ).first;
+  this->dataPtr->paramNrr         = _sdf->Get<double>("nRR",   0  ).first;
+
+  // Added mass according to Fossen's equations (p 37).
+  this->dataPtr->Ma = Eigen::MatrixXd::Zero(6, 6);
+
+  this->dataPtr->Ma(0, 0) = this->dataPtr->paramXdotU;
+  this->dataPtr->Ma(1, 1) = this->dataPtr->paramYdotV;
+  this->dataPtr->Ma(2, 2) = this->dataPtr->paramZdotW;
+  this->dataPtr->Ma(3, 3) = this->dataPtr->paramKdotP;
+  this->dataPtr->Ma(4, 4) = this->dataPtr->paramMdotQ;
+  this->dataPtr->Ma(5, 5) = this->dataPtr->paramNdotR;
+
+  igndbg << "SimpleHydrodynamics plugin successfully configured with the "
+         << "following parameters:"                        << std::endl;
+  igndbg << "  <link_name>: " << linkName                  << std::endl;
+  igndbg << "  <xDotU>: "     << this->dataPtr->paramXdotU << std::endl;
+  igndbg << "  <yDotV>: "     << this->dataPtr->paramYdotV << std::endl;
+  igndbg << "  <zDotW>: "     << this->dataPtr->paramZdotW << std::endl;
+  igndbg << "  <kDotP>: "     << this->dataPtr->paramKdotP << std::endl;
+  igndbg << "  <mDotQ>: "     << this->dataPtr->paramMdotQ << std::endl;
+  igndbg << "  <nDotR>: "     << this->dataPtr->paramNdotR << std::endl;
+  igndbg << "  <xU>: "        << this->dataPtr->paramXu    << std::endl;
+  igndbg << "  <xUU>: "       << this->dataPtr->paramXuu   << std::endl;
+  igndbg << "  <yV>: "        << this->dataPtr->paramYv    << std::endl;
+  igndbg << "  <yVV>: "       << this->dataPtr->paramYvv   << std::endl;
+  igndbg << "  <zW>: "        << this->dataPtr->paramZw    << std::endl;
+  igndbg << "  <zWW>: "       << this->dataPtr->paramZww   << std::endl;
+  igndbg << "  <kP>: "        << this->dataPtr->paramKp    << std::endl;
+  igndbg << "  <kPP>: "       << this->dataPtr->paramKpp   << std::endl;
+  igndbg << "  <mQ>: "        << this->dataPtr->paramMq    << std::endl;
+  igndbg << "  <mQQ>: "       << this->dataPtr->paramMqq   << std::endl;
+  igndbg << "  <nR>: "        << this->dataPtr->paramNr    << std::endl;
+  igndbg << "  <nRR>: "       << this->dataPtr->paramNrr   << std::endl;
+}
+
+//////////////////////////////////////////////////
+void SimpleHydrodynamics::PreUpdate(
+    const ignition::gazebo::UpdateInfo &/*_info*/,
+    ignition::gazebo::EntityComponentManager &_ecm)
+{
+  IGN_PROFILE("SimpleHydrodynamics::PreUpdate");
+
+  if (!this->dataPtr->link.Valid(_ecm))
+    return;
+
+  Eigen::VectorXd stateDot = Eigen::VectorXd(6);
+  Eigen::VectorXd state    = Eigen::VectorXd(6);
+  Eigen::MatrixXd Cmat     = Eigen::MatrixXd::Zero(6, 6);
+  Eigen::MatrixXd Dmat     = Eigen::MatrixXd::Zero(6, 6);
+
+  // Get vehicle state.
+  auto worldAngularVel = this->dataPtr->link.WorldAngularVelocity(_ecm);
+  auto worldLinearVel = this->dataPtr->link.WorldLinearVelocity(_ecm);
+  auto worldAngularAccel = this->dataPtr->link.WorldAngularAcceleration(_ecm);
+  auto worldLinearAccel = this->dataPtr->link.WorldLinearAcceleration(_ecm);
+
+  // Sanity check: Make sure that we can read the full state.
+  if (!worldAngularVel)
+  {
+    ignerr << "No angular velocity" <<"\n";
+    return;
+  }
+
+  if (!worldLinearVel)
+  {
+    ignerr << "No linear velocity" <<"\n";
+    return;
+  }
+
+  if (!worldAngularAccel)
+  {
+    ignerr << "No angular acceleration" <<"\n";
+    return;
+  }
+
+  if (!worldLinearAccel)
+  {
+    ignerr << "No linear acceleration" <<"\n";
+    return;
+  }
+
+  // Transform from world to local frame.
+  auto comPose = this->dataPtr->link.WorldInertialPose(_ecm);
+  auto localAngularVel   = comPose->Rot().Inverse() * (*worldAngularVel);
+  auto localLinearVel    = comPose->Rot().Inverse() * (*worldLinearVel);
+  auto localAngularAccel = comPose->Rot().Inverse() * (*worldAngularAccel);
+  auto localLinearAccel  = comPose->Rot().Inverse() * (*worldLinearAccel);
+
+  stateDot << localLinearAccel.X(), localLinearAccel.Y(), localLinearAccel.Z(),
+   localAngularAccel.X(), localAngularAccel.Y(), localAngularAccel.Z();
+
+  state << localLinearVel.X(), localLinearVel.Y(), localLinearVel.Z(),
+    localAngularVel.X(), localAngularVel.Y(), localAngularVel.Z();
+
+  // Added Mass.
+  const Eigen::VectorXd kAmassVec = -1.0 * this->dataPtr->Ma * stateDot;
+
+  // Coriolis - added mass components.
+  Cmat(0, 5) = this->dataPtr->paramYdotV * localLinearVel.Y();
+  Cmat(1, 5) = this->dataPtr->paramXdotU * localLinearVel.X();
+  Cmat(5, 0) = this->dataPtr->paramYdotV * localLinearVel.Y();
+  Cmat(5, 1) = this->dataPtr->paramXdotU * localLinearVel.X();
+
+  // Drag.
+  Dmat(0, 0) = this->dataPtr->paramXu +
+    this->dataPtr->paramXuu * std::abs(localLinearVel.X());
+  Dmat(1, 1) = this->dataPtr->paramYv +
+    this->dataPtr->paramYvv * std::abs(localLinearVel.Y());
+  Dmat(2, 2) = this->dataPtr->paramZw +
+    this->dataPtr->paramZww * std::abs(localLinearVel.Z());
+  Dmat(3, 3) = this->dataPtr->paramKp +
+    this->dataPtr->paramKpp * std::abs(localAngularVel.X());
+  Dmat(4, 4) = this->dataPtr->paramMq +
+    this->dataPtr->paramMqq * std::abs(localAngularVel.Y());
+  Dmat(5, 5) = this->dataPtr->paramNr +
+    this->dataPtr->paramNrr * std::abs(localAngularVel.Z());
+
+  const Eigen::VectorXd kDvec = -1.0 * Dmat * state;
+
+  // Sum all forces - in body frame.
+  const Eigen::VectorXd kForceSum = kAmassVec + kDvec;
+
+  // Transform the force and torque to the world frame.
+  ignition::math::Vector3d forceWorld = (*comPose).Rot().RotateVector(
+    ignition::math::Vector3d(kForceSum(0), kForceSum(1), kForceSum(2)));
+  ignition::math::Vector3d torqueWorld = (*comPose).Rot().RotateVector(
+    ignition::math::Vector3d(kForceSum(3), kForceSum(4), kForceSum(5)));
+
+  // Apply the force and torque at COM.
+  this->dataPtr->link.AddWorldWrench(_ecm, forceWorld, torqueWorld);
+}
+
+IGNITION_ADD_PLUGIN(SimpleHydrodynamics,
+                    ignition::gazebo::System,
+                    SimpleHydrodynamics::ISystemConfigure,
+                    SimpleHydrodynamics::ISystemPreUpdate)
+
+IGNITION_ADD_PLUGIN_ALIAS(SimpleHydrodynamics,
+                          "ignition::gazebo::systems::SimpleHydrodynamics")

--- a/mbzirc_ign/src/SimpleHydrodynamics.hh
+++ b/mbzirc_ign/src/SimpleHydrodynamics.hh
@@ -1,0 +1,128 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#ifndef IGNITION_GAZEBO_SYSTEMS_SIMPLE_HYDRODYNAMICS_HH_
+#define IGNITION_GAZEBO_SYSTEMS_SIMPLE_HYDRODYNAMICS_HH_
+
+#include <memory>
+#include <ignition/gazebo/System.hh>
+#include <sdf/sdf.hh>
+
+namespace ignition
+{
+namespace gazebo
+{
+// Inline bracket to help doxygen filtering.
+inline namespace IGNITION_GAZEBO_VERSION_NAMESPACE {
+namespace systems
+{
+  // Forward declaration
+  class SimpleHydrodynamicsPrivate;
+
+  /// \brief This class provides hydrodynamic behaviour for underwater vehicles
+  /// It is shamelessly based off Brian Bingham's
+  /// [plugin for VRX](https://github.com/osrf/vrx).
+  /// which in turn is based of Fossen's equations described in "Guidance and
+  /// Control of Ocean Vehicles" [1]. The class should be used together with a
+  /// buoyancy plugin to help simulate behaviour of maritime vehicles.
+  /// Hydrodynamics refers to the behaviour of bodies in water. It includes
+  /// forces like linear and quadratic drag, buoyancy (not provided by this
+  /// plugin), etc.
+  ///
+  /// ## Required system parameters
+  ///
+  ///  * <link_name> - The link of the model that is being subject to
+  ///     hydrodynamic forces.
+  ///
+  /// ## Optional system parameters
+  /// The exact description of these parameters can be found on p. 37 of
+  /// Fossen's book. They are used to calculate added mass, linear and quadratic
+  /// drag and coriolis force.
+  ///
+  ///  * <xDotU> - Added mass in x direction [kg]
+  ///  * <yDotV> - Added mass in y direction [kg]
+  ///  * <zDotW> - Added mass in z direction [kg]
+  ///  * <kDotP> - Added mass in roll direction [kgm^2]
+  ///  * <mDotQ> - Added mass in pitch direction [kgm^2]
+  ///  * <nDotR> - Added mass in yaw direction [kgm^2]
+  ///  * <xUU>   - Stability derivative, 2nd order, x component [kg/m]
+  ///  * <xU>    - Stability derivative, 1st order, x component [kg]
+  ///  * <yVV>   - Stability derivative, 2nd order, y component [kg/m]
+  ///  * <yV>    - Stability derivative, 1st order, y component [kg]
+  ///  * <zWW>   - Stability derivative, 2nd order, z component [kg/m]
+  ///  * <zW>    - Stability derivative, 1st order, z component [kg]
+  ///  * <kPP>   - Stability derivative, 2nd order, roll component [kg/m^2]
+  ///  * <kP>    - Stability derivative, 1st order, roll component [kg/m]
+  ///  * <mQQ>   - Stability derivative, 2nd order, pitch component [kg/m^2]
+  ///  * <mQ>    - Stability derivative, 1st order, pitch component [kg/m]
+  ///  * <nRR>   - Stability derivative, 2nd order, yaw component [kg/m^2]
+  ///  * <nR>    - Stability derivative, 1st order, yaw component [kg/m]
+  ///
+  /// # Example
+  /// <plugin
+  ///   filename="libSimpleHydrodynamics.so"
+  ///   name="ignition::gazebo::systems::SimpleHydrodynamics">
+  ///   <link_name>base_link</link_name>
+  ///   <!-- Added mass -->
+  ///   <xDotU>0.0</xDotU>
+  ///   <yDotV>0.0</yDotV>
+  ///   <nDotR>0.0</nDotR>
+  ///   <!-- Linear and quadratic drag -->
+  ///   <xU>51.3</xU>
+  ///   <xUU>72.4</xUU>
+  ///   <yV>40.0</yV>
+  ///   <yVV>0.0</yVV>
+  ///   <zW>500.0</zW>
+  ///   <kP>50.0</kP>
+  ///   <mQ>50.0</mQ>
+  ///   <nR>400.0</nR>
+  ///   <nRR>0.0</nRR>
+  /// </plugin>
+  ///
+  /// # Citations
+  /// [1] Fossen, Thor I. _Guidance and Control of Ocean Vehicles_.
+  ///    United Kingdom: Wiley, 1994.
+  class SimpleHydrodynamics
+      : public System,
+        public ISystemConfigure,
+        public ISystemPreUpdate
+  {
+    /// \brief Constructor.
+    public: SimpleHydrodynamics();
+
+    /// \brief Destructor.
+    public: ~SimpleHydrodynamics() override = default;
+
+    // Documentation inherited.
+    public: void Configure(const Entity &_entity,
+                           const std::shared_ptr<const sdf::Element> &_sdf,
+                           EntityComponentManager &_ecm,
+                           EventManager &_eventMgr) override;
+
+    // Documentation inherited.
+    public: void PreUpdate(
+                const ignition::gazebo::UpdateInfo &_info,
+                ignition::gazebo::EntityComponentManager &_ecm) override;
+
+    /// \brief Private data pointer.
+    private: std::unique_ptr<SimpleHydrodynamicsPrivate> dataPtr;
+  };
+  }
+}
+}
+}
+
+#endif

--- a/mbzirc_ign/src/Surface.cc
+++ b/mbzirc_ign/src/Surface.cc
@@ -1,0 +1,272 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include <ignition/msgs/wrench.pb.h>
+#include <string>
+#include <ignition/common/Profiler.hh>
+#include <ignition/math/Pose3.hh>
+#include <ignition/math/Vector3.hh>
+#include <ignition/plugin/Register.hh>
+#include <sdf/sdf.hh>
+
+#include "ignition/gazebo/components/Inertial.hh"
+#include "ignition/gazebo/components/Pose.hh"
+#include "ignition/gazebo/Link.hh"
+#include "ignition/gazebo/Model.hh"
+#include "ignition/gazebo/Util.hh"
+#include "ignition/gazebo/World.hh"
+
+#include "Surface.hh"
+
+using namespace ignition;
+using namespace gazebo;
+using namespace systems;
+
+class ignition::gazebo::systems::SurfacePrivate
+{
+  /// \brief The link entity
+  public: ignition::gazebo::Link link;
+
+  /// \brief Model interface
+  public: Model model{kNullEntity};
+
+  /// \brief Vessel length [m].
+  public: double vehicleLength = 4.9;
+
+  /// \brief Vessel width [m].
+  public: double vehicleWidth = 2.4;
+
+  /// \brief Demi-hull radius [m].
+  public: double hullRadius = 0.213;
+
+  /// \brief Length discretization, i.e., "N"
+  public: int numSamples = 2;
+
+  /// \brief Fluid height [m].
+  public: double fluidLevel = 0;
+
+  /// \brief Fluid density [kg/m^3].
+  public: double fluidDensity = 997.7735;
+
+  /// \brief The world's gravity [m/s^2].
+  public: ignition::math::Vector3d gravity;
+};
+
+
+//////////////////////////////////////////////////
+Surface::Surface()
+  : dataPtr(std::make_unique<SurfacePrivate>())
+{
+}
+
+//////////////////////////////////////////////////
+void Surface::Configure(const Entity &_entity,
+    const std::shared_ptr<const sdf::Element> &_sdf,
+    EntityComponentManager &_ecm,
+    EventManager &/*_eventMgr*/)
+{
+  this->dataPtr->model = Model(_entity);
+
+  // Parse required elements.
+  if (!_sdf->HasElement("link_name"))
+  {
+    ignerr << "No <link_name> specified" << std::endl;
+    return;
+  }
+
+  std::string linkName = _sdf->Get<std::string>("link_name");
+  this->dataPtr->link = Link(this->dataPtr->model.LinkByName(_ecm, linkName));
+  if (!this->dataPtr->link.Valid(_ecm))
+  {
+    ignerr << "Could not find link named [" << linkName
+           << "] in model" << std::endl;
+    return;
+  }
+
+  // Required parameters.
+  if (!_sdf->HasElement("vehicle_length"))
+  {
+    ignerr << "No <vehicle_length> specified" << std::endl;
+    return;
+  }
+  this->dataPtr->vehicleLength = _sdf->Get<double>("vehicle_length");
+
+  if (!_sdf->HasElement("vehicle_width"))
+  {
+    ignerr << "No <vehicle_width> specified" << std::endl;
+    return;
+  }
+  this->dataPtr->vehicleWidth = _sdf->Get<double>("vehicle_width");
+
+  if (!_sdf->HasElement("hull_radius"))
+  {
+    ignerr << "No <hull_radius> specified" << std::endl;
+    return;
+  }
+  this->dataPtr->hullRadius = _sdf->Get<double>("hull_radius");
+
+  // Optional parameters.
+  if (_sdf->HasElement("num_samples"))
+  {
+    this->dataPtr->numSamples = _sdf->Get<int>("num_samples");
+  }
+
+  if (_sdf->HasElement("fluid_level"))
+  {
+    this->dataPtr->fluidLevel = _sdf->Get<double>("fluid_level");
+  }
+
+  if (_sdf->HasElement("fluid_density"))
+  {
+    this->dataPtr->fluidDensity = _sdf->Get<double>("fluid_density");
+  }
+
+  // Get the gravity from the world.
+  auto worldEntity = gazebo::worldEntity(_ecm);
+  auto world = gazebo::World(worldEntity);
+  auto gravityOpt = world.Gravity(_ecm);
+  if (!gravityOpt)
+  {
+    ignerr << "Unable to get the gravity from the world" << std::endl;
+    return;
+  }
+  this->dataPtr->gravity = *gravityOpt;
+
+  // Create necessary components if not present.
+  enableComponent<components::Inertial>(_ecm, this->dataPtr->link.Entity());
+  enableComponent<components::WorldPose>(_ecm, this->dataPtr->link.Entity());
+
+  igndbg << "Surface plugin successfully configured with the following "
+         << "parameters:" << std::endl;
+  igndbg << "  <link_name>: " << linkName << std::endl;
+  igndbg << "  <vehicle_length>: " << this->dataPtr->vehicleLength << std::endl;
+  igndbg << "  <vehicle_width>: " << this->dataPtr->vehicleWidth << std::endl;
+  igndbg << "  <hull_radius>: " << this->dataPtr->hullRadius << std::endl;
+  igndbg << "  <num_samples>: " << this->dataPtr->numSamples << std::endl;
+  igndbg << "  <fluid_level>: " << this->dataPtr->fluidLevel << std::endl;
+  igndbg << "  <fluid_density>: " << this->dataPtr->fluidDensity << std::endl;
+}
+
+//////////////////////////////////////////////////
+void Surface::PreUpdate(const ignition::gazebo::UpdateInfo &/*_info*/,
+    ignition::gazebo::EntityComponentManager &_ecm)
+{
+  IGN_PROFILE("Surface::PreUpdate");
+
+  // Vehicle frame transform
+  const auto kPose = this->dataPtr->link.WorldPose(_ecm);
+  // std::optional<ignition::math::Pose3d> kPose;
+  // *kPose = {-532, 162, -0.008054, 0, 0, 1};
+  if (!kPose)
+  {
+    ignerr << "Unable to get world pose from link ["
+           << this->dataPtr->link.Entity() << "]" << std::endl;
+    return;
+  }
+  const ignition::math::Vector3d kEuler = (*kPose).Rot().Euler();
+  ignition::math::Quaternion vq(kEuler.X(), kEuler.Y(), kEuler.Z());
+
+  // Loop over boat grid points
+  // Grid point location in boat frame - might be able to precalculate these?
+  ignition::math::Vector3d bpnt(0, 0, 0);
+  // Grid point location in world frame
+  ignition::math::Vector3d bpntW(0, 0, 0);
+  // For each hull
+  // Debug output:
+  // igndbg << "===" << std::endl;
+  for (int i = 0; i < 2; ++i)
+  {
+    // Grid point in boat frame
+    bpnt.Set(bpnt.X(), (i * 2.0 - 1.0) * this->dataPtr->vehicleWidth / 2.0,
+      bpnt.Z());
+
+    // For each length segment
+    for (int j = 1; j <= this->dataPtr->numSamples; ++j)
+    {
+      bpnt.Set(((j - 0.5) / (static_cast<float>(this->dataPtr->numSamples)) -
+        0.5) * this->dataPtr->vehicleLength, bpnt.Y(), bpnt.Z());
+
+      // Transform from vessel to fluid/world frame.
+      bpntW = vq * bpnt;
+
+      // Vertical location of boat grid point in world frame.
+      const float kDdz = (*kPose).Pos().Z() + bpntW.Z();
+
+      // Find vertical displacement of wave field
+      // World location of grid point
+      ignition::math::Vector3d X;
+      X.X() = (*kPose).Pos().X() + bpntW.X();
+      X.Y() = (*kPose).Pos().Y() + bpntW.Y();
+
+      // Compute the depth at the grid point.
+      // ToDo: Add wave height here.
+      double depth = 0;
+
+      // Vertical wave displacement.
+      double dz = depth + X.Z();
+
+      // Total z location of boat grid point relative to fluid surface
+      double deltaZ = (this->dataPtr->fluidLevel + dz) - kDdz;
+      // enforce only upward buoy force
+      deltaZ = std::max(deltaZ, 0.0);
+      deltaZ = std::min(deltaZ, this->dataPtr->hullRadius);
+
+      // Buoyancy force at grid point
+      const float kBuoyForce =
+        this->CircleSegment(this->dataPtr->hullRadius, deltaZ) *
+          this->dataPtr->vehicleLength /
+          (static_cast<float>(this->dataPtr->numSamples)) *
+          -this->dataPtr->gravity.Z() * this->dataPtr->fluidDensity;
+
+      // Apply force at grid point
+      // Position is in the link frame and force is in world frame.
+      this->dataPtr->link.AddWorldForce(_ecm,
+        ignition::math::Vector3d(0, 0, kBuoyForce),
+        bpnt);
+
+      // Debug output:
+      // igndbg << bpnt.X() << "," << bpnt.Y() << "," << bpnt.Z() << std::endl;
+      // igndbg << "-" << std::endl;
+      // igndbg << bpntW.X() << "," << bpntW.Y() << "," << bpntW.Z() << std::endl;
+      // igndbg << "X: " << X << std::endl;
+      // igndbg << "depth: " << depth << std::endl;
+      // igndbg << "dz: " << dz << std::endl;
+      // igndbg << "kDdz: " << kDdz << std::endl;
+      // igndbg << "deltaZ: " << deltaZ << std::endl;
+      // igndbg << "hull radius: " << this->dataPtr->hullRadius << std::endl;
+      // igndbg << "vehicle length: " << this->dataPtr->vehicleLength << std::endl;
+      // igndbg << "num samples: " << this->dataPtr->numSamples << std::endl;
+      // igndbg << "gravity z: " << -this->dataPtr->gravity.Z() << std::endl;
+      // igndbg << "fluid density: " << this->dataPtr->fluidDensity << std::endl;
+      // igndbg << "Force: " << kBuoyForce << std::endl << std::endl;
+    }
+  }
+}
+
+//////////////////////////////////////////////////
+double Surface::CircleSegment(double _r, double _h) const
+{
+  return _r * _r * acos((_r -_h) / _r ) -
+    (_r - _h) * sqrt(2 * _r * _h - _h * _h);
+}
+
+IGNITION_ADD_PLUGIN(Surface,
+                    ignition::gazebo::System,
+                    Surface::ISystemConfigure,
+                    Surface::ISystemPreUpdate)
+
+IGNITION_ADD_PLUGIN_ALIAS(Surface,
+                          "ignition::gazebo::systems::Surface")

--- a/mbzirc_ign/src/Surface.hh
+++ b/mbzirc_ign/src/Surface.hh
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#ifndef IGNITION_GAZEBO_SYSTEMS_SURFACE_HH_
+#define IGNITION_GAZEBO_SYSTEMS_SURFACE_HH_
+
+#include <memory>
+#include <ignition/gazebo/System.hh>
+#include <sdf/sdf.hh>
+
+namespace ignition
+{
+namespace gazebo
+{
+// Inline bracket to help doxygen filtering.
+inline namespace IGNITION_GAZEBO_VERSION_NAMESPACE {
+namespace systems
+{
+  // Forward declaration
+  class SurfacePrivate;
+
+  /// \brief A system that simulates the buoyancy of an object at the surface of
+  /// a fluid. This system must be attached to a model and the system will apply
+  /// buoyancy to a few sample points around a given link.
+  ///
+  /// ## Required system parameters
+  ///
+  /// * `<link_name>` is the name of the link used to apply forces.
+  /// * `<vehicle_length>` is the length of the vessel [m].
+  /// * `<vehicle_width>` is the width of the vessel [m].
+  /// * `<hull_radius>` is the radius of the vessel's hull [m].
+  ///
+  /// ## Optional system parameters
+  ///
+  /// * `<num_samples>` is the number of samples where forces will be applied.
+  /// * `<fluid_level>` is the depth at which the fluid should be in the vehicle
+  /// * `<fluid_density>` is the density of the fluid.
+  ///
+  /// ## Example
+  /// <plugin
+  ///   filename="ignition-gazebo-surface-system"
+  ///   name="ignition::gazebo::systems::Surface">
+  ///   <link_name>base_link</link_name>
+  ///   <vehicle_length>4.9</vehicle_length>
+  ///   <vehicle_width>2.4</vehicle_width>
+  ///   <hull_radius>0.213</hull_radius>
+  /// </plugin>
+  class Surface
+      : public System,
+        public ISystemConfigure,
+        public ISystemPreUpdate
+  {
+    /// \brief Constructor.
+    public: Surface();
+
+    /// \brief Destructor.
+    public: ~Surface() override = default;
+
+    // Documentation inherited.
+    public: void Configure(const Entity &_entity,
+                           const std::shared_ptr<const sdf::Element> &_sdf,
+                           EntityComponentManager &_ecm,
+                           EventManager &_eventMgr) override;
+
+    // Documentation inherited.
+    public: void PreUpdate(
+                const ignition::gazebo::UpdateInfo &_info,
+                ignition::gazebo::EntityComponentManager &_ecm) override;
+
+    /// \brief Convenience function for calculating the area of circle segment.
+    /// \param[in] _r Radius of circle.
+    /// \param[in] _h Height of the chord line.
+    /// \return The area.
+    /// \ref https://www.mathopenref.com/segmentareaht.html
+    private: double CircleSegment(double _r, double _h) const;
+
+    /// \brief Private data pointer.
+    private: std::unique_ptr<SurfacePrivate> dataPtr;
+  };
+  }
+}
+}
+}
+
+#endif


### PR DESCRIPTION
We're moving the `Surface` plugin to mbzirc first since it still needs some work to make it generic enough for ign-gazebo. Currently this plugin assumes the USV has 2 hulls (i.e. catamaran) so it may not work for all surface vessels.

We can upstream this plugin once we make it more generic.

This PR removes the dependency on ign-gazebo's `surface_plugin` branch. ~However, it still needs some physics changes in ign-gazebo's `add_world_force` branch. Here's the PR: https://github.com/ignitionrobotics/ign-gazebo/pull/1279~. Update: ign-gazebo 6.4.0 has been released with changes needed by this PR.

Signed-off-by: Ian Chen <ichen@openrobotics.org>