### PR TITLE
Add more sensor slots

### DIFF
--- a/mbzirc_ign/launch/spawn.launch.py
+++ b/mbzirc_ign/launch/spawn.launch.py
@@ -47,11 +47,19 @@ def spawn_uav(context, model_path, world_name, model_name, link_name):
   slot1_payload = LaunchConfiguration('slot1').perform(context)
   slot2_payload = LaunchConfiguration('slot2').perform(context)
   slot3_payload = LaunchConfiguration('slot3').perform(context)
+  slot4_payload = LaunchConfiguration('slot4').perform(context)
+  slot5_payload = LaunchConfiguration('slot5').perform(context)
+  slot6_payload = LaunchConfiguration('slot6').perform(context)
+  slot7_payload = LaunchConfiguration('slot7').perform(context)
 
   slot0_rpy = LaunchConfiguration('slot0_rpy').perform(context)
   slot1_rpy = LaunchConfiguration('slot1_rpy').perform(context)
   slot2_rpy = LaunchConfiguration('slot2_rpy').perform(context)
   slot3_rpy = LaunchConfiguration('slot3_rpy').perform(context)
+  slot4_rpy = LaunchConfiguration('slot4_rpy').perform(context)
+  slot5_rpy = LaunchConfiguration('slot5_rpy').perform(context)
+  slot6_rpy = LaunchConfiguration('slot6_rpy').perform(context)
+  slot7_rpy = LaunchConfiguration('slot7_rpy').perform(context)
 
   # calculate battery capacity from time
   # capacity (Ah) = flight time (in hours) * load (watts) / voltage
@@ -75,6 +83,14 @@ def spawn_uav(context, model_path, world_name, model_name, link_name):
   if slot2_rpy: command.append(f'slot2_pos={slot2_rpy}')
   if slot3_payload: command.append(f'slot3={slot3_payload}')
   if slot3_rpy: command.append(f'slot3_pos={slot3_rpy}')
+  if slot4_payload: command.append(f'slot4={slot4_payload}')
+  if slot4_rpy: command.append(f'slot4_pos={slot4_rpy}')
+  if slot5_payload: command.append(f'slot5={slot5_payload}')
+  if slot5_rpy: command.append(f'slot5_pos={slot5_rpy}')
+  if slot6_payload: command.append(f'slot6={slot6_payload}')
+  if slot6_rpy: command.append(f'slot6_pos={slot6_rpy}')
+  if slot7_payload: command.append(f'slot7={slot7_payload}')
+  if slot7_rpy: command.append(f'slot7_pos={slot7_rpy}')
 
   command.append(model_file)
 
@@ -130,7 +146,8 @@ def spawn_uav(context, model_path, world_name, model_name, link_name):
   )
 
   payloads = []
-  check = [slot0_payload, slot1_payload, slot2_payload, slot3_payload]
+  check = [slot0_payload, slot1_payload, slot2_payload, slot3_payload,
+           slot4_payload, slot5_payload, slot6_payload, slot7_payload]
 
   for idx in range(0, 4):
       payload = check[idx]
@@ -427,6 +444,38 @@ def generate_launch_description():
             description='Payload mounted to slot 3'),
         DeclareLaunchArgument(
             'slot3_rpy',
+            default_value='0 0 0',
+            description='Roll, Pitch, Yaw in degrees of payload mount'),
+        DeclareLaunchArgument(
+            'slot4',
+            default_value='',
+            description='Payload mounted to slot 4'),
+        DeclareLaunchArgument(
+            'slot4_rpy',
+            default_value='0 0 0',
+            description='Roll, Pitch, Yaw in degrees of payload mount'),
+        DeclareLaunchArgument(
+            'slot5',
+            default_value='',
+            description='Payload mounted to slot 5'),
+        DeclareLaunchArgument(
+            'slot5_rpy',
+            default_value='0 0 0',
+            description='Roll, Pitch, Yaw in degrees of payload mount'),
+        DeclareLaunchArgument(
+            'slot6',
+            default_value='',
+            description='Payload mounted to slot 6'),
+        DeclareLaunchArgument(
+            'slot6_rpy',
+            default_value='0 0 0',
+            description='Roll, Pitch, Yaw in degrees of payload mount'),
+        DeclareLaunchArgument(
+            'slot7',
+            default_value='',
+            description='Payload mounted to slot 7'),
+        DeclareLaunchArgument(
+            'slot7_rpy',
             default_value='0 0 0',
             description='Roll, Pitch, Yaw in degrees of payload mount'),
         # launch setup

--- a/mbzirc_ign/models/mbzirc_hexrotor/model.sdf.erb
+++ b/mbzirc_ign/models/mbzirc_hexrotor/model.sdf.erb
@@ -9,38 +9,75 @@ $slot0_payload = nil
 $slot0_rpy = '0 0 0'
 
 $slot1_payload = nil
-$slot1_rpy = '0 0 0' 
+$slot1_rpy = '0 0 0'
 
 $slot2_payload = nil
-$slot2_rpy = '0 0 0' 
+$slot2_rpy = '0 0 0'
 
 $slot3_payload = nil
 $slot3_rpy = '0 0 0'
 
-if defined?(slot0) 
+$slot4_payload = nil
+$slot4_rpy = '0 0 0'
+
+$slot5_payload = nil
+$slot5_rpy = '0 0 0'
+
+$slot6_payload = nil
+$slot6_rpy = '0 0 0'
+
+$slot7_payload = nil
+$slot7_rpy = '0 0 0'
+
+if defined?(slot0)
   $slot0_payload = slot0
 end
-if defined?(slot0_pos) 
+if defined?(slot0_pos)
   $slot0_rpy = slot0_pos
 end
 if defined?(slot1)
   $slot1_payload = slot1
 end
-if defined?(slot1_pos) 
+if defined?(slot1_pos)
   $slot1_rpy = slot1_pos
 end
 if defined?(slot2)
   $slot2_payload = slot2
 end
-if defined?(slot2_pos) 
+if defined?(slot2_pos)
   $slot2_rpy = slot2_pos
 end
 if defined?(slot3)
   $slot3_payload = slot3
 end
-if defined?(slot3_pos) 
+if defined?(slot3_pos)
   $slot3_rpy = slot3_pos
 end
+if defined?(slot4)
+  $slot4_payload = slot4
+end
+if defined?(slot4_pos)
+  $slot4_rpy = slot4_pos
+end
+if defined?(slot5)
+  $slot5_payload = slot5
+end
+if defined?(slot5_pos)
+  $slot5_rpy = slot5_pos
+end
+if defined?(slot6)
+  $slot6_payload = slot6
+end
+if defined?(slot6_pos)
+  $slot6_rpy = slot6_pos
+end
+if defined?(slot7)
+  $slot7_payload = slot7
+end
+if defined?(slot7_pos)
+  $slot7_rpy = slot7_pos
+end
+
 %>
 <?xml version="1.0"?>
 <sdf version='1.9'>
@@ -114,6 +151,71 @@ end
       <child>sensor_3::mount_point</child>
     </joint>
     <% end %>
+    <% if $slot4_payload != nil%>
+    <!-- Payload slot4 -->
+    <include>
+      <name>sensor_4</name>
+      <uri>model://sensors/<%= $slot4_payload%></uri>
+      <placement_frame>mount_point</placement_frame>
+      <pose relative_to="slot_4" degrees="true">
+        0 0 0 <%= $slot4_rpy%>
+      </pose>
+    </include>
+
+    <joint name="slot_4_joint" type="fixed">
+      <parent>slot_4</parent>
+      <child>sensor_4::mount_point</child>
+    </joint>
+    <% end %>
+    <% if $slot5_payload != nil%>
+    <!-- Payload slot5 -->
+    <include>
+      <name>sensor_5</name>
+      <uri>model://sensors/<%= $slot5_payload%></uri>
+      <placement_frame>mount_point</placement_frame>
+      <pose relative_to="slot_5" degrees="true">
+        0 0 0 <%= $slot5_rpy%>
+      </pose>
+    </include>
+
+    <joint name="slot_5_joint" type="fixed">
+      <parent>slot_5</parent>
+      <child>sensor_5::mount_point</child>
+    </joint>
+    <% end %>
+    <% if $slot6_payload != nil%>
+    <!-- Payload slot6 -->
+    <include>
+      <name>sensor_6</name>
+      <uri>model://sensors/<%= $slot6_payload%></uri>
+      <placement_frame>mount_point</placement_frame>
+      <pose relative_to="slot_6" degrees="true">
+        0 0 0 <%= $slot6_rpy%>
+      </pose>
+    </include>
+
+    <joint name="slot_6_joint" type="fixed">
+      <parent>slot_6</parent>
+      <child>sensor_6::mount_point</child>
+    </joint>
+    <% end %>
+    <% if $slot7_payload != nil%>
+    <!-- Payload slot7 -->
+    <include>
+      <name>sensor_7</name>
+      <uri>model://sensors/<%= $slot7_payload%></uri>
+      <placement_frame>mount_point</placement_frame>
+      <pose relative_to="slot_7" degrees="true">
+        0 0 0 <%= $slot7_rpy%>
+      </pose>
+    </include>
+
+    <joint name="slot_7_joint" type="fixed">
+      <parent>slot_7</parent>
+      <child>sensor_7::mount_point</child>
+    </joint>
+    <% end %>
+
     <!-- Publish robot state information -->
     <plugin filename="libignition-gazebo-pose-publisher-system.so"
       name="ignition::gazebo::systems::PosePublisher">

--- a/mbzirc_ign/models/mbzirc_hexrotor_base/model.sdf
+++ b/mbzirc_ign/models/mbzirc_hexrotor_base/model.sdf
@@ -174,22 +174,42 @@
 
         <!-- Front payload slot -->
         <frame name="slot_0">
-          <pose>0.1 0 -0.03 0 0 0</pose>
+          <pose>0.15 0 -0.02 0 0 0</pose>
         </frame>
 
         <!-- Rear payload slot -->
         <frame name="slot_1">
-          <pose>-0.1 0 -0.03 0 0 -3.14159</pose>
+          <pose>-0.14 0 -0.02 0 0 -3.14159</pose>
         </frame>
 
         <!-- Top payload slot -->
         <frame name="slot_2">
-          <pose>0.0 0 0.08 0 1.57 0</pose>
+          <pose>0.0 0 0.09 0 -1.57 0</pose>
         </frame>
 
         <!-- Bottom payload slot -->
         <frame name="slot_3">
-          <pose>0.0 0 -0.02 0 -1.57 0</pose>
+          <pose>0.0 0 -0.07 0 1.57 0</pose>
+        </frame>
+
+        <!-- Left payload slot -->
+        <frame name="slot_4">
+          <pose>0.05 0.10 -0.02 0 0 1.57</pose>
+        </frame>
+
+        <!-- Right payload slot -->
+        <frame name="slot_5">
+          <pose>0.05 -0.10 -0.02 0 0 -1.57</pose>
+        </frame>
+
+        <!-- Bottom left payload slot -->
+        <frame name="slot_6">
+          <pose>0.0 0.05 -0.07 0 1.57 0</pose>
+        </frame>
+
+        <!-- Bottom right payload slot -->
+        <frame name="slot_7">
+          <pose>0.0 -0.05 -0.07 0 1.57 0</pose>
         </frame>
 
         <link name="rotor_0">
@@ -588,5 +608,103 @@
                 </dynamics>
             </axis>
         </joint>
+
+        <!-- uncomment to debug sensor slot frames -->
+        <!--
+        <link name="debug_link">
+          <visual name="sensor_slot0">
+            <pose relative_to="slot_0">0 0 0 0 0 0</pose>
+            <geometry>
+              <box>
+                <size>0.01 0.01 0.01</size>
+              </box>
+            </geometry>
+            <material>
+              <diffuse>0.0 1 0 1</diffuse>
+            </material>
+          </visual>
+          <visual name="sensor_slot1">
+            <pose relative_to="slot_1">0 0 0 0 0 0</pose>
+            <geometry>
+              <box>
+                <size>0.01 0.01 0.01</size>
+              </box>
+            </geometry>
+            <material>
+              <diffuse>0.0 1 0 1</diffuse>
+            </material>
+          </visual>
+          <visual name="sensor_slot2">
+            <pose relative_to="slot_2">0 0 0 0 0 0</pose>
+            <geometry>
+              <box>
+                <size>0.01 0.01 0.01</size>
+              </box>
+            </geometry>
+            <material>
+              <diffuse>0.0 1 0 1</diffuse>
+            </material>
+          </visual>
+          <visual name="sensor_slot3">
+            <pose relative_to="slot_3">0 0 0 0 0 0</pose>
+            <geometry>
+              <box>
+                <size>0.01 0.01 0.01</size>
+              </box>
+            </geometry>
+            <material>
+              <diffuse>0.0 1 0 1</diffuse>
+            </material>
+          </visual>
+          <visual name="sensor_slot4">
+            <pose relative_to="slot_4">0 0 0 0 0 0</pose>
+            <geometry>
+              <box>
+                <size>0.01 0.01 0.01</size>
+              </box>
+            </geometry>
+            <material>
+              <diffuse>0.0 1 0 1</diffuse>
+            </material>
+          </visual>
+          <visual name="sensor_slot5">
+            <pose relative_to="slot_5">0 0 0 0 0 0</pose>
+            <geometry>
+              <box>
+                <size>0.01 0.01 0.01</size>
+              </box>
+            </geometry>
+            <material>
+              <diffuse>0.0 1 0 1</diffuse>
+            </material>
+          </visual>
+          <visual name="sensor_slot6">
+            <pose relative_to="slot_6">0 0 0 0 0 0</pose>
+            <geometry>
+              <box>
+                <size>0.01 0.01 0.01</size>
+              </box>
+            </geometry>
+            <material>
+              <diffuse>0.0 1 0 1</diffuse>
+            </material>
+          </visual>
+          <visual name="sensor_slot7">
+            <pose relative_to="slot_7">0 0 0 0 0 0</pose>
+            <geometry>
+              <box>
+                <size>0.01 0.01 0.01</size>
+              </box>
+            </geometry>
+            <material>
+              <diffuse>0.0 1 0 1</diffuse>
+            </material>
+          </visual>
+        </link>
+        <joint name="debug_link_joint" type="fixed">
+            <child>debug_link</child>
+            <parent>base_link</parent>
+        </joint>
+        -->
     </model>
 </sdf>

--- a/mbzirc_ign/models/mbzirc_quadrotor/model.sdf.erb
+++ b/mbzirc_ign/models/mbzirc_quadrotor/model.sdf.erb
@@ -8,37 +8,70 @@ end
 $slot0_payload = nil
 $slot0_rpy = '0 0 0'
 $slot1_payload = nil
-$slot1_rpy = '0 0 0' 
+$slot1_rpy = '0 0 0'
 $slot2_payload = nil
-$slot2_rpy = '0 0 0' 
+$slot2_rpy = '0 0 0'
 $slot3_payload = nil
 $slot3_rpy = '0 0 0'
+$slot4_payload = nil
+$slot4_rpy = '0 0 0'
+$slot5_payload = nil
+$slot5_rpy = '0 0 0'
+$slot6_payload = nil
+$slot6_rpy = '0 0 0'
+$slot7_payload = nil
+$slot7_rpy = '0 0 0'
 
-if defined?(slot0) 
+if defined?(slot0)
   $slot0_payload = slot0
 end
-if defined?(slot0_pos) 
+if defined?(slot0_pos)
   $slot0_rpy = slot0_pos
 end
 if defined?(slot1)
   $slot1_payload = slot1
 end
-if defined?(slot1_pos) 
+if defined?(slot1_pos)
   $slot1_rpy = slot1_pos
 end
 if defined?(slot2)
   $slot2_payload = slot2
 end
-if defined?(slot2_pos) 
+if defined?(slot2_pos)
   $slot2_rpy = slot2_pos
 end
 if defined?(slot3)
   $slot3_payload = slot3
 end
-if defined?(slot3_pos) 
+if defined?(slot3_pos)
   $slot3_rpy = slot3_pos
 end
+if defined?(slot4)
+  $slot4_payload = slot4
+end
+if defined?(slot4_pos)
+  $slot4_rpy = slot4_pos
+end
+if defined?(slot5)
+  $slot5_payload = slot5
+end
+if defined?(slot5_pos)
+  $slot5_rpy = slot5_pos
+end
+if defined?(slot6)
+  $slot6_payload = slot6
+end
+if defined?(slot6_pos)
+  $slot6_rpy = slot6_pos
+end
+if defined?(slot7)
+  $slot7_payload = slot7
+end
+if defined?(slot7_pos)
+  $slot7_rpy = slot7_pos
+end
 %>
+
 <?xml version="1.0"?>
 <sdf version='1.9'>
   <model name="<%= $model_name%>">
@@ -109,6 +142,70 @@ end
     <joint name="slot_3_joint" type="fixed">
       <parent>slot_3</parent>
       <child>sensor_3::mount_point</child>
+    </joint>
+    <% end %>
+    <% if $slot4_payload != nil%>
+    <!-- Payload slot4 -->
+    <include>
+      <name>sensor_4</name>
+      <uri>model://sensors/<%= $slot4_payload%></uri>
+      <placement_frame>mount_point</placement_frame>
+      <pose relative_to="slot_4" degrees="true">
+        0 0 0 <%= $slot4_rpy%>
+      </pose>
+    </include>
+
+    <joint name="slot_4_joint" type="fixed">
+      <parent>slot_4</parent>
+      <child>sensor_4::mount_point</child>
+    </joint>
+    <% end %>
+    <% if $slot5_payload != nil%>
+    <!-- Payload slot5 -->
+    <include>
+      <name>sensor_5</name>
+      <uri>model://sensors/<%= $slot5_payload%></uri>
+      <placement_frame>mount_point</placement_frame>
+      <pose relative_to="slot_5" degrees="true">
+        0 0 0 <%= $slot5_rpy%>
+      </pose>
+    </include>
+
+    <joint name="slot_5_joint" type="fixed">
+      <parent>slot_5</parent>
+      <child>sensor_5::mount_point</child>
+    </joint>
+    <% end %>
+    <% if $slot6_payload != nil%>
+    <!-- Payload slot6 -->
+    <include>
+      <name>sensor_6</name>
+      <uri>model://sensors/<%= $slot6_payload%></uri>
+      <placement_frame>mount_point</placement_frame>
+      <pose relative_to="slot_6" degrees="true">
+        0 0 0 <%= $slot6_rpy%>
+      </pose>
+    </include>
+
+    <joint name="slot_6_joint" type="fixed">
+      <parent>slot_6</parent>
+      <child>sensor_6::mount_point</child>
+    </joint>
+    <% end %>
+    <% if $slot7_payload != nil%>
+    <!-- Payload slot7 -->
+    <include>
+      <name>sensor_7</name>
+      <uri>model://sensors/<%= $slot7_payload%></uri>
+      <placement_frame>mount_point</placement_frame>
+      <pose relative_to="slot_7" degrees="true">
+        0 0 0 <%= $slot7_rpy%>
+      </pose>
+    </include>
+
+    <joint name="slot_7_joint" type="fixed">
+      <parent>slot_7</parent>
+      <child>sensor_7::mount_point</child>
     </joint>
     <% end %>
     <plugin filename="libignition-gazebo-pose-publisher-system.so"

--- a/mbzirc_ign/models/mbzirc_quadrotor_base/model.sdf
+++ b/mbzirc_ign/models/mbzirc_quadrotor_base/model.sdf
@@ -168,18 +168,47 @@
         </magnetometer>
       </sensor>
     </link>
-    <frame name='slot_0'>
-      <pose>0.1 0 0 0 0 0</pose>
+
+    <!-- Front payload slot -->
+    <frame name="slot_0">
+      <pose>0.1 0 0.0 0 0 0</pose>
     </frame>
-    <frame name='slot_1'>
-      <pose>-0.1 0 0 0 0 -3.14159</pose>
+
+    <!-- Rear payload slot -->
+    <frame name="slot_1">
+      <pose>-0.12 0 0.0 0 0 -3.14159</pose>
     </frame>
-    <frame name='slot_2'>
-      <pose>0.0 0 0.05 0 1.57 0</pose>
+
+    <!-- Top payload slot -->
+    <frame name="slot_2">
+      <pose>0.0 0 0.06 0 -1.57 0</pose>
     </frame>
-    <frame name='slot_3'>
-      <pose>0.0 0 -0.05 0 -1.57 0</pose>
+
+    <!-- Bottom payload slot -->
+    <frame name="slot_3">
+      <pose>0.0 0 -0.05 0 1.57 0</pose>
     </frame>
+
+    <!-- Left payload slot -->
+    <frame name="slot_4">
+      <pose>0.0 0.08 0.0 0 0 1.57</pose>
+    </frame>
+
+    <!-- Right payload slot -->
+    <frame name="slot_5">
+      <pose>0.0 -0.08 0.0 0 0 -1.57</pose>
+    </frame>
+
+    <!-- Bottom left payload slot -->
+    <frame name="slot_6">
+      <pose>0.0 0.05 -0.05 0 1.57 0</pose>
+    </frame>
+
+    <!-- Bottom right payload slot -->
+    <frame name="slot_7">
+      <pose>0.0 -0.05 -0.05 0 1.57 0</pose>
+    </frame>
+
     <link name='rotor_0'>
       <pose>0.13 -0.22 0.023 0 -0 0</pose>
       <inertial>
@@ -444,5 +473,103 @@
         </dynamics>
       </axis>
     </joint>
+
+    <!-- uncomment to debug sensor slot frames -->
+    <!--
+    <link name="debug_link">
+      <visual name="sensor_slot0">
+        <pose relative_to="slot_0">0 0 0 0 0 0</pose>
+        <geometry>
+          <box>
+            <size>0.01 0.01 0.01</size>
+          </box>
+        </geometry>
+        <material>
+          <diffuse>0.0 1 0 1</diffuse>
+        </material>
+      </visual>
+      <visual name="sensor_slot1">
+        <pose relative_to="slot_1">0 0 0 0 0 0</pose>
+        <geometry>
+          <box>
+            <size>0.01 0.01 0.01</size>
+          </box>
+        </geometry>
+        <material>
+          <diffuse>0.0 1 0 1</diffuse>
+        </material>
+      </visual>
+      <visual name="sensor_slot2">
+        <pose relative_to="slot_2">0 0 0 0 0 0</pose>
+        <geometry>
+          <box>
+            <size>0.01 0.01 0.01</size>
+          </box>
+        </geometry>
+        <material>
+          <diffuse>0.0 1 0 1</diffuse>
+        </material>
+      </visual>
+      <visual name="sensor_slot3">
+        <pose relative_to="slot_3">0 0 0 0 0 0</pose>
+        <geometry>
+          <box>
+            <size>0.01 0.01 0.01</size>
+          </box>
+        </geometry>
+        <material>
+          <diffuse>0.0 1 0 1</diffuse>
+        </material>
+      </visual>
+      <visual name="sensor_slot4">
+        <pose relative_to="slot_4">0 0 0 0 0 0</pose>
+        <geometry>
+          <box>
+            <size>0.01 0.01 0.01</size>
+          </box>
+        </geometry>
+        <material>
+          <diffuse>0.0 1 0 1</diffuse>
+        </material>
+      </visual>
+      <visual name="sensor_slot5">
+        <pose relative_to="slot_5">0 0 0 0 0 0</pose>
+        <geometry>
+          <box>
+            <size>0.01 0.01 0.01</size>
+          </box>
+        </geometry>
+        <material>
+          <diffuse>0.0 1 0 1</diffuse>
+        </material>
+      </visual>
+      <visual name="sensor_slot6">
+        <pose relative_to="slot_6">0 0 0 0 0 0</pose>
+        <geometry>
+          <box>
+            <size>0.01 0.01 0.01</size>
+          </box>
+        </geometry>
+        <material>
+          <diffuse>0.0 1 0 1</diffuse>
+        </material>
+      </visual>
+      <visual name="sensor_slot7">
+        <pose relative_to="slot_7">0 0 0 0 0 0</pose>
+        <geometry>
+          <box>
+            <size>0.01 0.01 0.01</size>
+          </box>
+        </geometry>
+        <material>
+          <diffuse>0.0 1 0 1</diffuse>
+        </material>
+      </visual>
+    </link>
+    <joint name="debug_link_joint" type="fixed">
+        <child>debug_link</child>
+        <parent>base_link</parent>
+    </joint>
+    -->
   </model>
 </sdf>

--- a/mbzirc_ign/models/mbzirc_quadrotor_base/model.sdf
+++ b/mbzirc_ign/models/mbzirc_quadrotor_base/model.sdf
@@ -186,7 +186,7 @@
 
     <!-- Bottom payload slot -->
     <frame name="slot_3">
-      <pose>0.0 0 -0.05 0 1.57 0</pose>
+      <pose>0.0 0 -0.044 0 1.57 0</pose>
     </frame>
 
     <!-- Left payload slot -->
@@ -201,12 +201,12 @@
 
     <!-- Bottom left payload slot -->
     <frame name="slot_6">
-      <pose>0.0 0.05 -0.05 0 1.57 0</pose>
+      <pose>0.0 0.05 -0.044 0 1.57 0</pose>
     </frame>
 
     <!-- Bottom right payload slot -->
     <frame name="slot_7">
-      <pose>0.0 -0.05 -0.05 0 1.57 0</pose>
+      <pose>0.0 -0.05 -0.044 0 1.57 0</pose>
     </frame>
 
     <link name='rotor_0'>


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@openrobotics.org>

Adds 4 more sensor slots. Now a total of 8.

**Existing slots:**
slot 0: front
slot 1: rear
slot 2: top
slot 3 : bottom

**New slots:**
slot 4: left
slot 5: right
slot 6: bottom left
slot 7: bottom right

I also added some green box visuals for debugging the sensor positions. Uncomment them in the sdf to see their positions:

![quad_sensor_slots](https://user-images.githubusercontent.com/4000684/150042830-9b92f8cf-4066-4a97-a27d-d9612bceb699.png)
![hex_sensor_slots](https://user-images.githubusercontent.com/4000684/150042863-c61f45ef-be9d-4782-b3f2-920f7e51c641.png)

