### PR TITLE
Initial configurable payload support

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,10 +171,10 @@ Each UAV platfrom (quadrotor and hexrotor) has four available payload slots as f
 
 1. `slot0`: front
 2. `slot1`: rear
-3. `slot2`: top 
-4. `slot3`: bottom 
+3. `slot2`: bottom
+4. `slot3`: top
 
-In each of these four slots, various perceptive sensors may be installed. 
+In each of these four slots, various perceptive sensors may be installed.
 The avilable sensors are listed in the repository in the [`models/sensors` directory](https://github.com/osrf/mbzirc/tree/main/mbzirc_ign/models/sensors)
 
 To choose a sensor for a payload slot, pass the argument to the spawn launch file:

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ See Installation instructions for:
     # remember to source the setup.bash
     source install/setup.bash
 
-    ros2 launch mbzirc_ign spawn.launch.py name:=quadrotor_1 world:=simple_demo model:=mbzirc_quadrotor type:=uav x:=1 y:=2 z:=0.05 R:=0 P:=0 Y:=0
+    ros2 launch mbzirc_ign spawn.launch.py name:=quadrotor_1 world:=simple_demo model:=mbzirc_quadrotor type:=uav x:=1 y:=2 z:=0.05 R:=0 P:=0 Y:=0 slot0:=mbzirc_hd_camera
     ```
 
 1. In another terminal, you can take a look at the ROS2 topics available
@@ -146,6 +146,7 @@ See Installation instructions for:
     ign topic -t /usv/left/thruster/joint/cmd_pos -m ignition.msgs.Double -p 'data: -1'
     ign topic -t /usv/right/thruster/joint/cmd_pos -m ignition.msgs.Double -p 'data: -1'
     ```
+    
 
 ### Build a Docker image
 
@@ -162,3 +163,39 @@ See Installation instructions for:
     ```
     bash run.bash mbzirc_sim
     ```
+    
+    
+### Configuring UAV Platform Payloads
+
+Each UAV platfrom (quadrotor and hexrotor) has four available payload slots as follows:
+
+1. `slot0`: front
+2. `slot1`: rear
+3. `slot2`: top 
+4. `slot3`: bottom 
+
+In each of these four slots, various perceptive sensors may be installed. 
+The avilable sensors are listed in the repository in the [`models/sensors` directory](https://github.com/osrf/mbzirc/tree/main/mbzirc_ign/models/sensors)
+
+To choose a sensor for a payload slot, pass the argument to the spawn launch file:
+
+```
+ros2 launch mbzirc_ign spawn.launch.py name:=quadrotor_1 world:=simple_demo model:=mbzirc_quadrotor type:=uav x:=1 y:=2 z:=0.05 R:=0 P:=0 Y:=0 \
+  slot0:=mbzirc_hd_camera \
+  slot1:=mbzirc_vga_camera \
+  slot3:=mbzirc_planar_lidar 
+```
+
+To modify the orientation of the payload sensor, pass the desired mounting position in degrees (note the quotation marks)
+
+```
+ros2 launch mbzirc_ign spawn.launch.py name:=quadrotor_1 world:=simple_demo model:=mbzirc_quadrotor type:=uav x:=1 y:=2 z:=0.05 R:=0 P:=0 Y:=0 \
+  slot0:=mbzirc_hd_camera \
+  slot0_rpy:="0 -5 0" \
+  slot1:=mbzirc_vga_camera \
+  slot1_rpy:="0 -90 0" \
+  slot3:=mbzirc_planar_lidar \
+  slot3_rpy:="0 10 0"
+```
+
+

--- a/mbzirc_ign/launch/spawn.launch.py
+++ b/mbzirc_ign/launch/spawn.launch.py
@@ -43,6 +43,11 @@ def spawn_uav(context, model_path, world_name, model_name, link_name):
   # take flight time in minutes
   flight_time = LaunchConfiguration('flightTime').perform(context)
 
+  slot0_payload = LaunchConfiguration('slot0').perform(context)
+  slot1_payload = LaunchConfiguration('slot1').perform(context)
+  slot2_payload = LaunchConfiguration('slot2').perform(context)
+  slot3_payload = LaunchConfiguration('slot3').perform(context)
+
   # calculate battery capacity from time
   # capacity (Ah) = flight time (in hours) * load (watts) / voltage
   # assume constant voltage for battery to keep things simple for now.
@@ -53,12 +58,22 @@ def spawn_uav(context, model_path, world_name, model_name, link_name):
   print("spawning UAV file: " + model_file)
 
   # run erb
-  process = subprocess.Popen(['erb',
-    'name=' + model_name,
-    'capacity='+str(battery_capacity),
-    model_file], stdout=subprocess.PIPE)
+  command = ['erb']
+  command.append(f'name={model_name}')
+  command.append(f'capacity={battery_capacity}')
+
+  if slot0_payload: command.append(f'slot0={slot0_payload}')
+  if slot1_payload: command.append(f'slot1={slot1_payload}')
+  if slot2_payload: command.append(f'slot2={slot2_payload}')
+  if slot3_payload: command.append(f'slot3={slot3_payload}')
+
+  command.append(model_file)
+
+  process = subprocess.Popen(command, stdout=subprocess.PIPE)
   stdout = process.communicate()[0]
   str_output = codecs.getdecoder("unicode_escape")(stdout)[0]
+
+  print(command, str_output)
 
   ignition_spawn_entity = Node(
       package='ros_ign_gazebo',
@@ -105,44 +120,80 @@ def spawn_uav(context, model_path, world_name, model_name, link_name):
       remappings=[(sensor_prefix + '/air_pressure/air_pressure', 'air_pressure')]
   )
 
-  # camera - image transport
-  # ros2_ign_camera_bridge = Node(
-  #     package='ros_ign_image',
-  #     executable='image_bridge',
-  #     output='screen',
-  #     arguments=[sensor_prefix +  '/camera_front/image'],
-  #     remappings=[(sensor_prefix + '/camera_front/image', 'front/image_raw')]
-  # )
+  payloads = []
+  check = [slot0_payload, slot1_payload, slot2_payload, slot3_payload]
 
-  # camera - parameter bridge
-  ros2_ign_camera_bridge = Node(
-      package='ros_ign_bridge',
-      executable='parameter_bridge',
-      arguments=[sensor_prefix +  '/camera_front/image@sensor_msgs/msg/Image@ignition.msgs.Image',
-                 sensor_prefix +  '/camera_front/camera_info@sensor_msgs/msg/CameraInfo@ignition.msgs.CameraInfo'],
-      remappings=[(sensor_prefix + '/camera_front/image', 'front/image_raw'),
-                  (sensor_prefix + '/camera_front/camera_info', 'front/camera_info')]
-  )
+  for idx in range(0, 4):
+      payload = check[idx]
+      if len(payload) == 0:
+          continue
+      prefix = f'/world/{world_name}/model/{model_name}/model/sensor_{idx}/link/sensor_link/sensor'
 
-  # camera optical frame publisher
-  ros2_camera_optical_frame_publisher = Node(
-      package='mbzirc_ros',
-      executable='optical_frame_publisher',
-      arguments=['1'],
-      remappings=[('input/image', 'front/image_raw'),
-                  ('output/image', 'front/optical/image_raw'),
-                  ('input/camera_info', 'front/camera_info'),
-                  ('output/camera_info', 'front/optical/camera_info'),
-                 ]
-  )
+      if payload in ['mbzirc_vga_camera', 'mbzirc_hd_camera']:
+          camera_bridge = Node(
+              package='ros_ign_bridge',
+              executable='parameter_bridge',
+              arguments=[prefix +  '/camera/image@sensor_msgs/msg/Image@ignition.msgs.Image',
+                         prefix +  '/camera/camera_info@sensor_msgs/msg/CameraInfo@ignition.msgs.CameraInfo'],
+              remappings=[(prefix + '/camera/image', f'slot{idx}/image_raw'),
+                          (prefix + '/camera/camera_info', f'slot{idx}/camera_info')]
+          )
 
-  # lidar
-  ros2_ign_lidar_bridge = Node(
-      package='ros_ign_bridge',
-      executable='parameter_bridge',
-      arguments=[sensor_prefix +  '/front_laser/scan/points@sensor_msgs/msg/PointCloud2@ignition.msgs.PointCloudPacked'],
-      remappings=[(sensor_prefix + '/front_laser/scan/points', 'points')]
-  )
+          # camera optical frame publisher
+          ros2_camera_optical_frame_publisher = Node(
+              package='mbzirc_ros',
+              executable='optical_frame_publisher',
+              arguments=['1'],
+              remappings=[('input/image',  f'slot{idx}/image_raw'),
+                          ('output/image', f'slot{idx}/optical/image_raw'),
+                          ('input/camera_info', f'slot{idx}/camera_info'),
+                          ('output/camera_info', f'slot{idx}/optical/camera_info'),
+                         ]
+          )
+
+          payloads.append(camera_bridge)
+          payloads.append(ros2_camera_optical_frame_publisher)
+      elif payload in ['mbzirc_planar_lidar', 'mbzirc_3d_lidar']:
+          ros2_ign_lidar_bridge = Node(
+              package='ros_ign_bridge',
+              executable='parameter_bridge',
+              output='screen',
+              arguments=[prefix + '/lidar/scan/points@sensor_msgs/msg/PointCloud2@ignition.msgs.PointCloudPacked'],
+              remappings=[(prefix + '/lidar/scan/points', f'slot{idx}/points')]
+          )
+          payloads.append(ros2_ign_lidar_bridge)
+      elif payload in ['mbzirc_rgbd_camera']:
+          rgbd_pointcloud_bridge = Node(
+              package='ros_ign_bridge',
+              executable='parameter_bridge',
+              output='screen',
+              arguments=[
+                  prefix + '/camera/image@sensor_msgs/msg/Image@ignition.msgs.Image',
+                  prefix + '/camera/camera_info@sensor_msgs/msg/CameraInfo@ignition.msgs.CameraInfo',
+                  prefix + '/camera/points@sensor_msgs/msg/PointCloud2@ignition.msgs.PointCloudPacked',
+              ],
+              remappings=[
+                  (prefix + '/camera/image', f'slot{idx}/image_raw'),
+                  (prefix + '/camera/points', f'slot{idx}/points'),
+                  (prefix + '/camera/camera_info', f'slot{idx}/camera_info'),
+              ]
+          )
+
+          image_optical_frame = Node(
+              package='mbzirc_ros',
+              executable='optical_frame_publisher',
+              arguments=['1'],
+              remappings=[('input/image',  f'slot{idx}/image_raw'),
+                          ('output/image', f'slot{idx}/optical/image_raw'),
+                          ('input/camera_info', f'slot{idx}/camera_info'),
+                          ('output/camera_info', f'slot{idx}/optical/camera_info'),
+                         ]
+          )
+
+          payloads.append(rgbd_pointcloud_bridge)
+          payloads.append(image_optical_frame)
+      else:
+          print('Unknown payload: ', payload)
 
   # twist
   ros2_ign_twist_bridge = Node(
@@ -184,13 +235,11 @@ def spawn_uav(context, model_path, world_name, model_name, link_name):
         ros2_ign_imu_bridge,
         ros2_ign_magnetometer_bridge,
         ros2_ign_air_pressure_bridge,
-        ros2_ign_camera_bridge,
-        ros2_camera_optical_frame_publisher,
-        ros2_ign_lidar_bridge,
         ros2_ign_twist_bridge,
         ros2_ign_pose_bridge,
         ros2_ign_pose_static_bridge,
         ros2_tf_broadcaster,
+        *payloads
   ])
 
   handler = RegisterEventHandler(
@@ -322,7 +371,6 @@ def generate_launch_description():
             'R',
             default_value='0',
             description='R rotation to spawn'),
-
         DeclareLaunchArgument(
             'P',
             default_value='0',
@@ -331,11 +379,28 @@ def generate_launch_description():
             'Y',
             default_value='0',
             description='Y rotation to spawn'),
+
         DeclareLaunchArgument(
             'flightTime',
             default_value='10',
-            description='Battery flight time in minutes (only for UAVs)'
-        ),
+            description='Battery flight time in minutes (only for UAVs)'),
+
+        DeclareLaunchArgument(
+            'slot0',
+            default_value='',
+            description='Payload mounted to slot 0'),
+        DeclareLaunchArgument(
+            'slot1',
+            default_value='',
+            description='Payload mounted to slot 1'),
+        DeclareLaunchArgument(
+            'slot2',
+            default_value='',
+            description='Payload mounted to slot 2'),
+        DeclareLaunchArgument(
+            'slot3',
+            default_value='',
+            description='Payload mounted to slot 3'),
         # launch setup
         OpaqueFunction(function = launch)
     ])

--- a/mbzirc_ign/launch/spawn.launch.py
+++ b/mbzirc_ign/launch/spawn.launch.py
@@ -48,6 +48,11 @@ def spawn_uav(context, model_path, world_name, model_name, link_name):
   slot2_payload = LaunchConfiguration('slot2').perform(context)
   slot3_payload = LaunchConfiguration('slot3').perform(context)
 
+  slot0_rpy = LaunchConfiguration('slot0_rpy').perform(context)
+  slot1_rpy = LaunchConfiguration('slot1_rpy').perform(context)
+  slot2_rpy = LaunchConfiguration('slot2_rpy').perform(context)
+  slot3_rpy = LaunchConfiguration('slot3_rpy').perform(context)
+
   # calculate battery capacity from time
   # capacity (Ah) = flight time (in hours) * load (watts) / voltage
   # assume constant voltage for battery to keep things simple for now.
@@ -63,9 +68,13 @@ def spawn_uav(context, model_path, world_name, model_name, link_name):
   command.append(f'capacity={battery_capacity}')
 
   if slot0_payload: command.append(f'slot0={slot0_payload}')
+  if slot0_rpy: command.append(f'slot0_pos={slot0_rpy}')
   if slot1_payload: command.append(f'slot1={slot1_payload}')
-  if slot2_payload: command.append(f'slot2={slot2_payload}')
+  if slot1_rpy: command.append(f'slot1_pos={slot1_rpy}')
+  if slot2_payload: command.append(f'slot2="{slot2_payload}"')
+  if slot2_rpy: command.append(f'slot2_pos={slot2_rpy}')
   if slot3_payload: command.append(f'slot3={slot3_payload}')
+  if slot3_rpy: command.append(f'slot3_pos={slot3_rpy}')
 
   command.append(model_file)
 
@@ -390,17 +399,33 @@ def generate_launch_description():
             default_value='',
             description='Payload mounted to slot 0'),
         DeclareLaunchArgument(
+            'slot0_rpy',
+            default_value='0 0 0',
+            description='Roll, Pitch, Yaw in degrees of payload mount'),
+        DeclareLaunchArgument(
             'slot1',
             default_value='',
             description='Payload mounted to slot 1'),
+        DeclareLaunchArgument(
+            'slot1_rpy',
+            default_value='0 0 0',
+            description='Roll, Pitch, Yaw in degrees of payload mount'),
         DeclareLaunchArgument(
             'slot2',
             default_value='',
             description='Payload mounted to slot 2'),
         DeclareLaunchArgument(
+            'slot2_rpy',
+            default_value='0 0 0',
+            description='Roll, Pitch, Yaw in degrees of payload mount'),
+        DeclareLaunchArgument(
             'slot3',
             default_value='',
             description='Payload mounted to slot 3'),
+        DeclareLaunchArgument(
+            'slot3_rpy',
+            default_value='0 0 0',
+            description='Roll, Pitch, Yaw in degrees of payload mount'),
         # launch setup
         OpaqueFunction(function = launch)
     ])

--- a/mbzirc_ign/launch/spawn.launch.py
+++ b/mbzirc_ign/launch/spawn.launch.py
@@ -71,7 +71,7 @@ def spawn_uav(context, model_path, world_name, model_name, link_name):
   if slot0_rpy: command.append(f'slot0_pos={slot0_rpy}')
   if slot1_payload: command.append(f'slot1={slot1_payload}')
   if slot1_rpy: command.append(f'slot1_pos={slot1_rpy}')
-  if slot2_payload: command.append(f'slot2="{slot2_payload}"')
+  if slot2_payload: command.append(f'slot2={slot2_payload}')
   if slot2_rpy: command.append(f'slot2_pos={slot2_rpy}')
   if slot3_payload: command.append(f'slot3={slot3_payload}')
   if slot3_rpy: command.append(f'slot3_pos={slot3_rpy}')

--- a/mbzirc_ign/launch/spawn.launch.py
+++ b/mbzirc_ign/launch/spawn.launch.py
@@ -237,6 +237,9 @@ def spawn_uav(context, model_path, world_name, model_name, link_name):
       package='mbzirc_ros',
       executable='pose_tf_broadcaster',
       output='screen',
+      parameters=[
+          {"world_frame": world_name}
+      ]
   )
 
   group_action = GroupAction([

--- a/mbzirc_ign/models/mbzirc_hexrotor/model.sdf.erb
+++ b/mbzirc_ign/models/mbzirc_hexrotor/model.sdf.erb
@@ -121,7 +121,7 @@ end
       <publish_sensor_pose>true</publish_sensor_pose>
       <publish_collision_pose>false</publish_collision_pose>
       <publish_visual_pose>false</publish_visual_pose>
-      <!--<publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>-->
+      <publish_nested_model_pose>true</publish_nested_model_pose>
       <use_pose_vector_msg>true</use_pose_vector_msg>
       <static_publisher>true</static_publisher>
       <static_update_frequency>1</static_update_frequency>

--- a/mbzirc_ign/models/mbzirc_hexrotor/model.sdf.erb
+++ b/mbzirc_ign/models/mbzirc_hexrotor/model.sdf.erb
@@ -1,220 +1,310 @@
-<?xml version="1.0"?>
-
 <%
 if !defined?(name) || name== nil || name.empty?
   $model_name = 'mbzirc_hexrotor'
 else
   $model_name = name
 end
-%>
 
-<sdf version='1.6'>
-<include>
-  <name><%= $model_name%></name>
-  <uri>mbzirc_hexrotor_base</uri>
-  <!-- Publish robot state information -->
-  <plugin filename="libignition-gazebo-pose-publisher-system.so"
-    name="ignition::gazebo::systems::PosePublisher">
-    <publish_link_pose>true</publish_link_pose>
-    <publish_sensor_pose>true</publish_sensor_pose>
-    <publish_collision_pose>false</publish_collision_pose>
-    <publish_visual_pose>false</publish_visual_pose>
-    <!--<publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>-->
-    <use_pose_vector_msg>true</use_pose_vector_msg>
-    <static_publisher>true</static_publisher>
-    <static_update_frequency>1</static_update_frequency>
-  </plugin>
-  <plugin filename="libignition-gazebo-multicopter-motor-model-system.so"
-    name="ignition::gazebo::systems::MulticopterMotorModel">
-    <robotNamespace>model/<%= $model_name%></robotNamespace>
-    <jointName>rotor_0_joint</jointName>
-    <linkName>rotor_0</linkName>
-    <turningDirection>ccw</turningDirection>
-    <timeConstantUp>0.0182</timeConstantUp>
-    <timeConstantDown>0.0182</timeConstantDown>
-    <maxRotVelocity>1000.0</maxRotVelocity>
-    <motorConstant>1.269e-05</motorConstant>
-    <momentConstant>0.016754</momentConstant>
-    <commandSubTopic>command/motor_speed</commandSubTopic>
-    <motorNumber>0</motorNumber>
-    <rotorDragCoefficient>2.0673e-04</rotorDragCoefficient>
-    <rollingMomentCoefficient>0</rollingMomentCoefficient>
-    <motorSpeedPubTopic>motor_speed/0</motorSpeedPubTopic>
-    <rotorVelocitySlowdownSim>10</rotorVelocitySlowdownSim>
-    <motorType>velocity</motorType>
-  </plugin>
-  <plugin filename="libignition-gazebo-multicopter-motor-model-system.so"
-    name="ignition::gazebo::systems::MulticopterMotorModel">
-    <robotNamespace>model/<%= $model_name%></robotNamespace>
-    <jointName>rotor_1_joint</jointName>
-    <linkName>rotor_1</linkName>
-    <turningDirection>cw</turningDirection>
-    <timeConstantUp>0.0182</timeConstantUp>
-    <timeConstantDown>0.0182</timeConstantDown>
-    <maxRotVelocity>1000.0</maxRotVelocity>
-    <motorConstant>1.269e-05</motorConstant>
-    <momentConstant>0.016754</momentConstant>
-    <commandSubTopic>command/motor_speed</commandSubTopic>
-    <motorNumber>1</motorNumber>
-    <rotorDragCoefficient>2.0673e-04</rotorDragCoefficient>
-    <rollingMomentCoefficient>0</rollingMomentCoefficient>
-    <motorSpeedPubTopic>motor_speed/1</motorSpeedPubTopic>
-    <rotorVelocitySlowdownSim>10</rotorVelocitySlowdownSim>
-    <motorType>velocity</motorType>
-  </plugin>
-  <plugin filename="libignition-gazebo-multicopter-motor-model-system.so"
-    name="ignition::gazebo::systems::MulticopterMotorModel">
-    <robotNamespace>model/<%= $model_name%></robotNamespace>
-    <jointName>rotor_2_joint</jointName>
-    <linkName>rotor_2</linkName>
-    <turningDirection>ccw</turningDirection>
-    <timeConstantUp>0.0182</timeConstantUp>
-    <timeConstantDown>0.0182</timeConstantDown>
-    <maxRotVelocity>1000.0</maxRotVelocity>
-    <motorConstant>1.269e-05</motorConstant>
-    <momentConstant>0.016754</momentConstant>
-    <commandSubTopic>command/motor_speed</commandSubTopic>
-    <motorNumber>2</motorNumber>
-    <rotorDragCoefficient>2.0673e-04</rotorDragCoefficient>
-    <rollingMomentCoefficient>0</rollingMomentCoefficient>
-    <motorSpeedPubTopic>motor_speed/2</motorSpeedPubTopic>
-    <rotorVelocitySlowdownSim>10</rotorVelocitySlowdownSim>
-    <motorType>velocity</motorType>
-  </plugin>
-  <plugin filename="libignition-gazebo-multicopter-motor-model-system.so"
-    name="ignition::gazebo::systems::MulticopterMotorModel">
-    <robotNamespace>model/<%= $model_name%></robotNamespace>
-    <jointName>rotor_3_joint</jointName>
-    <linkName>rotor_3</linkName>
-    <turningDirection>cw</turningDirection>
-    <timeConstantUp>0.0182</timeConstantUp>
-    <timeConstantDown>0.0182</timeConstantDown>
-    <maxRotVelocity>1000.0</maxRotVelocity>
-    <motorConstant>1.269e-05</motorConstant>
-    <momentConstant>0.016754</momentConstant>
-    <commandSubTopic>command/motor_speed</commandSubTopic>
-    <motorNumber>3</motorNumber>
-    <rotorDragCoefficient>2.0673e-04</rotorDragCoefficient>
-    <rollingMomentCoefficient>0</rollingMomentCoefficient>
-    <motorSpeedPubTopic>motor_speed/3</motorSpeedPubTopic>
-    <rotorVelocitySlowdownSim>10</rotorVelocitySlowdownSim>
-    <motorType>velocity</motorType>
-  </plugin>
-  <plugin filename="libignition-gazebo-multicopter-motor-model-system.so"
-    name="ignition::gazebo::systems::MulticopterMotorModel">
-    <robotNamespace>model/<%= $model_name%></robotNamespace>
-    <jointName>rotor_4_joint</jointName>
-    <linkName>rotor_4</linkName>
-    <turningDirection>ccw</turningDirection>
-    <timeConstantUp>0.0182</timeConstantUp>
-    <timeConstantDown>0.0182</timeConstantDown>
-    <maxRotVelocity>1000.0</maxRotVelocity>
-    <motorConstant>1.269e-05</motorConstant>
-    <momentConstant>0.016754</momentConstant>
-    <commandSubTopic>command/motor_speed</commandSubTopic>
-    <motorNumber>4</motorNumber>
-    <rotorDragCoefficient>2.0673e-04</rotorDragCoefficient>
-    <rollingMomentCoefficient>0</rollingMomentCoefficient>
-    <motorSpeedPubTopic>motor_speed/4</motorSpeedPubTopic>
-    <rotorVelocitySlowdownSim>10</rotorVelocitySlowdownSim>
-    <motorType>velocity</motorType>
-  </plugin>
-  <plugin filename="libignition-gazebo-multicopter-motor-model-system.so"
-    name="ignition::gazebo::systems::MulticopterMotorModel">
-    <robotNamespace>model/<%= $model_name%></robotNamespace>
-    <jointName>rotor_5_joint</jointName>
-    <linkName>rotor_5</linkName>
-    <turningDirection>cw</turningDirection>
-    <timeConstantUp>0.0182</timeConstantUp>
-    <timeConstantDown>0.0182</timeConstantDown>
-    <maxRotVelocity>1000.0</maxRotVelocity>
-    <motorConstant>1.269e-05</motorConstant>
-    <momentConstant>0.016754</momentConstant>
-    <commandSubTopic>command/motor_speed</commandSubTopic>
-    <motorNumber>5</motorNumber>
-    <rotorDragCoefficient>2.0673e-04</rotorDragCoefficient>
-    <rollingMomentCoefficient>0</rollingMomentCoefficient>
-    <motorSpeedPubTopic>motor_speed/5</motorSpeedPubTopic>
-    <rotorVelocitySlowdownSim>10</rotorVelocitySlowdownSim>
-    <motorType>velocity</motorType>
-  </plugin>
-  <!--Multicopter velocity controller-->
-  <plugin
-    filename="libignition-gazebo-multicopter-control-system.so"
-    name="ignition::gazebo::systems::MulticopterVelocityControl">
-    <robotNamespace>model/<%= $model_name%></robotNamespace>
-    <commandSubTopic>cmd_vel</commandSubTopic>
-    <motorControlPubTopic>command/motor_speed</motorControlPubTopic>
-    <enableSubTopic>velocity_controller/enable</enableSubTopic>
-    <comLinkName>base_link</comLinkName>
-    <velocityGain>6 6 10</velocityGain>
-    <attitudeGain>4 4 2</attitudeGain>
-    <angularRateGain>0.7 0.7 0.7</angularRateGain>
-    <maximumLinearAcceleration>1 1 2</maximumLinearAcceleration>
-    <maximumLinearVelocity>5 5 5</maximumLinearVelocity>
-    <maximumAngularVelocity>3 3 3</maximumAngularVelocity>
-    <linearVelocityNoiseMean>0 0 0</linearVelocityNoiseMean>
-    <!-- linearVelocityNoiseStdDev based on error values reported in the paper Shen et. al., -->
-    <!-- Vision-Based State Estimation and Trajectory Control Towards High-Speed Flight with a Quadrotor -->
-    <!-- http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.490.7958&rep=rep1&type=pdf -->
-    <linearVelocityNoiseStdDev>0.1105 0.1261 0.0947</linearVelocityNoiseStdDev>
-    <angularVelocityNoiseMean>0 0 0</angularVelocityNoiseMean>
-    <!-- angularVelocityNoiseStdDev values based on ADIS16448's Rate Noise Density with a sample  -->
-    <!-- time of 0.004 ms. -->
-    <angularVelocityNoiseStdDev>0.004 0.004 0.004</angularVelocityNoiseStdDev>
-    <rotorConfiguration>
-      <rotor>
-        <jointName>rotor_0_joint</jointName>
-        <forceConstant>1.269e-05</forceConstant>
-        <momentConstant>1.6754e-2</momentConstant>
-        <direction>1</direction>
-      </rotor>
-      <rotor>
-        <jointName>rotor_1_joint</jointName>
-        <forceConstant>1.269e-05</forceConstant>
-        <momentConstant>1.6754e-2</momentConstant>
-        <direction>-1</direction>
-      </rotor>
-      <rotor>
-        <jointName>rotor_2_joint</jointName>
-        <forceConstant>1.269e-05</forceConstant>
-        <momentConstant>1.6754e-2</momentConstant>
-        <direction>1</direction>
-      </rotor>
-      <rotor>
-        <jointName>rotor_3_joint</jointName>
-        <forceConstant>1.269e-05</forceConstant>
-        <momentConstant>1.6754e-2</momentConstant>
-        <direction>-1</direction>
-      </rotor>
-      <rotor>
-        <jointName>rotor_4_joint</jointName>
-        <forceConstant>1.269e-05</forceConstant>
-        <momentConstant>1.6754e-2</momentConstant>
-        <direction>1</direction>
-      </rotor>
-      <rotor>
-        <jointName>rotor_5_joint</jointName>
-        <forceConstant>1.269e-05</forceConstant>
-        <momentConstant>1.6754e-2</momentConstant>
-        <direction>-1</direction>
-      </rotor>
-    </rotorConfiguration>
-  </plugin>
-  <!-- Battery plugin -->
-  <plugin filename="libignition-gazebo-linearbatteryplugin-system.so"
-    name="ignition::gazebo::systems::LinearBatteryPlugin">
-    <battery_name>linear_battery</battery_name>
-    <voltage>12.694</voltage>
-    <open_circuit_voltage_constant_coef>12.694</open_circuit_voltage_constant_coef>
-    <open_circuit_voltage_linear_coef>0</open_circuit_voltage_linear_coef>
-    <initial_charge><%= capacity%></initial_charge>
-    <capacity><%= capacity%></capacity>
-    <resistance>0.061523</resistance>
-    <smooth_current_tau>1.9499</smooth_current_tau>
-    <power_load>6.6</power_load>
-    <start_on_motion>true</start_on_motion>
-    <fix_issue_225>true</fix_issue_225>
-  </plugin>
-  </include>
+$slot0_payload = nil
+$slot0_rpy = '0 0 0'
+
+$slot1_payload = nil
+$slot1_rpy = '0 0 0' 
+
+$slot2_payload = nil
+$slot2_rpy = '0 0 0' 
+
+$slot3_payload = nil
+$slot3_rpy = '0 0 0'
+
+if defined?(slot0) 
+  $slot0_payload = slot0
+end
+if defined?(slot1)
+  $slot1_payload = slot1
+end
+if defined?(slot2)
+  $slot2_payload = slot2
+end
+if defined?(slot3)
+  $slot3_payload = slot3
+end
+%>
+<?xml version="1.0"?>
+<sdf version='1.9'>
+  <model name="<%= model_name%>">
+
+    <!-- Platform base model -->
+    <include merge="true">
+      <uri>model://mbzirc_hexrotor_base</uri>
+    </include>
+    <% if $slot0_payload != nil%>
+    <!-- Payload slot0 -->
+    <include>
+      <name>sensor_0</name>
+      <uri>model://sensors/<%= $slot0_payload%></uri>
+      <placement_frame>mount_point</placement_frame>
+      <pose relative_to="slot_0" degrees="true">
+        0 0 0 <%= $slot0_rpy%>
+      </pose>
+    </include>
+
+    <joint name="slot_0_joint" type="fixed">
+      <parent>slot_0</parent>
+      <child>sensor_0::mount_point</child>
+    </joint>
+    <% end %>
+    <% if $slot1_payload != nil%>
+    <!-- Payload slot1 -->
+    <include>
+      <name>sensor_1</name>
+      <uri>model://sensors/<%= $slot1_payload%></uri>
+      <placement_frame>mount_point</placement_frame>
+      <pose relative_to="slot_1" degrees="true">
+        0 0 0 <%= $slot1_rpy%>
+      </pose>
+    </include>
+
+    <joint name="slot_1_joint" type="fixed">
+      <parent>slot_1</parent>
+      <child>sensor_1::mount_point</child>
+    </joint>
+    <% end %>
+    <% if $slot2_payload != nil%>
+    <!-- Payload slot2 -->
+    <include>
+      <name>sensor_2</name>
+      <uri>model://sensors/<%= $slot2_payload%></uri>
+      <placement_frame>mount_point</placement_frame>
+      <pose relative_to="slot_2" degrees="true">
+        0 0 0 <%= $slot2_rpy%>
+      </pose>
+    </include>
+
+    <joint name="slot_2_joint" type="fixed">
+      <parent>slot_2</parent>
+      <child>sensor_2::mount_point</child>
+    </joint>
+    <% end %>
+    <% if $slot3_payload != nil%>
+    <!-- Payload slot3 -->
+    <include>
+      <name>sensor_3</name>
+      <uri>model://sensors/<%= $slot3_payload%></uri>
+      <placement_frame>mount_point</placement_frame>
+      <pose relative_to="slot_3" degrees="true">
+        0 0 0 <%= $slot3_rpy%>
+      </pose>
+    </include>
+
+    <joint name="slot_3_joint" type="fixed">
+      <parent>slot_3</parent>
+      <child>sensor_3::mount_point</child>
+    </joint>
+    <% end %>
+    <!-- Publish robot state information -->
+    <plugin filename="libignition-gazebo-pose-publisher-system.so"
+      name="ignition::gazebo::systems::PosePublisher">
+      <publish_link_pose>true</publish_link_pose>
+      <publish_sensor_pose>true</publish_sensor_pose>
+      <publish_collision_pose>false</publish_collision_pose>
+      <publish_visual_pose>false</publish_visual_pose>
+      <!--<publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>-->
+      <use_pose_vector_msg>true</use_pose_vector_msg>
+      <static_publisher>true</static_publisher>
+      <static_update_frequency>1</static_update_frequency>
+    </plugin>
+    <plugin filename="libignition-gazebo-multicopter-motor-model-system.so"
+      name="ignition::gazebo::systems::MulticopterMotorModel">
+      <robotNamespace>model/<%= $model_name%></robotNamespace>
+      <jointName>rotor_0_joint</jointName>
+      <linkName>rotor_0</linkName>
+      <turningDirection>ccw</turningDirection>
+      <timeConstantUp>0.0182</timeConstantUp>
+      <timeConstantDown>0.0182</timeConstantDown>
+      <maxRotVelocity>1000.0</maxRotVelocity>
+      <motorConstant>1.269e-05</motorConstant>
+      <momentConstant>0.016754</momentConstant>
+      <commandSubTopic>command/motor_speed</commandSubTopic>
+      <motorNumber>0</motorNumber>
+      <rotorDragCoefficient>2.0673e-04</rotorDragCoefficient>
+      <rollingMomentCoefficient>0</rollingMomentCoefficient>
+      <motorSpeedPubTopic>motor_speed/0</motorSpeedPubTopic>
+      <rotorVelocitySlowdownSim>10</rotorVelocitySlowdownSim>
+      <motorType>velocity</motorType>
+    </plugin>
+    <plugin filename="libignition-gazebo-multicopter-motor-model-system.so"
+      name="ignition::gazebo::systems::MulticopterMotorModel">
+      <robotNamespace>model/<%= $model_name%></robotNamespace>
+      <jointName>rotor_1_joint</jointName>
+      <linkName>rotor_1</linkName>
+      <turningDirection>cw</turningDirection>
+      <timeConstantUp>0.0182</timeConstantUp>
+      <timeConstantDown>0.0182</timeConstantDown>
+      <maxRotVelocity>1000.0</maxRotVelocity>
+      <motorConstant>1.269e-05</motorConstant>
+      <momentConstant>0.016754</momentConstant>
+      <commandSubTopic>command/motor_speed</commandSubTopic>
+      <motorNumber>1</motorNumber>
+      <rotorDragCoefficient>2.0673e-04</rotorDragCoefficient>
+      <rollingMomentCoefficient>0</rollingMomentCoefficient>
+      <motorSpeedPubTopic>motor_speed/1</motorSpeedPubTopic>
+      <rotorVelocitySlowdownSim>10</rotorVelocitySlowdownSim>
+      <motorType>velocity</motorType>
+    </plugin>
+    <plugin filename="libignition-gazebo-multicopter-motor-model-system.so"
+      name="ignition::gazebo::systems::MulticopterMotorModel">
+      <robotNamespace>model/<%= $model_name%></robotNamespace>
+      <jointName>rotor_2_joint</jointName>
+      <linkName>rotor_2</linkName>
+      <turningDirection>ccw</turningDirection>
+      <timeConstantUp>0.0182</timeConstantUp>
+      <timeConstantDown>0.0182</timeConstantDown>
+      <maxRotVelocity>1000.0</maxRotVelocity>
+      <motorConstant>1.269e-05</motorConstant>
+      <momentConstant>0.016754</momentConstant>
+      <commandSubTopic>command/motor_speed</commandSubTopic>
+      <motorNumber>2</motorNumber>
+      <rotorDragCoefficient>2.0673e-04</rotorDragCoefficient>
+      <rollingMomentCoefficient>0</rollingMomentCoefficient>
+      <motorSpeedPubTopic>motor_speed/2</motorSpeedPubTopic>
+      <rotorVelocitySlowdownSim>10</rotorVelocitySlowdownSim>
+      <motorType>velocity</motorType>
+    </plugin>
+    <plugin filename="libignition-gazebo-multicopter-motor-model-system.so"
+      name="ignition::gazebo::systems::MulticopterMotorModel">
+      <robotNamespace>model/<%= $model_name%></robotNamespace>
+      <jointName>rotor_3_joint</jointName>
+      <linkName>rotor_3</linkName>
+      <turningDirection>cw</turningDirection>
+      <timeConstantUp>0.0182</timeConstantUp>
+      <timeConstantDown>0.0182</timeConstantDown>
+      <maxRotVelocity>1000.0</maxRotVelocity>
+      <motorConstant>1.269e-05</motorConstant>
+      <momentConstant>0.016754</momentConstant>
+      <commandSubTopic>command/motor_speed</commandSubTopic>
+      <motorNumber>3</motorNumber>
+      <rotorDragCoefficient>2.0673e-04</rotorDragCoefficient>
+      <rollingMomentCoefficient>0</rollingMomentCoefficient>
+      <motorSpeedPubTopic>motor_speed/3</motorSpeedPubTopic>
+      <rotorVelocitySlowdownSim>10</rotorVelocitySlowdownSim>
+      <motorType>velocity</motorType>
+    </plugin>
+    <plugin filename="libignition-gazebo-multicopter-motor-model-system.so"
+      name="ignition::gazebo::systems::MulticopterMotorModel">
+      <robotNamespace>model/<%= $model_name%></robotNamespace>
+      <jointName>rotor_4_joint</jointName>
+      <linkName>rotor_4</linkName>
+      <turningDirection>ccw</turningDirection>
+      <timeConstantUp>0.0182</timeConstantUp>
+      <timeConstantDown>0.0182</timeConstantDown>
+      <maxRotVelocity>1000.0</maxRotVelocity>
+      <motorConstant>1.269e-05</motorConstant>
+      <momentConstant>0.016754</momentConstant>
+      <commandSubTopic>command/motor_speed</commandSubTopic>
+      <motorNumber>4</motorNumber>
+      <rotorDragCoefficient>2.0673e-04</rotorDragCoefficient>
+      <rollingMomentCoefficient>0</rollingMomentCoefficient>
+      <motorSpeedPubTopic>motor_speed/4</motorSpeedPubTopic>
+      <rotorVelocitySlowdownSim>10</rotorVelocitySlowdownSim>
+      <motorType>velocity</motorType>
+    </plugin>
+    <plugin filename="libignition-gazebo-multicopter-motor-model-system.so"
+      name="ignition::gazebo::systems::MulticopterMotorModel">
+      <robotNamespace>model/<%= $model_name%></robotNamespace>
+      <jointName>rotor_5_joint</jointName>
+      <linkName>rotor_5</linkName>
+      <turningDirection>cw</turningDirection>
+      <timeConstantUp>0.0182</timeConstantUp>
+      <timeConstantDown>0.0182</timeConstantDown>
+      <maxRotVelocity>1000.0</maxRotVelocity>
+      <motorConstant>1.269e-05</motorConstant>
+      <momentConstant>0.016754</momentConstant>
+      <commandSubTopic>command/motor_speed</commandSubTopic>
+      <motorNumber>5</motorNumber>
+      <rotorDragCoefficient>2.0673e-04</rotorDragCoefficient>
+      <rollingMomentCoefficient>0</rollingMomentCoefficient>
+      <motorSpeedPubTopic>motor_speed/5</motorSpeedPubTopic>
+      <rotorVelocitySlowdownSim>10</rotorVelocitySlowdownSim>
+      <motorType>velocity</motorType>
+    </plugin>
+    <!--Multicopter velocity controller-->
+    <plugin
+      filename="libignition-gazebo-multicopter-control-system.so"
+      name="ignition::gazebo::systems::MulticopterVelocityControl">
+      <robotNamespace>model/<%= $model_name%></robotNamespace>
+      <commandSubTopic>cmd_vel</commandSubTopic>
+      <motorControlPubTopic>command/motor_speed</motorControlPubTopic>
+      <enableSubTopic>velocity_controller/enable</enableSubTopic>
+      <comLinkName>base_link</comLinkName>
+      <velocityGain>6 6 10</velocityGain>
+      <attitudeGain>4 4 2</attitudeGain>
+      <angularRateGain>0.7 0.7 0.7</angularRateGain>
+      <maximumLinearAcceleration>1 1 2</maximumLinearAcceleration>
+      <maximumLinearVelocity>5 5 5</maximumLinearVelocity>
+      <maximumAngularVelocity>3 3 3</maximumAngularVelocity>
+      <linearVelocityNoiseMean>0 0 0</linearVelocityNoiseMean>
+      <!-- linearVelocityNoiseStdDev based on error values reported in the paper Shen et. al., -->
+      <!-- Vision-Based State Estimation and Trajectory Control Towards High-Speed Flight with a Quadrotor -->
+      <!-- http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.490.7958&rep=rep1&type=pdf -->
+      <linearVelocityNoiseStdDev>0.1105 0.1261 0.0947</linearVelocityNoiseStdDev>
+      <angularVelocityNoiseMean>0 0 0</angularVelocityNoiseMean>
+      <!-- angularVelocityNoiseStdDev values based on ADIS16448's Rate Noise Density with a sample  -->
+      <!-- time of 0.004 ms. -->
+      <angularVelocityNoiseStdDev>0.004 0.004 0.004</angularVelocityNoiseStdDev>
+      <rotorConfiguration>
+        <rotor>
+          <jointName>rotor_0_joint</jointName>
+          <forceConstant>1.269e-05</forceConstant>
+          <momentConstant>1.6754e-2</momentConstant>
+          <direction>1</direction>
+        </rotor>
+        <rotor>
+          <jointName>rotor_1_joint</jointName>
+          <forceConstant>1.269e-05</forceConstant>
+          <momentConstant>1.6754e-2</momentConstant>
+          <direction>-1</direction>
+        </rotor>
+        <rotor>
+          <jointName>rotor_2_joint</jointName>
+          <forceConstant>1.269e-05</forceConstant>
+          <momentConstant>1.6754e-2</momentConstant>
+          <direction>1</direction>
+        </rotor>
+        <rotor>
+          <jointName>rotor_3_joint</jointName>
+          <forceConstant>1.269e-05</forceConstant>
+          <momentConstant>1.6754e-2</momentConstant>
+          <direction>-1</direction>
+        </rotor>
+        <rotor>
+          <jointName>rotor_4_joint</jointName>
+          <forceConstant>1.269e-05</forceConstant>
+          <momentConstant>1.6754e-2</momentConstant>
+          <direction>1</direction>
+        </rotor>
+        <rotor>
+          <jointName>rotor_5_joint</jointName>
+          <forceConstant>1.269e-05</forceConstant>
+          <momentConstant>1.6754e-2</momentConstant>
+          <direction>-1</direction>
+        </rotor>
+      </rotorConfiguration>
+    </plugin>
+    <!-- Battery plugin -->
+    <plugin filename="libignition-gazebo-linearbatteryplugin-system.so"
+      name="ignition::gazebo::systems::LinearBatteryPlugin">
+      <battery_name>linear_battery</battery_name>
+      <voltage>12.694</voltage>
+      <open_circuit_voltage_constant_coef>12.694</open_circuit_voltage_constant_coef>
+      <open_circuit_voltage_linear_coef>0</open_circuit_voltage_linear_coef>
+      <initial_charge><%= capacity%></initial_charge>
+      <capacity><%= capacity%></capacity>
+      <resistance>0.061523</resistance>
+      <smooth_current_tau>1.9499</smooth_current_tau>
+      <power_load>6.6</power_load>
+      <start_on_motion>true</start_on_motion>
+      <fix_issue_225>true</fix_issue_225>
+    </plugin>
+  </model>
 </sdf>

--- a/mbzirc_ign/models/mbzirc_hexrotor/model.sdf.erb
+++ b/mbzirc_ign/models/mbzirc_hexrotor/model.sdf.erb
@@ -44,7 +44,7 @@ end
 %>
 <?xml version="1.0"?>
 <sdf version='1.9'>
-  <model name="<%= model_name%>">
+  <model name="<%= $model_name%>">
 
     <!-- Platform base model -->
     <include merge="true">

--- a/mbzirc_ign/models/mbzirc_hexrotor/model.sdf.erb
+++ b/mbzirc_ign/models/mbzirc_hexrotor/model.sdf.erb
@@ -20,14 +20,26 @@ $slot3_rpy = '0 0 0'
 if defined?(slot0) 
   $slot0_payload = slot0
 end
+if defined?(slot0_pos) 
+  $slot0_rpy = slot0_pos
+end
 if defined?(slot1)
   $slot1_payload = slot1
+end
+if defined?(slot1_pos) 
+  $slot1_rpy = slot1_pos
 end
 if defined?(slot2)
   $slot2_payload = slot2
 end
+if defined?(slot2_pos) 
+  $slot2_rpy = slot2_pos
+end
 if defined?(slot3)
   $slot3_payload = slot3
+end
+if defined?(slot3_pos) 
+  $slot3_rpy = slot3_pos
 end
 %>
 <?xml version="1.0"?>

--- a/mbzirc_ign/models/mbzirc_quadrotor/model.sdf.erb
+++ b/mbzirc_ign/models/mbzirc_quadrotor/model.sdf.erb
@@ -1,172 +1,257 @@
-<?xml version="1.0"?>
-
 <%
 if !defined?(name) || name== nil || name.empty?
   $model_name = 'mbzirc_quadrotor'
 else
   $model_name = name
 end
+
+$slot0_payload = nil
+$slot0_rpy = '0 0 0'
+$slot1_payload = nil
+$slot1_rpy = '0 0 0' 
+$slot2_payload = nil
+$slot2_rpy = '0 0 0' 
+$slot3_payload = nil
+$slot3_rpy = '0 0 0'
+
+if defined?(slot0) 
+  $slot0_payload = slot0
+end
+if defined?(slot1)
+  $slot1_payload = slot1
+end
+if defined?(slot2)
+  $slot2_payload = slot2
+end
+if defined?(slot3)
+  $slot3_payload = slot3
+end
 %>
+<?xml version="1.0"?>
+<sdf version='1.9'>
+  <model name="<%= $model_name%>">
 
-<sdf version='1.6'>
- <include>
-   <name><%= $model_name%></name>
-   <uri>mbzirc_quadrotor_base</uri>
+    <!-- Platform base model-->
+    <include merge="true">
+      <uri>model://mbzirc_quadrotor_base</uri>
+    </include>
+    <% if $slot0_payload != nil%>
+    <!-- Payload slot0 -->
+    <include>
+      <name>sensor_0</name>
+      <uri>model://sensors/<%= $slot0_payload%></uri>
+      <placement_frame>mount_point</placement_frame>
+      <pose relative_to="slot_0" degrees="true">
+        0 0 0 <%= $slot0_rpy%>
+      </pose>
+    </include>
 
-   <!-- Publish robot state information -->
-   <plugin filename="libignition-gazebo-pose-publisher-system.so"
-     name="ignition::gazebo::systems::PosePublisher">
-     <publish_link_pose>true</publish_link_pose>
-     <publish_sensor_pose>true</publish_sensor_pose>
-     <publish_collision_pose>false</publish_collision_pose>
-     <publish_visual_pose>false</publish_visual_pose>
-     <!--<publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>-->
-     <use_pose_vector_msg>true</use_pose_vector_msg>
-     <static_publisher>true</static_publisher>
-     <static_update_frequency>1</static_update_frequency>
-   </plugin>
-   <plugin filename="libignition-gazebo-multicopter-motor-model-system.so"
-     name="ignition::gazebo::systems::MulticopterMotorModel">
-     <robotNamespace>model/<%= $model_name%></robotNamespace>
-     <jointName>rotor_0_joint</jointName>
-     <linkName>rotor_0</linkName>
-     <turningDirection>ccw</turningDirection>
-     <timeConstantUp>0.0125</timeConstantUp>
-     <timeConstantDown>0.025</timeConstantDown>
-     <maxRotVelocity>800.0</maxRotVelocity>
-     <motorConstant>8.54858e-06</motorConstant>
-     <momentConstant>0.016</momentConstant>
-     <commandSubTopic>command/motor_speed</commandSubTopic>
-     <motorNumber>0</motorNumber>
-     <rotorDragCoefficient>8.06428e-05</rotorDragCoefficient>
-     <rollingMomentCoefficient>1e-06</rollingMomentCoefficient>
-     <motorSpeedPubTopic>motor_speed/0</motorSpeedPubTopic>
-     <rotorVelocitySlowdownSim>10</rotorVelocitySlowdownSim>
-     <motorType>velocity</motorType>
-   </plugin>
-   <plugin filename="libignition-gazebo-multicopter-motor-model-system.so"
-     name="ignition::gazebo::systems::MulticopterMotorModel">
-     <robotNamespace>model/<%= $model_name%></robotNamespace>
-     <jointName>rotor_1_joint</jointName>
-     <linkName>rotor_1</linkName>
-     <turningDirection>ccw</turningDirection>
-     <timeConstantUp>0.0125</timeConstantUp>
-     <timeConstantDown>0.025</timeConstantDown>
-     <maxRotVelocity>800.0</maxRotVelocity>
-     <motorConstant>8.54858e-06</motorConstant>
-     <momentConstant>0.016</momentConstant>
-     <commandSubTopic>command/motor_speed</commandSubTopic>
-     <motorNumber>1</motorNumber>
-     <rotorDragCoefficient>8.06428e-05</rotorDragCoefficient>
-     <rollingMomentCoefficient>1e-06</rollingMomentCoefficient>
-     <motorSpeedPubTopic>motor_speed/1</motorSpeedPubTopic>
-     <rotorVelocitySlowdownSim>10</rotorVelocitySlowdownSim>
-     <motorType>velocity</motorType>
-   </plugin>
-   <plugin filename="libignition-gazebo-multicopter-motor-model-system.so"
-     name="ignition::gazebo::systems::MulticopterMotorModel">
-     <robotNamespace>model/<%= $model_name%></robotNamespace>
-     <jointName>rotor_2_joint</jointName>
-     <linkName>rotor_2</linkName>
-     <turningDirection>cw</turningDirection>
-     <timeConstantUp>0.0125</timeConstantUp>
-     <timeConstantDown>0.025</timeConstantDown>
-     <maxRotVelocity>800.0</maxRotVelocity>
-     <motorConstant>8.54858e-06</motorConstant>
-     <momentConstant>0.016</momentConstant>
-     <commandSubTopic>command/motor_speed</commandSubTopic>
-     <motorNumber>2</motorNumber>
-     <rotorDragCoefficient>8.06428e-05</rotorDragCoefficient>
-     <rollingMomentCoefficient>1e-06</rollingMomentCoefficient>
-     <motorSpeedPubTopic>motor_speed/2</motorSpeedPubTopic>
-     <rotorVelocitySlowdownSim>10</rotorVelocitySlowdownSim>
-     <motorType>velocity</motorType>
-   </plugin>
-   <plugin filename="libignition-gazebo-multicopter-motor-model-system.so"
-     name="ignition::gazebo::systems::MulticopterMotorModel">
-     <robotNamespace>model/<%= $model_name%></robotNamespace>
-     <jointName>rotor_3_joint</jointName>
-     <linkName>rotor_3</linkName>
-     <turningDirection>cw</turningDirection>
-     <timeConstantUp>0.0125</timeConstantUp>
-     <timeConstantDown>0.025</timeConstantDown>
-     <maxRotVelocity>800.0</maxRotVelocity>
-     <motorConstant>8.54858e-06</motorConstant>
-     <momentConstant>0.016</momentConstant>
-     <commandSubTopic>command/motor_speed</commandSubTopic>
-     <motorNumber>3</motorNumber>
-     <rotorDragCoefficient>8.06428e-05</rotorDragCoefficient>
-     <rollingMomentCoefficient>1e-06</rollingMomentCoefficient>
-     <motorSpeedPubTopic>motor_speed/3</motorSpeedPubTopic>
-     <rotorVelocitySlowdownSim>10</rotorVelocitySlowdownSim>
-     <motorType>velocity</motorType>
-   </plugin>
-   <!--Multicopter velocity controller-->
-   <plugin
-     filename="libignition-gazebo-multicopter-control-system.so"
-     name="ignition::gazebo::systems::MulticopterVelocityControl">
-     <robotNamespace>model/<%= $model_name%></robotNamespace>
-     <commandSubTopic>cmd_vel</commandSubTopic>
-     <motorControlPubTopic>command/motor_speed</motorControlPubTopic>
-     <enableSubTopic>velocity_controller/enable</enableSubTopic>
-     <comLinkName>base_link</comLinkName>
-     <velocityGain>2.7 2.7 2.7</velocityGain>
-     <attitudeGain>2 3 0.15</attitudeGain>
-     <angularRateGain>0.4 0.52 0.18</angularRateGain>
-     <maximumLinearAcceleration>1 1 2</maximumLinearAcceleration>
-     <maximumLinearVelocity>5 5 5</maximumLinearVelocity>
-     <maximumAngularVelocity>3 3 3</maximumAngularVelocity>
-     <linearVelocityNoiseMean>0 0 0.05</linearVelocityNoiseMean>
-     <!-- linearVelocityNoiseStdDev based on error values reported in the paper Shen et. al., -->
-     <!-- Vision-Based State Estimation and Trajectory Control Towards High-Speed Flight with a Quadrotor -->
-     <!-- http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.490.7958&rep=rep1&type=pdf -->
-     <linearVelocityNoiseStdDev>0.1105 0.1261 0.00947</linearVelocityNoiseStdDev>
-     <angularVelocityNoiseMean>0 0 0</angularVelocityNoiseMean>
-     <!-- angularVelocityNoiseStdDev values based on ADIS16448's Rate Noise Density with a sample  -->
-     <!-- time of 0.004 ms. -->
-     <angularVelocityNoiseStdDev>0.004 0.004 0.004</angularVelocityNoiseStdDev>
-     <rotorConfiguration>
-       <rotor>
-         <jointName>rotor_0_joint</jointName>
-         <forceConstant>8.54858e-06</forceConstant>
-         <momentConstant>0.016</momentConstant>
-         <direction>1</direction>
-       </rotor>
-       <rotor>
-         <jointName>rotor_1_joint</jointName>
-         <forceConstant>8.54858e-06</forceConstant>
-         <momentConstant>0.016</momentConstant>
-         <direction>1</direction>
-       </rotor>
-       <rotor>
-         <jointName>rotor_2_joint</jointName>
-         <forceConstant>8.54858e-06</forceConstant>
-         <momentConstant>0.016</momentConstant>
-         <direction>-1</direction>
-       </rotor>
-       <rotor>
-         <jointName>rotor_3_joint</jointName>
-         <forceConstant>8.54858e-06</forceConstant>
-         <momentConstant>0.016</momentConstant>
-         <direction>-1</direction>
-       </rotor>
-     </rotorConfiguration>
-   </plugin>
-   <!-- Battery plugin -->
-   <!-- Since we are interested in using time as the limiting factor -->
-   <plugin filename="libignition-gazebo-linearbatteryplugin-system.so"
-     name="ignition::gazebo::systems::LinearBatteryPlugin">
-     <battery_name>linear_battery</battery_name>
-     <voltage>12.694</voltage>
-     <open_circuit_voltage_constant_coef>12.694</open_circuit_voltage_constant_coef>
-     <open_circuit_voltage_linear_coef>0</open_circuit_voltage_linear_coef>
-     <initial_charge><%= capacity%></initial_charge>
-     <capacity><%= capacity%></capacity>
-     <resistance>0.061523</resistance>
-     <smooth_current_tau>1.9499</smooth_current_tau>
-     <power_load>6.6</power_load>
-     <start_on_motion>true</start_on_motion>
-     <fix_issue_225>true</fix_issue_225>
-   </plugin>
- </include>
+    <joint name="slot_0_joint" type="fixed">
+      <parent>slot_0</parent>
+      <child>sensor_0::mount_point</child>
+    </joint>
+    <% end %>
+    <% if $slot1_payload != nil%>
+    <!-- Payload slot1 -->
+    <include>
+      <name>sensor_1</name>
+      <uri>model://sensors/<%= $slot1_payload%></uri>
+      <placement_frame>mount_point</placement_frame>
+      <pose relative_to="slot_1" degrees="true">
+        0 0 0 <%= $slot1_rpy%>
+      </pose>
+    </include>
+
+    <joint name="slot_1_joint" type="fixed">
+      <parent>slot_1</parent>
+      <child>sensor_1::mount_point</child>
+    </joint>
+    <% end %>
+    <% if $slot2_payload != nil%>
+    <!-- Payload slot2 -->
+    <include>
+      <name>sensor_2</name>
+      <uri>model://sensors/<%= $slot2_payload%></uri>
+      <placement_frame>mount_point</placement_frame>
+      <pose relative_to="slot_2" degrees="true">
+        0 0 0 <%= $slot2_rpy%>
+      </pose>
+    </include>
+
+    <joint name="slot_2_joint" type="fixed">
+      <parent>slot_2</parent>
+      <child>sensor_2::mount_point</child>
+    </joint>
+    <% end %>
+    <% if $slot3_payload != nil%>
+    <!-- Payload slot3 -->
+    <include>
+      <name>sensor_3</name>
+      <uri>model://sensors/<%= $slot3_payload%></uri>
+      <placement_frame>mount_point</placement_frame>
+      <pose relative_to="slot_3" degrees="true">
+        0 0 0 <%= $slot3_rpy%>
+      </pose>
+    </include>
+
+    <joint name="slot_3_joint" type="fixed">
+      <parent>slot_3</parent>
+      <child>sensor_3::mount_point</child>
+    </joint>
+    <% end %>
+    <plugin filename="libignition-gazebo-pose-publisher-system.so"
+      name="ignition::gazebo::systems::PosePublisher">
+      <publish_link_pose>true</publish_link_pose>
+      <publish_sensor_pose>true</publish_sensor_pose>
+      <publish_collision_pose>false</publish_collision_pose>
+      <publish_visual_pose>false</publish_visual_pose>
+      <!--<publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>-->
+      <use_pose_vector_msg>true</use_pose_vector_msg>
+      <static_publisher>true</static_publisher>
+      <static_update_frequency>1</static_update_frequency>
+    </plugin>
+    <plugin filename="libignition-gazebo-multicopter-motor-model-system.so"
+      name="ignition::gazebo::systems::MulticopterMotorModel">
+      <robotNamespace>model/<%= $model_name%></robotNamespace>
+      <jointName>rotor_0_joint</jointName>
+      <linkName>rotor_0</linkName>
+      <turningDirection>ccw</turningDirection>
+      <timeConstantUp>0.0125</timeConstantUp>
+      <timeConstantDown>0.025</timeConstantDown>
+      <maxRotVelocity>800.0</maxRotVelocity>
+      <motorConstant>8.54858e-06</motorConstant>
+      <momentConstant>0.016</momentConstant>
+      <commandSubTopic>command/motor_speed</commandSubTopic>
+      <motorNumber>0</motorNumber>
+      <rotorDragCoefficient>8.06428e-05</rotorDragCoefficient>
+      <rollingMomentCoefficient>1e-06</rollingMomentCoefficient>
+      <motorSpeedPubTopic>motor_speed/0</motorSpeedPubTopic>
+      <rotorVelocitySlowdownSim>10</rotorVelocitySlowdownSim>
+      <motorType>velocity</motorType>
+    </plugin>
+    <plugin filename="libignition-gazebo-multicopter-motor-model-system.so"
+      name="ignition::gazebo::systems::MulticopterMotorModel">
+      <robotNamespace>model/<%= $model_name%></robotNamespace>
+      <jointName>rotor_1_joint</jointName>
+      <linkName>rotor_1</linkName>
+      <turningDirection>ccw</turningDirection>
+      <timeConstantUp>0.0125</timeConstantUp>
+      <timeConstantDown>0.025</timeConstantDown>
+      <maxRotVelocity>800.0</maxRotVelocity>
+      <motorConstant>8.54858e-06</motorConstant>
+      <momentConstant>0.016</momentConstant>
+      <commandSubTopic>command/motor_speed</commandSubTopic>
+      <motorNumber>1</motorNumber>
+      <rotorDragCoefficient>8.06428e-05</rotorDragCoefficient>
+      <rollingMomentCoefficient>1e-06</rollingMomentCoefficient>
+      <motorSpeedPubTopic>motor_speed/1</motorSpeedPubTopic>
+      <rotorVelocitySlowdownSim>10</rotorVelocitySlowdownSim>
+      <motorType>velocity</motorType>
+    </plugin>
+    <plugin filename="libignition-gazebo-multicopter-motor-model-system.so"
+      name="ignition::gazebo::systems::MulticopterMotorModel">
+      <robotNamespace>model/<%= $model_name%></robotNamespace>
+      <jointName>rotor_2_joint</jointName>
+      <linkName>rotor_2</linkName>
+      <turningDirection>cw</turningDirection>
+      <timeConstantUp>0.0125</timeConstantUp>
+      <timeConstantDown>0.025</timeConstantDown>
+      <maxRotVelocity>800.0</maxRotVelocity>
+      <motorConstant>8.54858e-06</motorConstant>
+      <momentConstant>0.016</momentConstant>
+      <commandSubTopic>command/motor_speed</commandSubTopic>
+      <motorNumber>2</motorNumber>
+      <rotorDragCoefficient>8.06428e-05</rotorDragCoefficient>
+      <rollingMomentCoefficient>1e-06</rollingMomentCoefficient>
+      <motorSpeedPubTopic>motor_speed/2</motorSpeedPubTopic>
+      <rotorVelocitySlowdownSim>10</rotorVelocitySlowdownSim>
+      <motorType>velocity</motorType>
+    </plugin>
+    <plugin filename="libignition-gazebo-multicopter-motor-model-system.so"
+      name="ignition::gazebo::systems::MulticopterMotorModel">
+      <robotNamespace>model/<%= $model_name%></robotNamespace>
+      <jointName>rotor_3_joint</jointName>
+      <linkName>rotor_3</linkName>
+      <turningDirection>cw</turningDirection>
+      <timeConstantUp>0.0125</timeConstantUp>
+      <timeConstantDown>0.025</timeConstantDown>
+      <maxRotVelocity>800.0</maxRotVelocity>
+      <motorConstant>8.54858e-06</motorConstant>
+      <momentConstant>0.016</momentConstant>
+      <commandSubTopic>command/motor_speed</commandSubTopic>
+      <motorNumber>3</motorNumber>
+      <rotorDragCoefficient>8.06428e-05</rotorDragCoefficient>
+      <rollingMomentCoefficient>1e-06</rollingMomentCoefficient>
+      <motorSpeedPubTopic>motor_speed/3</motorSpeedPubTopic>
+      <rotorVelocitySlowdownSim>10</rotorVelocitySlowdownSim>
+      <motorType>velocity</motorType>
+    </plugin>
+    <!--Multicopter velocity controller-->
+    <plugin
+      filename="libignition-gazebo-multicopter-control-system.so"
+      name="ignition::gazebo::systems::MulticopterVelocityControl">
+      <robotNamespace>model/<%= $model_name%></robotNamespace>
+      <commandSubTopic>cmd_vel</commandSubTopic>
+      <motorControlPubTopic>command/motor_speed</motorControlPubTopic>
+      <enableSubTopic>velocity_controller/enable</enableSubTopic>
+      <comLinkName>base_link</comLinkName>
+      <velocityGain>2.7 2.7 2.7</velocityGain>
+      <attitudeGain>2 3 0.15</attitudeGain>
+      <angularRateGain>0.4 0.52 0.18</angularRateGain>
+      <maximumLinearAcceleration>1 1 2</maximumLinearAcceleration>
+      <maximumLinearVelocity>5 5 5</maximumLinearVelocity>
+      <maximumAngularVelocity>3 3 3</maximumAngularVelocity>
+      <linearVelocityNoiseMean>0 0 0.05</linearVelocityNoiseMean>
+      <!-- linearVelocityNoiseStdDev based on error values reported in the paper Shen et. al., -->
+      <!-- Vision-Based State Estimation and Trajectory Control Towards High-Speed Flight with a Quadrotor -->
+      <!-- http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.490.7958&rep=rep1&type=pdf -->
+      <linearVelocityNoiseStdDev>0.1105 0.1261 0.00947</linearVelocityNoiseStdDev>
+      <angularVelocityNoiseMean>0 0 0</angularVelocityNoiseMean>
+      <!-- angularVelocityNoiseStdDev values based on ADIS16448's Rate Noise Density with a sample  -->
+      <!-- time of 0.004 ms. -->
+      <angularVelocityNoiseStdDev>0.004 0.004 0.004</angularVelocityNoiseStdDev>
+      <rotorConfiguration>
+        <rotor>
+          <jointName>rotor_0_joint</jointName>
+          <forceConstant>8.54858e-06</forceConstant>
+          <momentConstant>0.016</momentConstant>
+          <direction>1</direction>
+        </rotor>
+        <rotor>
+          <jointName>rotor_1_joint</jointName>
+          <forceConstant>8.54858e-06</forceConstant>
+          <momentConstant>0.016</momentConstant>
+          <direction>1</direction>
+        </rotor>
+        <rotor>
+          <jointName>rotor_2_joint</jointName>
+          <forceConstant>8.54858e-06</forceConstant>
+          <momentConstant>0.016</momentConstant>
+          <direction>-1</direction>
+        </rotor>
+        <rotor>
+          <jointName>rotor_3_joint</jointName>
+          <forceConstant>8.54858e-06</forceConstant>
+          <momentConstant>0.016</momentConstant>
+          <direction>-1</direction>
+        </rotor>
+      </rotorConfiguration>
+    </plugin>
+    <!-- Battery plugin -->
+    <!-- Since we are interested in using time as the limiting factor -->
+    <plugin filename="libignition-gazebo-linearbatteryplugin-system.so"
+      name="ignition::gazebo::systems::LinearBatteryPlugin">
+      <battery_name>linear_battery</battery_name>
+      <voltage>12.694</voltage>
+      <open_circuit_voltage_constant_coef>12.694</open_circuit_voltage_constant_coef>
+      <open_circuit_voltage_linear_coef>0</open_circuit_voltage_linear_coef>
+      <initial_charge><%= capacity%></initial_charge>
+      <capacity><%= capacity%></capacity>
+      <resistance>0.061523</resistance>
+      <smooth_current_tau>1.9499</smooth_current_tau>
+      <power_load>6.6</power_load>
+      <start_on_motion>true</start_on_motion>
+      <fix_issue_225>true</fix_issue_225>
+    </plugin>
+ </model>
 </sdf>

--- a/mbzirc_ign/models/mbzirc_quadrotor/model.sdf.erb
+++ b/mbzirc_ign/models/mbzirc_quadrotor/model.sdf.erb
@@ -117,7 +117,7 @@ end
       <publish_sensor_pose>true</publish_sensor_pose>
       <publish_collision_pose>false</publish_collision_pose>
       <publish_visual_pose>false</publish_visual_pose>
-      <!--<publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>-->
+      <publish_nested_model_pose>true</publish_nested_model_pose>
       <use_pose_vector_msg>true</use_pose_vector_msg>
       <static_publisher>true</static_publisher>
       <static_update_frequency>1</static_update_frequency>

--- a/mbzirc_ign/models/mbzirc_quadrotor/model.sdf.erb
+++ b/mbzirc_ign/models/mbzirc_quadrotor/model.sdf.erb
@@ -17,14 +17,26 @@ $slot3_rpy = '0 0 0'
 if defined?(slot0) 
   $slot0_payload = slot0
 end
+if defined?(slot0_pos) 
+  $slot0_rpy = slot0_pos
+end
 if defined?(slot1)
   $slot1_payload = slot1
+end
+if defined?(slot1_pos) 
+  $slot1_rpy = slot1_pos
 end
 if defined?(slot2)
   $slot2_payload = slot2
 end
+if defined?(slot2_pos) 
+  $slot2_rpy = slot2_pos
+end
 if defined?(slot3)
   $slot3_payload = slot3
+end
+if defined?(slot3_pos) 
+  $slot3_rpy = slot3_pos
 end
 %>
 <?xml version="1.0"?>

--- a/mbzirc_ign/models/mbzirc_quadrotor_base/model.sdf
+++ b/mbzirc_ign/models/mbzirc_quadrotor_base/model.sdf
@@ -1,457 +1,448 @@
 <?xml version="1.0"?>
-<sdf version="1.9">
-    <model name="mbzirc_quadrotor_base">
-        <pose>0 0 0.053302 0 0 0</pose>
-        <link name="base_link">
-            <pose>0 0 0 0 -0 0</pose>
-            <inertial>
-                <pose>0 0 0 0 -0 0</pose>
-                <mass>1.5</mass>
-                <inertia>
-                    <ixx>0.025</ixx>
-                    <ixy>0</ixy>
-                    <ixz>0</ixz>
-                    <iyy>0.009</iyy>
-                    <iyz>0</iyz>
-                    <izz>0.033</izz>
-                </inertia>
-            </inertial>
-            <collision name="base_link_inertia_collision">
-                <pose>0 0 0 0 -0 0</pose>
-                <geometry>
-                    <box>
-                        <size>0.47 0.47 0.11</size>
-                    </box>
-                </geometry>
-            </collision>
-            <visual name="base_link_inertia_visual">
-                <pose>0 0 0 0 -0 0</pose>
-                <geometry>
-                    <mesh>
-                        <scale>1 1 1</scale>
-                        <uri>meshes/quadrotor.dae</uri>
-                    </mesh>
-                </geometry>
-            </visual>
-            <visual name="marker_visual_1">
-                <pose>-0.07 0 0.065 0 -0 0</pose>
-                <geometry>
-                    <mesh>
-                        <uri>meshes/led.dae</uri>
-                    </mesh>
-                </geometry>
-            </visual>
-            <visual name="marker_visual_2">
-                <pose>-0.08 0.037 0.04 -1.0472 -0 0.2</pose>
-                <geometry>
-                    <mesh>
-                        <uri>meshes/led.dae</uri>
-                    </mesh>
-                </geometry>
-            </visual>
-            <visual name="marker_visual_3">
-                <pose>-0.08 -0.035 0.04 1.0472 -0 -0.1</pose>
-                <geometry>
-                    <mesh>
-                        <uri>meshes/led.dae</uri>
-                    </mesh>
-                </geometry>
-            </visual>
-            <sensor name="imu_sensor" type="imu">
-                <always_on>1</always_on>
-                <update_rate>250</update_rate>
-                <imu>
-                    <angular_velocity>
-                        <x>
-                            <noise type="gaussian">
-                                <mean>0</mean>
-                                <stddev>0.009</stddev>
-                                <bias_mean>0.00075</bias_mean>
-                                <bias_stddev>0.005</bias_stddev>
-                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
-                                <precision>0.00025</precision>
-                            </noise>
-                        </x>
-                        <y>
-                            <noise type="gaussian">
-                                <mean>0</mean>
-                                <stddev>0.009</stddev>
-                                <bias_mean>0.00075</bias_mean>
-                                <bias_stddev>0.005</bias_stddev>
-                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
-                                <precision>0.00025</precision>
-                            </noise>
-                        </y>
-                        <z>
-                            <noise type="gaussian">
-                                <mean>0</mean>
-                                <stddev>0.009</stddev>
-                                <bias_mean>0.00075</bias_mean>
-                                <bias_stddev>0.005</bias_stddev>
-                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
-                                <precision>0.00025</precision>
-                            </noise>
-                        </z>
-                    </angular_velocity>
-                    <linear_acceleration>
-                        <x>
-                            <noise type="gaussian">
-                                <mean>0</mean>
-                                <stddev>0.021</stddev>
-                                <bias_mean>0.05</bias_mean>
-                                <bias_stddev>0.0075</bias_stddev>
-                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
-                                <precision>0.005</precision>
-                            </noise>
-                        </x>
-                        <y>
-                            <noise type="gaussian">
-                                <mean>0</mean>
-                                <stddev>0.021</stddev>
-                                <bias_mean>0.05</bias_mean>
-                                <bias_stddev>0.0075</bias_stddev>
-                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
-                                <precision>0.005</precision>
-                            </noise>
-                        </y>
-                        <z>
-                            <noise type="gaussian">
-                                <mean>0</mean>
-                                <stddev>0.021</stddev>
-                                <bias_mean>0.05</bias_mean>
-                                <bias_stddev>0.0075</bias_stddev>
-                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
-                                <precision>0.005</precision>
-                            </noise>
-                        </z>
-                    </linear_acceleration>
-                </imu>
-            </sensor>
-            <sensor name="air_pressure" type="air_pressure">
-                <always_on>1</always_on>
-                <update_rate>20</update_rate>
-                <air_pressure>
-                    <reference_altitude>0</reference_altitude>
-                    <noise type="gaussian">
-                        <mean>0.00000008</mean>
-                    </noise>
-                </air_pressure>
-            </sensor>
-            <sensor name="magnetometer" type="magnetometer">
-                <always_on>1</always_on>
-                <update_rate>20</update_rate>
-                <magnetometer>
-                    <x>
-                        <noise type="gaussian">
-                            <mean>0.000000080</mean>
-                            <bias_mean>0.000000400</bias_mean>
-                        </noise>
-                    </x>
-                    <y>
-                        <noise type="gaussian">
-                            <mean>0.000000080</mean>
-                            <bias_mean>0.000000400</bias_mean>
-                        </noise>
-                    </y>
-                    <z>
-                        <noise type="gaussian">
-                            <mean>0.000000080</mean>
-                            <bias_mean>0.000000400</bias_mean>
-                        </noise>
-                    </z>
-                </magnetometer>
-            </sensor>
-        </link>
-
-        <!-- Front payload slot -->
-        <frame name="slot_0">
-          <pose>0.1 0 0 0 0 0</pose>
-        </frame>
-
-        <!-- Rear payload slot -->
-        <frame name="slot_1">
-          <pose>-0.1 0 0 0 0 -3.14159</pose>
-        </frame>
-
-        <!-- Top payload slot -->
-        <frame name="slot_2">
-          <pose>0.0 0 0.05 0 1.57 0</pose>
-        </frame>
-
-        <!-- Bottom payload slot -->
-        <frame name="slot_3">
-          <pose>0.0 0 -0.05 0 -1.57 0</pose>
-        </frame>
-
-        <link name="rotor_0">
-            <pose>0.13 -0.22 0.023 0 -0 0</pose>
-            <inertial>
-                <pose>0 0 0 0 -0 0</pose>
-                <mass>0.005</mass>
-                <inertia>
-                    <ixx>9.75e-07</ixx>
-                    <ixy>0</ixy>
-                    <ixz>0</ixz>
-                    <iyy>4.17041e-05</iyy>
-                    <iyz>0</iyz>
-                    <izz>4.26041e-05</izz>
-                </inertia>
-            </inertial>
-            <collision name="rotor_0_collision">
-                <pose>0 0 0 0 -0 0</pose>
-                <geometry>
-                    <cylinder>
-                        <length>0.005</length>
-                        <radius>0.1</radius>
-                    </cylinder>
-                </geometry>
-                <surface>
-                    <contact>
-                        <ode/>
-                    </contact>
-                    <friction>
-                        <ode/>
-                    </friction>
-                </surface>
-            </collision>
-            <visual name="rotor_0_visual">
-                <pose>0 0 0 0 -0 0</pose>
-                <geometry>
-                    <mesh>
-                        <scale>0.1 0.1 0.1</scale>
-                        <uri>meshes/propeller_ccw.dae</uri>
-                    </mesh>
-                </geometry>
-                <material>
-                    <diffuse>0 0 1 1</diffuse>
-                    <script>
-                        <name>Gazebo/Blue</name>
-                        <uri>file://media/materials/scripts/gazebo.material</uri>
-                    </script>
-                </material>
-                <cast_shadows>0</cast_shadows>
-            </visual>
-            <gravity>1</gravity>
-            <velocity_decay/>
-        </link>
-        <joint name="rotor_0_joint" type="revolute">
-            <child>rotor_0</child>
-            <parent>base_link</parent>
-            <axis>
-                <xyz>0 0 1</xyz>
-                <limit>
-                    <lower>-1e+16</lower>
-                    <upper>1e+16</upper>
-                </limit>
-                <dynamics>
-                    <spring_reference>0</spring_reference>
-                    <spring_stiffness>0</spring_stiffness>
-                </dynamics>
-            </axis>
-        </joint>
-        <link name="rotor_1">
-            <pose>-0.13 0.2 0.023 0 -0 0</pose>
-            <inertial>
-                <pose>0 0 0 0 -0 0</pose>
-                <mass>0.005</mass>
-                <inertia>
-                    <ixx>9.75e-07</ixx>
-                    <ixy>0</ixy>
-                    <ixz>0</ixz>
-                    <iyy>4.17041e-05</iyy>
-                    <iyz>0</iyz>
-                    <izz>4.26041e-05</izz>
-                </inertia>
-            </inertial>
-            <collision name="rotor_1_collision">
-                <pose>0 0 0 0 -0 0</pose>
-                <geometry>
-                    <cylinder>
-                        <length>0.005</length>
-                        <radius>0.1</radius>
-                    </cylinder>
-                </geometry>
-                <surface>
-                    <contact>
-                        <ode/>
-                    </contact>
-                    <friction>
-                        <ode/>
-                    </friction>
-                </surface>
-            </collision>
-            <visual name="rotor_1_visual">
-                <pose>0 0 0 0 -0 0</pose>
-                <geometry>
-                    <mesh>
-                        <scale>0.1 0.1 0.1</scale>
-                        <uri>meshes/propeller_ccw.dae</uri>
-                    </mesh>
-                </geometry>
-                <material>
-                    <diffuse>1 0 0 1</diffuse>
-                    <script>
-                        <name>Gazebo/Red</name>
-                        <uri>file://media/materials/scripts/gazebo.material</uri>
-                    </script>
-                </material>
-                <cast_shadows>0</cast_shadows>
-            </visual>
-            <gravity>1</gravity>
-            <velocity_decay/>
-        </link>
-        <joint name="rotor_1_joint" type="revolute">
-            <child>rotor_1</child>
-            <parent>base_link</parent>
-            <axis>
-                <xyz>0 0 1</xyz>
-                <limit>
-                    <lower>-1e+16</lower>
-                    <upper>1e+16</upper>
-                </limit>
-                <dynamics>
-                    <spring_reference>0</spring_reference>
-                    <spring_stiffness>0</spring_stiffness>
-                </dynamics>
-            </axis>
-        </joint>
-        <link name="rotor_2">
-            <pose>0.13 0.22 0.023 0 -0 0</pose>
-            <inertial>
-                <pose>0 0 0 0 -0 0</pose>
-                <mass>0.005</mass>
-                <inertia>
-                    <ixx>9.75e-07</ixx>
-                    <ixy>0</ixy>
-                    <ixz>0</ixz>
-                    <iyy>4.17041e-05</iyy>
-                    <iyz>0</iyz>
-                    <izz>4.26041e-05</izz>
-                </inertia>
-            </inertial>
-            <collision name="rotor_2_collision">
-                <pose>0 0 0 0 -0 0</pose>
-                <geometry>
-                    <cylinder>
-                        <length>0.005</length>
-                        <radius>0.1</radius>
-                    </cylinder>
-                </geometry>
-                <surface>
-                    <contact>
-                        <ode/>
-                    </contact>
-                    <friction>
-                        <ode/>
-                    </friction>
-                </surface>
-            </collision>
-            <visual name="rotor_2_visual">
-                <pose>0 0 0 0 -0 0</pose>
-                <geometry>
-                    <mesh>
-                        <scale>0.1 0.1 0.1</scale>
-                        <uri>meshes/propeller_cw.dae</uri>
-                    </mesh>
-                </geometry>
-                <material>
-                    <diffuse>0 0 1 1</diffuse>
-                    <script>
-                        <name>Gazebo/Blue</name>
-                        <uri>file://media/materials/scripts/gazebo.material</uri>
-                    </script>
-                </material>
-                <cast_shadows>0</cast_shadows>
-            </visual>
-            <gravity>1</gravity>
-            <velocity_decay/>
-        </link>
-        <joint name="rotor_2_joint" type="revolute">
-            <child>rotor_2</child>
-            <parent>base_link</parent>
-            <axis>
-                <xyz>0 0 1</xyz>
-                <limit>
-                    <lower>-1e+16</lower>
-                    <upper>1e+16</upper>
-                </limit>
-                <dynamics>
-                    <spring_reference>0</spring_reference>
-                    <spring_stiffness>0</spring_stiffness>
-                </dynamics>
-            </axis>
-        </joint>
-        <link name="rotor_3">
-            <pose>-0.13 -0.2 0.023 0 -0 0</pose>
-            <inertial>
-                <pose>0 0 0 0 -0 0</pose>
-                <mass>0.005</mass>
-                <inertia>
-                    <ixx>9.75e-07</ixx>
-                    <ixy>0</ixy>
-                    <ixz>0</ixz>
-                    <iyy>4.17041e-05</iyy>
-                    <iyz>0</iyz>
-                    <izz>4.26041e-05</izz>
-                </inertia>
-            </inertial>
-            <collision name="rotor_3_collision">
-                <pose>0 0 0 0 -0 0</pose>
-                <geometry>
-                    <cylinder>
-                        <length>0.005</length>
-                        <radius>0.1</radius>
-                    </cylinder>
-                </geometry>
-                <surface>
-                    <contact>
-                        <ode/>
-                    </contact>
-                    <friction>
-                        <ode/>
-                    </friction>
-                </surface>
-            </collision>
-            <visual name="rotor_3_visual">
-                <pose>0 0 0 0 -0 0</pose>
-                <geometry>
-                    <mesh>
-                        <scale>0.1 0.1 0.1</scale>
-                        <uri>meshes/propeller_cw.dae</uri>
-                    </mesh>
-                </geometry>
-                <material>
-                    <diffuse>1 0 0 1</diffuse>
-                    <script>
-                        <name>Gazebo/Red</name>
-                        <uri>file://media/materials/scripts/gazebo.material</uri>
-                    </script>
-                </material>
-                <cast_shadows>0</cast_shadows>
-            </visual>
-            <gravity>1</gravity>
-            <velocity_decay/>
-        </link>
-        <joint name="rotor_3_joint" type="revolute">
-            <child>rotor_3</child>
-            <parent>base_link</parent>
-            <axis>
-                <xyz>0 0 1</xyz>
-                <limit>
-                    <lower>-1e+16</lower>
-                    <upper>1e+16</upper>
-                </limit>
-                <dynamics>
-                    <spring_reference>0</spring_reference>
-                    <spring_stiffness>0</spring_stiffness>
-                </dynamics>
-            </axis>
-        </joint>
-    </model>
+<sdf version='1.9'>
+  <model name='mbzirc_quadrotor_base'>
+    <pose>0 0 0.053302 0 0 0</pose>
+    <link name='base_link'>
+      <pose>0 0 0 0 -0 0</pose>
+      <inertial>
+        <pose>0 0 0 0 -0 0</pose>
+        <mass>1.5</mass>
+        <inertia>
+          <ixx>0.025</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>0.009</iyy>
+          <iyz>0</iyz>
+          <izz>0.033</izz>
+        </inertia>
+      </inertial>
+      <collision name='base_link_inertia_collision'>
+        <pose>0 0 0 0 -0 0</pose>
+        <geometry>
+          <box>
+            <size>0.47 0.47 0.11</size>
+          </box>
+        </geometry>
+      </collision>
+      <visual name='base_link_inertia_visual'>
+        <pose>0 0 0 0 -0 0</pose>
+        <geometry>
+          <mesh>
+            <scale>1 1 1</scale>
+            <uri>meshes/quadrotor.dae</uri>
+          </mesh>
+        </geometry>
+      </visual>
+      <visual name='marker_visual_1'>
+        <pose>-0.07 0 0.065 0 -0 0</pose>
+        <geometry>
+          <mesh>
+            <uri>meshes/led.dae</uri>
+          </mesh>
+        </geometry>
+      </visual>
+      <visual name='marker_visual_2'>
+        <pose>-0.08 0.037 0.04 -1.0472 -0 0.2</pose>
+        <geometry>
+          <mesh>
+            <uri>meshes/led.dae</uri>
+          </mesh>
+        </geometry>
+      </visual>
+      <visual name='marker_visual_3'>
+        <pose>-0.08 -0.035 0.04 1.0472 -0 -0.1</pose>
+        <geometry>
+          <mesh>
+            <uri>meshes/led.dae</uri>
+          </mesh>
+        </geometry>
+      </visual>
+      <sensor name='imu_sensor' type='imu'>
+        <always_on>1</always_on>
+        <update_rate>250</update_rate>
+        <imu>
+          <angular_velocity>
+            <x>
+              <noise type='gaussian'>
+                <mean>0</mean>
+                <stddev>0.009</stddev>
+                <bias_mean>0.00075</bias_mean>
+                <bias_stddev>0.005</bias_stddev>
+                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                <precision>0.00025</precision>
+              </noise>
+            </x>
+            <y>
+              <noise type='gaussian'>
+                <mean>0</mean>
+                <stddev>0.009</stddev>
+                <bias_mean>0.00075</bias_mean>
+                <bias_stddev>0.005</bias_stddev>
+                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                <precision>0.00025</precision>
+              </noise>
+            </y>
+            <z>
+              <noise type='gaussian'>
+                <mean>0</mean>
+                <stddev>0.009</stddev>
+                <bias_mean>0.00075</bias_mean>
+                <bias_stddev>0.005</bias_stddev>
+                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                <precision>0.00025</precision>
+              </noise>
+            </z>
+          </angular_velocity>
+          <linear_acceleration>
+            <x>
+              <noise type='gaussian'>
+                <mean>0</mean>
+                <stddev>0.021</stddev>
+                <bias_mean>0.05</bias_mean>
+                <bias_stddev>0.0075</bias_stddev>
+                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                <precision>0.005</precision>
+              </noise>
+            </x>
+            <y>
+              <noise type='gaussian'>
+                <mean>0</mean>
+                <stddev>0.021</stddev>
+                <bias_mean>0.05</bias_mean>
+                <bias_stddev>0.0075</bias_stddev>
+                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                <precision>0.005</precision>
+              </noise>
+            </y>
+            <z>
+              <noise type='gaussian'>
+                <mean>0</mean>
+                <stddev>0.021</stddev>
+                <bias_mean>0.05</bias_mean>
+                <bias_stddev>0.0075</bias_stddev>
+                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                <precision>0.005</precision>
+              </noise>
+            </z>
+          </linear_acceleration>
+        </imu>
+      </sensor>
+      <sensor name='air_pressure' type='air_pressure'>
+        <always_on>1</always_on>
+        <update_rate>20</update_rate>
+        <air_pressure>
+          <reference_altitude>0</reference_altitude>
+          <noise type='gaussian'>
+            <mean>0.00000008</mean>
+          </noise>
+        </air_pressure>
+      </sensor>
+      <sensor name='magnetometer' type='magnetometer'>
+        <always_on>1</always_on>
+        <update_rate>20</update_rate>
+        <magnetometer>
+          <x>
+            <noise type='gaussian'>
+              <mean>0.000000080</mean>
+              <bias_mean>0.000000400</bias_mean>
+            </noise>
+          </x>
+          <y>
+            <noise type='gaussian'>
+              <mean>0.000000080</mean>
+              <bias_mean>0.000000400</bias_mean>
+            </noise>
+          </y>
+          <z>
+            <noise type='gaussian'>
+              <mean>0.000000080</mean>
+              <bias_mean>0.000000400</bias_mean>
+            </noise>
+          </z>
+        </magnetometer>
+      </sensor>
+    </link>
+    <frame name='slot_0'>
+      <pose>0.1 0 0 0 0 0</pose>
+    </frame>
+    <frame name='slot_1'>
+      <pose>0.11 0 0 0 0 -3.14159</pose>
+    </frame>
+    <frame name='slot_2'>
+      <pose>0.0 0 0.05 0 1.57 0</pose>
+    </frame>
+    <frame name='slot_3'>
+      <pose>0.0 0 -0.05 0 -1.57 0</pose>
+    </frame>
+    <link name='rotor_0'>
+      <pose>0.13 -0.22 0.023 0 -0 0</pose>
+      <inertial>
+        <pose>0 0 0 0 -0 0</pose>
+        <mass>0.005</mass>
+        <inertia>
+          <ixx>9.75e-07</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>4.17041e-05</iyy>
+          <iyz>0</iyz>
+          <izz>4.26041e-05</izz>
+        </inertia>
+      </inertial>
+      <collision name='rotor_0_collision'>
+        <pose>0 0 0 0 -0 0</pose>
+        <geometry>
+          <cylinder>
+            <length>0.005</length>
+            <radius>0.1</radius>
+          </cylinder>
+        </geometry>
+        <surface>
+          <contact>
+            <ode/>
+          </contact>
+          <friction>
+            <ode/>
+          </friction>
+        </surface>
+      </collision>
+      <visual name='rotor_0_visual'>
+        <pose>0 0 0 0 -0 0</pose>
+        <geometry>
+          <mesh>
+            <scale>0.1 0.1 0.1</scale>
+            <uri>meshes/propeller_ccw.dae</uri>
+          </mesh>
+        </geometry>
+        <material>
+          <diffuse>0 0 1 1</diffuse>
+          <script>
+            <name>Gazebo/Blue</name>
+            <uri>file://media/materials/scripts/gazebo.material</uri>
+          </script>
+        </material>
+        <cast_shadows>0</cast_shadows>
+      </visual>
+      <gravity>1</gravity>
+      <velocity_decay/>
+    </link>
+    <joint name='rotor_0_joint' type='revolute'>
+      <child>rotor_0</child>
+      <parent>base_link</parent>
+      <axis>
+        <xyz expressed_in='__model__'>0 0 1</xyz>
+        <limit>
+          <lower>-1e+16</lower>
+          <upper>1e+16</upper>
+        </limit>
+        <dynamics>
+          <spring_reference>0</spring_reference>
+          <spring_stiffness>0</spring_stiffness>
+        </dynamics>
+      </axis>
+    </joint>
+    <link name='rotor_1'>
+      <pose>-0.13 0.2 0.023 0 -0 0</pose>
+      <inertial>
+        <pose>0 0 0 0 -0 0</pose>
+        <mass>0.005</mass>
+        <inertia>
+          <ixx>9.75e-07</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>4.17041e-05</iyy>
+          <iyz>0</iyz>
+          <izz>4.26041e-05</izz>
+        </inertia>
+      </inertial>
+      <collision name='rotor_1_collision'>
+        <pose>0 0 0 0 -0 0</pose>
+        <geometry>
+          <cylinder>
+            <length>0.005</length>
+            <radius>0.1</radius>
+          </cylinder>
+        </geometry>
+        <surface>
+          <contact>
+            <ode/>
+          </contact>
+          <friction>
+            <ode/>
+          </friction>
+        </surface>
+      </collision>
+      <visual name='rotor_1_visual'>
+        <pose>0 0 0 0 -0 0</pose>
+        <geometry>
+          <mesh>
+            <scale>0.1 0.1 0.1</scale>
+            <uri>meshes/propeller_ccw.dae</uri>
+          </mesh>
+        </geometry>
+        <material>
+          <diffuse>1 0 0 1</diffuse>
+          <script>
+            <name>Gazebo/Red</name>
+            <uri>file://media/materials/scripts/gazebo.material</uri>
+          </script>
+        </material>
+        <cast_shadows>0</cast_shadows>
+      </visual>
+      <gravity>1</gravity>
+      <velocity_decay/>
+    </link>
+    <joint name='rotor_1_joint' type='revolute'>
+      <child>rotor_1</child>
+      <parent>base_link</parent>
+      <axis>
+        <xyz expressed_in='__model__'>0 0 1</xyz>
+        <limit>
+          <lower>-1e+16</lower>
+          <upper>1e+16</upper>
+        </limit>
+        <dynamics>
+          <spring_reference>0</spring_reference>
+          <spring_stiffness>0</spring_stiffness>
+        </dynamics>
+      </axis>
+    </joint>
+    <link name='rotor_2'>
+      <pose>0.13 0.22 0.023 0 -0 0</pose>
+      <inertial>
+        <pose>0 0 0 0 -0 0</pose>
+        <mass>0.005</mass>
+        <inertia>
+          <ixx>9.75e-07</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>4.17041e-05</iyy>
+          <iyz>0</iyz>
+          <izz>4.26041e-05</izz>
+        </inertia>
+      </inertial>
+      <collision name='rotor_2_collision'>
+        <pose>0 0 0 0 -0 0</pose>
+        <geometry>
+          <cylinder>
+            <length>0.005</length>
+            <radius>0.1</radius>
+          </cylinder>
+        </geometry>
+        <surface>
+          <contact>
+            <ode/>
+          </contact>
+          <friction>
+            <ode/>
+          </friction>
+        </surface>
+      </collision>
+      <visual name='rotor_2_visual'>
+        <pose>0 0 0 0 -0 0</pose>
+        <geometry>
+          <mesh>
+            <scale>0.1 0.1 0.1</scale>
+            <uri>meshes/propeller_cw.dae</uri>
+          </mesh>
+        </geometry>
+        <material>
+          <diffuse>0 0 1 1</diffuse>
+          <script>
+            <name>Gazebo/Blue</name>
+            <uri>file://media/materials/scripts/gazebo.material</uri>
+          </script>
+        </material>
+        <cast_shadows>0</cast_shadows>
+      </visual>
+      <gravity>1</gravity>
+      <velocity_decay/>
+    </link>
+    <joint name='rotor_2_joint' type='revolute'>
+      <child>rotor_2</child>
+      <parent>base_link</parent>
+      <axis>
+        <xyz expressed_in='__model__'>0 0 1</xyz>
+        <limit>
+          <lower>-1e+16</lower>
+          <upper>1e+16</upper>
+        </limit>
+        <dynamics>
+          <spring_reference>0</spring_reference>
+          <spring_stiffness>0</spring_stiffness>
+        </dynamics>
+      </axis>
+    </joint>
+    <link name='rotor_3'>
+      <pose>-0.13 -0.2 0.023 0 -0 0</pose>
+      <inertial>
+        <pose>0 0 0 0 -0 0</pose>
+        <mass>0.005</mass>
+        <inertia>
+          <ixx>9.75e-07</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>4.17041e-05</iyy>
+          <iyz>0</iyz>
+          <izz>4.26041e-05</izz>
+        </inertia>
+      </inertial>
+      <collision name='rotor_3_collision'>
+        <pose>0 0 0 0 -0 0</pose>
+        <geometry>
+          <cylinder>
+            <length>0.005</length>
+            <radius>0.1</radius>
+          </cylinder>
+        </geometry>
+        <surface>
+          <contact>
+            <ode/>
+          </contact>
+          <friction>
+            <ode/>
+          </friction>
+        </surface>
+      </collision>
+      <visual name='rotor_3_visual'>
+        <pose>0 0 0 0 -0 0</pose>
+        <geometry>
+          <mesh>
+            <scale>0.1 0.1 0.1</scale>
+            <uri>meshes/propeller_cw.dae</uri>
+          </mesh>
+        </geometry>
+        <material>
+          <diffuse>1 0 0 1</diffuse>
+          <script>
+            <name>Gazebo/Red</name>
+            <uri>file://media/materials/scripts/gazebo.material</uri>
+          </script>
+        </material>
+        <cast_shadows>0</cast_shadows>
+      </visual>
+      <gravity>1</gravity>
+      <velocity_decay/>
+    </link>
+    <joint name='rotor_3_joint' type='revolute'>
+      <child>rotor_3</child>
+      <parent>base_link</parent>
+      <axis>
+        <xyz expressed_in='__model__'>0 0 1</xyz>
+        <limit>
+          <lower>-1e+16</lower>
+          <upper>1e+16</upper>
+        </limit>
+        <dynamics>
+          <spring_reference>0</spring_reference>
+          <spring_stiffness>0</spring_stiffness>
+        </dynamics>
+      </axis>
+    </joint>
+  </model>
 </sdf>

--- a/mbzirc_ign/models/sensors/mbzirc_3d_lidar/model.config
+++ b/mbzirc_ign/models/sensors/mbzirc_3d_lidar/model.config
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+
+<model>
+  <name>MBZIRC RGB Camera</name>
+  <version>1.0</version>
+  <sdf version="1.6">model.sdf</sdf>
+
+  <author>
+    <name>Michael Carroll</name>
+    <email>michael@openrobotics.org</email>
+  </author>
+
+  <description>
+    RGB Camera with 1280x960 resolution at 30 Hz.
+  </description>
+</model>

--- a/mbzirc_ign/models/sensors/mbzirc_3d_lidar/model.sdf
+++ b/mbzirc_ign/models/sensors/mbzirc_3d_lidar/model.sdf
@@ -1,0 +1,37 @@
+<?xml version="1.0"?>
+<sdf version="1.9">
+    <model name="mbzirc_3d_lidar">
+        <link name="sensor_link">
+            <sensor name="lidar" type="gpu_ray">
+                <update_rate>10</update_rate>
+                <lidar>
+                    <scan>
+                        <horizontal>
+                            <samples>1800</samples>
+                            <resolution>1</resolution>
+                            <min_angle>-3.14159</min_angle>
+                            <max_angle>3.14159</max_angle>
+                        </horizontal>
+                        <vertical>
+                            <samples>16</samples>
+                            <resolution>1</resolution>
+                            <min_angle>-0.261799</min_angle>
+                            <max_angle>0.261799</max_angle>
+                        </vertical>
+                    </scan>
+                    <range>
+                        <min>0.05</min>
+                        <max>100</max>
+                        <resolution>0.01</resolution>
+                    </range>
+                    <noise>
+                        <type>gaussian</type>
+                        <mean>0</mean>
+                        <stddev>0.01</stddev>
+                    </noise>
+                </lidar>
+            </sensor>
+        </link>
+        <frame name="mount_point"/>
+    </model>
+</sdf>

--- a/mbzirc_ign/models/sensors/mbzirc_3d_lidar/model.sdf
+++ b/mbzirc_ign/models/sensors/mbzirc_3d_lidar/model.sdf
@@ -2,6 +2,17 @@
 <sdf version="1.9">
     <model name="mbzirc_3d_lidar">
         <link name="sensor_link">
+            <inertial>
+                <mass>0.005</mass>
+                <inertia>
+                    <ixx>8.33e-06</ixx>
+                    <ixy>0</ixy>
+                    <ixz>0</ixz>
+                    <iyy>8.33e-06</iyy>
+                    <iyz>0</iyz>
+                    <izz>8.33e-06</izz>
+                </inertia>
+            </inertial>
             <sensor name="lidar" type="gpu_ray">
                 <update_rate>10</update_rate>
                 <lidar>

--- a/mbzirc_ign/models/sensors/mbzirc_hd_camera/model.config
+++ b/mbzirc_ign/models/sensors/mbzirc_hd_camera/model.config
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+
+<model>
+  <name>MBZIRC HD Camera</name>
+  <version>1.0</version>
+  <sdf version="1.6">model.sdf</sdf>
+
+  <author>
+    <name>Michael Carroll</name>
+    <email>michael@openrobotics.org</email>
+  </author>
+
+  <description>
+    RGB Camera with 1280x960 resolution
+  </description>
+</model>

--- a/mbzirc_ign/models/sensors/mbzirc_hd_camera/model.sdf
+++ b/mbzirc_ign/models/sensors/mbzirc_hd_camera/model.sdf
@@ -2,6 +2,17 @@
 <sdf version="1.9">
     <model name="mbzirc_hd_camera">
         <link name="sensor_link">
+            <inertial>
+                <mass>0.005</mass>
+                <inertia>
+                    <ixx>1e-03</ixx>
+                    <ixy>0</ixy>
+                    <ixz>0</ixz>
+                    <iyy>1e-03</iyy>
+                    <iyz>0</iyz>
+                    <izz>1e-03</izz>
+                </inertia>
+            </inertial>
             <sensor name="camera" type="camera">
                 <always_on>1</always_on>
                 <update_rate>20</update_rate>

--- a/mbzirc_ign/models/sensors/mbzirc_hd_camera/model.sdf
+++ b/mbzirc_ign/models/sensors/mbzirc_hd_camera/model.sdf
@@ -1,0 +1,49 @@
+<?xml version="1.0"?>
+<sdf version="1.9">
+    <model name="mbzirc_hd_camera">
+        <link name="sensor_link">
+            <sensor name="camera" type="camera">
+                <always_on>1</always_on>
+                <update_rate>20</update_rate>
+                <camera name="camera">
+                    <horizontal_fov>1.0472</horizontal_fov>
+                    <lens>
+                        <intrinsics>
+                            <!-- fx = fy = width / ( 2 * tan (hfov / 2 ) ) -->
+                            <fx>1108.5</fx>
+                            <fy>1108.5</fy>
+                            <!-- cx = ( width + 1 ) / 2 -->
+                            <cx>640.5</cx>
+                            <!-- cy = ( height + 1 ) / 2 -->
+                            <cy>480.5</cy>
+                            <s>0</s>
+                        </intrinsics>
+                    </lens>
+                    <distortion>
+                        <k1>0.0</k1>
+                        <k2>0.0</k2>
+                        <k3>0.0</k3>
+                        <p1>0.0</p1>
+                        <p2>0.0</p2>
+                        <center>0.5 0.5</center>
+                    </distortion>
+                    <image>
+                        <width>1280</width>
+                        <height>960</height>
+                        <format>R8G8B8</format>
+                    </image>
+                    <clip>
+                        <near>0.01</near>
+                        <far>300</far>
+                    </clip>
+                    <noise>
+                        <type>gaussian</type>
+                        <mean>0</mean>
+                        <stddev>0.007</stddev>
+                    </noise>
+                </camera>
+            </sensor>
+        </link>
+        <frame name="mount_point"/>
+    </model>
+</sdf>

--- a/mbzirc_ign/models/sensors/mbzirc_planar_lidar/model.config
+++ b/mbzirc_ign/models/sensors/mbzirc_planar_lidar/model.config
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+
+<model>
+  <name>MBZIRC Planar Lidar</name>
+  <version>1.0</version>
+  <sdf version="1.6">model.sdf</sdf>
+
+  <author>
+    <name>Michael Carroll</name>
+    <email>michael@openrobotics.org</email>
+  </author>
+
+  <description>
+    Planar scanning two-dimension lidar with 30 meter range
+  </description>
+</model>

--- a/mbzirc_ign/models/sensors/mbzirc_planar_lidar/model.sdf
+++ b/mbzirc_ign/models/sensors/mbzirc_planar_lidar/model.sdf
@@ -2,6 +2,17 @@
 <sdf version="1.9">
     <model name="mbzirc_planar_lidar">
         <link name="sensor_link">
+            <inertial>
+                <mass>0.005</mass>
+                <inertia>
+                    <ixx>1e-03</ixx>
+                    <ixy>0</ixy>
+                    <ixz>0</ixz>
+                    <iyy>1e-03</iyy>
+                    <iyz>0</iyz>
+                    <izz>1e-03</izz>
+                </inertia>
+            </inertial>
             <sensor name="lidar" type="gpu_ray">
                 <update_rate>30</update_rate>
                 <lidar>

--- a/mbzirc_ign/models/sensors/mbzirc_planar_lidar/model.sdf
+++ b/mbzirc_ign/models/sensors/mbzirc_planar_lidar/model.sdf
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<sdf version="1.9">
+    <model name="mbzirc_planar_lidar">
+        <link name="sensor_link">
+            <sensor name="lidar" type="gpu_ray">
+                <update_rate>30</update_rate>
+                <lidar>
+                    <scan>
+                        <horizontal>
+                            <samples>720</samples>
+                            <resolution>1</resolution>
+                            <min_angle>-2.3562</min_angle>
+                            <max_angle>2.3562</max_angle>
+                        </horizontal>
+                    </scan>
+                    <range>
+                        <min>0.04</min>
+                        <max>30</max>
+                        <resolution>0.01</resolution>
+                    </range>
+                    <noise>
+                        <type>gaussian</type>
+                        <mean>0</mean>
+                        <stddev>0.01</stddev>
+                    </noise>
+                </lidar>
+            </sensor>
+        </link>
+        <frame name="mount_point"/>
+    </model>
+</sdf>

--- a/mbzirc_ign/models/sensors/mbzirc_rgbd_camera/model.config
+++ b/mbzirc_ign/models/sensors/mbzirc_rgbd_camera/model.config
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+
+<model>
+  <name>MBZIRC RGB-D Camera</name>
+  <version>1.0</version>
+  <sdf version="1.6">model.sdf</sdf>
+
+  <author>
+    <name>Michael Carroll</name>
+    <email>michael@openrobotics.org</email>
+  </author>
+
+  <description>
+    RGBD Camera with 640x480 resolution and 10 meters of depth sensing
+  </description>
+</model>

--- a/mbzirc_ign/models/sensors/mbzirc_rgbd_camera/model.sdf
+++ b/mbzirc_ign/models/sensors/mbzirc_rgbd_camera/model.sdf
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+<sdf version="1.9">
+    <model name="mbzirc_rgbd_camera">
+        <link name="sensor_link">
+            <sensor name="camera" type="rgbd_camera">
+                <always_on>1</always_on>
+                <update_rate>20</update_rate>
+                <camera name="camera">
+                    <horizontal_fov>1.0472</horizontal_fov>
+                    <lens>
+                        <intrinsics>
+                            <!-- fx = fy = width / ( 2 * tan (hfov / 2 ) ) -->
+                            <fx>554.3</fx>
+                            <fy>554.3</fy>
+                            <!-- cx = ( width + 1 ) / 2 -->
+                            <cx>320.5</cx>
+                            <!-- cy = ( height + 1 ) / 2 -->
+                            <cy>240.5</cy>
+                            <s>0</s>
+                        </intrinsics>
+                    </lens>
+                    <distortion>
+                        <k1>0.0</k1>
+                        <k2>0.0</k2>
+                        <k3>0.0</k3>
+                        <p1>0.0</p1>
+                        <p2>0.0</p2>
+                        <center>0.5 0.5</center>
+                    </distortion>
+                    <image>
+                        <width>640</width>
+                        <height>480</height>
+                        <format>R8G8B8</format>
+                    </image>
+                    <clip>
+                        <near>0.01</near>
+                        <far>300</far>
+                    </clip>
+                    <depth_camera>
+                        <clip>
+                            <near>0.1</near>
+                            <far>10</far>
+                        </clip>
+                    </depth_camera>
+                    <noise>
+                        <type>gaussian</type>
+                        <mean>0</mean>
+                        <stddev>0.007</stddev>
+                    </noise>
+              </camera>
+            </sensor>
+        </link>
+        <frame name="mount_point"/>
+    </model>
+</sdf>

--- a/mbzirc_ign/models/sensors/mbzirc_rgbd_camera/model.sdf
+++ b/mbzirc_ign/models/sensors/mbzirc_rgbd_camera/model.sdf
@@ -2,6 +2,17 @@
 <sdf version="1.9">
     <model name="mbzirc_rgbd_camera">
         <link name="sensor_link">
+            <inertial>
+                <mass>0.005</mass>
+                <inertia>
+                    <ixx>8.33e-06</ixx>
+                    <ixy>0</ixy>
+                    <ixz>0</ixz>
+                    <iyy>8.33e-06</iyy>
+                    <iyz>0</iyz>
+                    <izz>8.33e-06</izz>
+                </inertia>
+            </inertial>
             <sensor name="camera" type="rgbd_camera">
                 <always_on>1</always_on>
                 <update_rate>20</update_rate>

--- a/mbzirc_ign/models/sensors/mbzirc_vga_camera/model.config
+++ b/mbzirc_ign/models/sensors/mbzirc_vga_camera/model.config
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+
+<model>
+  <name>MBZIRC VGA Camera</name>
+  <version>1.0</version>
+  <sdf version="1.6">model.sdf</sdf>
+
+  <author>
+    <name>Michael Carroll</name>
+    <email>michael@openrobotics.org</email>
+  </author>
+
+  <description>
+    RGB Camera with 640x480 resolution.
+  </description>
+</model>

--- a/mbzirc_ign/models/sensors/mbzirc_vga_camera/model.sdf
+++ b/mbzirc_ign/models/sensors/mbzirc_vga_camera/model.sdf
@@ -1,0 +1,49 @@
+<?xml version="1.0"?>
+<sdf version="1.9">
+    <model name="mbzirc_vga_camera">
+        <link name="sensor_link">
+            <sensor name="camera" type="camera">
+                <always_on>1</always_on>
+                <update_rate>60</update_rate>
+                <camera name="camera">
+                    <horizontal_fov>1.0472</horizontal_fov>
+                    <lens>
+                        <intrinsics>
+                            <!-- fx = fy = width / ( 2 * tan (hfov / 2 ) ) -->
+                            <fx>554.3</fx>
+                            <fy>554.3</fy>
+                            <!-- cx = ( width + 1 ) / 2 -->
+                            <cx>320.5</cx>
+                            <!-- cy = ( height + 1 ) / 2 -->
+                            <cy>240.5</cy>
+                            <s>0</s>
+                        </intrinsics>
+                    </lens>
+                    <distortion>
+                        <k1>0.0</k1>
+                        <k2>0.0</k2>
+                        <k3>0.0</k3>
+                        <p1>0.0</p1>
+                        <p2>0.0</p2>
+                        <center>0.5 0.5</center>
+                    </distortion>
+                    <image>
+                        <width>640</width>
+                        <height>480</height>
+                        <format>R8G8B8</format>
+                    </image>
+                    <clip>
+                        <near>0.01</near>
+                        <far>300</far>
+                    </clip>
+                    <noise>
+                        <type>gaussian</type>
+                        <mean>0</mean>
+                        <stddev>0.007</stddev>
+                    </noise>
+                </camera>
+            </sensor>
+        </link>
+        <frame name="mount_point"/>
+    </model>
+</sdf>

--- a/mbzirc_ign/models/sensors/mbzirc_vga_camera/model.sdf
+++ b/mbzirc_ign/models/sensors/mbzirc_vga_camera/model.sdf
@@ -2,6 +2,17 @@
 <sdf version="1.9">
     <model name="mbzirc_vga_camera">
         <link name="sensor_link">
+            <inertial>
+                <mass>0.005</mass>
+                <inertia>
+                    <ixx>8.33e-06</ixx>
+                    <ixy>0</ixy>
+                    <ixz>0</ixz>
+                    <iyy>8.33e-06</iyy>
+                    <iyz>0</iyz>
+                    <izz>8.33e-06</izz>
+                </inertia>
+            </inertial>
             <sensor name="camera" type="camera">
                 <always_on>1</always_on>
                 <update_rate>60</update_rate>

--- a/mbzirc_ros/src/pose_tf_broadcaster.cc
+++ b/mbzirc_ros/src/pose_tf_broadcaster.cc
@@ -31,6 +31,8 @@ class FramePublisher : public rclcpp::Node
 {
   public: FramePublisher() : Node("frame_publisher")
   {
+    this->declare_parameter<std::string>("world_frame", "");
+
     this->tfBroadcaster =
       std::make_unique<tf2_ros::TransformBroadcaster>(*this);
     this->tfBroadcasterStatic =
@@ -48,14 +50,48 @@ class FramePublisher : public rclcpp::Node
 
   private: void HandlePose(const std::shared_ptr<tf2_msgs::msg::TFMessage> _msg)
   {
-    // Send the transformation
-    this->tfBroadcaster->sendTransform(_msg->transforms);
+    std::string world_frame;
+    this->get_parameter("world_frame", world_frame); 
+    if (!world_frame.empty())
+    {
+      std::vector<geometry_msgs::msg::TransformStamped> filtered;
+      for (auto transform: _msg->transforms)
+      {
+        if (transform.header.frame_id != world_frame)
+        {
+          filtered.push_back(transform);
+        }
+      }
+      this->tfBroadcaster->sendTransform(filtered);
+    }
+    else
+    {
+      // Send the transformation
+      this->tfBroadcaster->sendTransform(_msg->transforms);
+    }
   }
 
   private: void HandlePoseStatic(const std::shared_ptr<tf2_msgs::msg::TFMessage> _msg)
   {
-    // Send the transformation
-    this->tfBroadcasterStatic->sendTransform(_msg->transforms);
+    std::string world_frame;
+    this->get_parameter("world_frame", world_frame); 
+    if (!world_frame.empty())
+    {
+      std::vector<geometry_msgs::msg::TransformStamped> filtered;
+      for (auto transform: _msg->transforms)
+      {
+        if (transform.header.frame_id != world_frame)
+        {
+          filtered.push_back(transform);
+        }
+      }
+      this->tfBroadcasterStatic->sendTransform(filtered);
+    }
+    else
+    {
+      // Send the transformation
+      this->tfBroadcasterStatic->sendTransform(_msg->transforms);
+    }
   }
 
   private: rclcpp::Subscription<tf2_msgs::msg::TFMessage>::SharedPtr subscription;


### PR DESCRIPTION
Builds on #16 to provide user-configurable payload.

To launch a UAV with various payload configurations:

```
ros2 launch mbzirc_ign spawn.launch.py name:=quadrotor_1 world:=simple_demo model:=mbzirc_quadrotor type:=uav x:=3 y:=6 z:=0.12 R:=0 P:=0 Y:=0 slot0:=mbzirc_rgb_camera slot1:=mbzirc_planar_lidar
```

Where both UAVs now have 4 slots [`slot0`, `slot1`, `slot2`, `slot3`] and sensors are defined in `mbzirc_ign/models/sensors` to include [`mbzirc_3d_lidar`,  `mbzirc_hd_camera`,  `mbzirc_planar_lidar`,  `mbzirc_rgb_camera`, `mbzirc_rgbd_camera`,  `mbzirc_vga_camera`]



Signed-off-by: Michael Carroll <michael@openrobotics.org>