### PR TITLE
Add basic GameLogicPlugin

### DIFF
--- a/mbzirc_ign/CMakeLists.txt
+++ b/mbzirc_ign/CMakeLists.txt
@@ -27,6 +27,7 @@ configure_file(
 #============================================================================
 # Plugins
 list(APPEND MBZIRC_IGN_PLUGINS
+  GameLogicPlugin
   SimpleHydrodynamics
   Surface
 )
@@ -61,12 +62,12 @@ if(BUILD_TESTING)
   configure_file(test/helper/TestConstants.hh.in TestConstants.hh @ONLY)
 
   foreach(TEST_TARGET
-    test_spawn_uav_battery)
+    test_spawn_uav_battery test_game_logic)
     ament_add_gtest(
       ${TEST_TARGET}
       test/${TEST_TARGET}.cc
     )
-    target_include_directories(${TEST_TARGET} 
+    target_include_directories(${TEST_TARGET}
       PRIVATE ${CMAKE_BINARY_DIR} ${CMAKE_BINARY_DIR}/proto )
     target_link_libraries(${TEST_TARGET} ignition-gazebo6::ignition-gazebo6)
     set_tests_properties(${TEST_TARGET} PROPERTIES TIMEOUT 120)

--- a/mbzirc_ign/src/GameLogicPlugin.cc
+++ b/mbzirc_ign/src/GameLogicPlugin.cc
@@ -200,12 +200,9 @@ void GameLogicPlugin::Configure(const ignition::gazebo::Entity & /*_entity*/,
   this->dataPtr->eventManager = &_eventMgr;
 
   // Check if the game logic plugin has a <logging> element.
-  // The <logging> element can contain a <filename_prefix> child element.
-  // The <filename_prefix> is used to specify the log filename prefix. For
   // example:
   // <logging>
   //   <path>/tmp</path>
-  //   <filename_prefix>mbzirc_</filename_prefix>
   // </logging>
   const sdf::ElementPtr loggingElem =
     const_cast<sdf::Element *>(_sdf.get())->GetElement("logging");
@@ -269,8 +266,6 @@ void GameLogicPlugin::Configure(const ignition::gazebo::Entity & /*_entity*/,
     ignmsg << "Setup duration set to " << this->dataPtr->setupTimeSec
            << " seconds.\n";
   }
-
-
 
   this->dataPtr->node.Advertise("/mbzirc/start",
       &GameLogicPluginPrivate::OnStartCall, this->dataPtr.get());

--- a/mbzirc_ign/src/GameLogicPlugin.cc
+++ b/mbzirc_ign/src/GameLogicPlugin.cc
@@ -1,0 +1,658 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <ignition/msgs/boolean.pb.h>
+#include <ignition/msgs/float.pb.h>
+#include <ignition/plugin/Register.hh>
+
+#include <chrono>
+#include <mutex>
+
+#include <ignition/gazebo/components/Link.hh>
+#include <ignition/gazebo/components/Model.hh>
+#include <ignition/gazebo/components/Name.hh>
+#include <ignition/gazebo/components/ParentEntity.hh>
+#include <ignition/gazebo/components/Sensor.hh>
+#include <ignition/gazebo/EntityComponentManager.hh>
+#include <ignition/gazebo/Events.hh>
+#include <ignition/gazebo/Util.hh>
+
+#include <ignition/common/Console.hh>
+#include <ignition/common/Util.hh>
+#include <ignition/transport/Node.hh>
+
+#include <sdf/sdf.hh>
+
+#include "GameLogicPlugin.hh"
+
+IGNITION_ADD_PLUGIN(
+    mbzirc::GameLogicPlugin,
+    ignition::gazebo::System,
+    mbzirc::GameLogicPlugin::ISystemConfigure,
+    mbzirc::GameLogicPlugin::ISystemPreUpdate,
+    mbzirc::GameLogicPlugin::ISystemPostUpdate)
+
+using namespace ignition;
+using namespace gazebo;
+using namespace systems;
+using namespace mbzirc;
+
+class mbzirc::GameLogicPluginPrivate
+{
+  /// \brief Write a simulation timestamp to a logfile.
+  /// \param[in] _simTime Current sim time.
+  /// \return A file stream that can be used to write additional
+  /// information to the logfile.
+  public: std::ofstream &Log(const ignition::msgs::Time &_simTime);
+
+  /// \brief Publish the score.
+  /// \param[in] _event Unused.
+  public: void PublishScore();
+
+  /// \brief Finish game and generate log files
+  /// \param[in] _simTime Simulation time.
+  public: void Finish(const ignition::msgs::Time &_simTime);
+
+  /// \brief Update the score.yml and summary.yml files. This function also
+  /// returns the time point used to calculate the elapsed real time. By
+  /// returning this time point, we can make sure that the ::Finish function
+  /// uses the same time point.
+  /// \param[in] _simTime Current sim time.
+  /// \return The time point used to calculate the elapsed real time.
+  public: std::chrono::steady_clock::time_point UpdateScoreFiles(
+              const ignition::msgs::Time &_simTime);
+
+  /// \brief Log an event to the eventStream.
+  /// \param[in] _event The event to log.
+  public: void LogEvent(const std::string &_event);
+
+  /// \brief Battery subscription callback.
+  /// \param[in] _msg Battery message.
+  /// \param[in] _info Message information.
+  public: void OnBatteryMsg(const ignition::msgs::BatteryState &_msg,
+    const transport::MessageInfo &_info);
+
+  /// \brief Ignition service callback triggered when the service is called.
+  /// \param[in] _req The message containing a flag telling if the game
+  /// is to start.
+  /// \param[out] _res The response message.
+  public: bool OnStartCall(const ignition::msgs::Boolean &_req,
+                            ignition::msgs::Boolean &_res);
+
+  /// \brief Helper function to start the competition.
+  /// \param[in] _simTime Simulation time.
+  /// \return True if the run was started.
+  public: bool Start(const ignition::msgs::Time &_simTime);
+
+  /// \brief Ignition service callback triggered when the service is called.
+  /// \param[in] _req The message containing a flag telling if the game is to
+  /// be finished.
+  /// \param[out] _res The response message.
+  public: bool OnFinishCall(const ignition::msgs::Boolean &_req,
+               ignition::msgs::Boolean &_res);
+
+  /// \brief Ignition Transport node.
+  public: transport::Node node;
+
+  /// \brief Current simulation time.
+  public: ignition::msgs::Time simTime;
+
+  /// \brief The simulation time of the start call.
+  public: ignition::msgs::Time startSimTime;
+
+  /// \brief Number of simulation seconds allowed.
+  public: std::chrono::seconds runDuration{0};
+
+  /// \brief Thread on which scores are published
+  /// \brief Whether the task has started.
+  public: bool started = false;
+
+  /// \brief Whether the task has finished.
+  public: bool finished = false;
+
+  /// \brief Start time used for scoring.
+  public: std::chrono::steady_clock::time_point startTime;
+
+  /// \brief A mutex.
+  public: std::mutex logMutex;
+
+  /// \brief Log file output stream.
+  public: std::ofstream logStream;
+
+  /// \brief Event file output stream.
+  public: std::ofstream eventStream;
+
+  /// \brief Mutex to protect the eventStream.
+  public: std::mutex eventMutex;
+
+  /// \brief Ignition transport competition clock publisher.
+  public: transport::Node::Publisher competitionClockPub;
+
+  /// \brief Logpath.
+  public: std::string logPath{"/dev/null"};
+
+  /// \brief Names of the spawned robots.
+  public: std::set<std::string> robotNames;
+
+ /// \brief Current state.
+  public: std::string state = "init";
+
+  /// \brief Time at which the last status publication took place.
+  public: std::chrono::steady_clock::time_point lastStatusPubTime;
+
+  /// \brief Time at which the summary.yaml file was last updated.
+  public: mutable std::chrono::steady_clock::time_point lastUpdateScoresTime;
+
+  /// \brief Event manager for pausing simulation
+  public: EventManager *eventManager{nullptr};
+
+  /// \brief Models with dead batteries.
+  public: std::set<std::string> deadBatteries;
+
+  /// \brief Amount of allowed setup time in seconds.
+  public: int setupTimeSec = 900;
+
+  /// \brief Mutex to protect the eventCounter.
+  public: std::mutex eventCounterMutex;
+
+  /// \brief Counter to create unique id for events
+  public: int eventCounter = 0;
+
+  /// \brief Total score.
+  public: double totalScore = 0.0;
+};
+
+//////////////////////////////////////////////////
+GameLogicPlugin::GameLogicPlugin()
+  : dataPtr(new GameLogicPluginPrivate)
+{
+}
+
+//////////////////////////////////////////////////
+GameLogicPlugin::~GameLogicPlugin()
+{
+  // set eventManager to nullptr so that Finish call does not attempt to
+  // pause sim
+  this->dataPtr->eventManager = nullptr;
+  this->dataPtr->Finish(this->dataPtr->simTime);
+}
+
+//////////////////////////////////////////////////
+void GameLogicPlugin::Configure(const ignition::gazebo::Entity & /*_entity*/,
+                           const std::shared_ptr<const sdf::Element> &_sdf,
+                           ignition::gazebo::EntityComponentManager & /*_ecm*/,
+                           ignition::gazebo::EventManager & _eventMgr)
+{
+  this->dataPtr->eventManager = &_eventMgr;
+
+  // Check if the game logic plugin has a <logging> element.
+  // The <logging> element can contain a <filename_prefix> child element.
+  // The <filename_prefix> is used to specify the log filename prefix. For
+  // example:
+  // <logging>
+  //   <path>/tmp</path>
+  //   <filename_prefix>mbzirc_</filename_prefix>
+  // </logging>
+  const sdf::ElementPtr loggingElem =
+    const_cast<sdf::Element *>(_sdf.get())->GetElement("logging");
+
+  if (loggingElem)
+  {
+    // Get the logpath from the <path> element, if it exists.
+    if (loggingElem->HasElement("path"))
+    {
+      this->dataPtr->logPath =
+        loggingElem->Get<std::string>("path", "/dev/null").first;
+    }
+    else
+    {
+      // Make sure that we can access the HOME environment variable.
+      char *homePath = getenv("HOME");
+      if (!homePath)
+      {
+        ignerr << "Unable to get HOME environment variable. Report this error "
+          << "to https://github.com/osrf/mbzirc/issues/new. "
+          << "MBZIRC logging will be disabled.\n";
+      }
+      else
+      {
+        this->dataPtr->logPath = homePath;
+      }
+    }
+  }
+
+  ignmsg << "MBZIRC log path: " << this->dataPtr->logPath << std::endl;
+  common::removeAll(this->dataPtr->logPath);
+  common::createDirectories(this->dataPtr->logPath);
+
+  // Open the log file.
+  std::string filenamePrefix = "mbzirc";
+  this->dataPtr->logStream.open(
+      (common::joinPaths(this->dataPtr->logPath, filenamePrefix + "_" +
+      ignition::common::systemTimeISO() + ".log")).c_str(), std::ios::out);
+
+  // Open the event log file.
+  this->dataPtr->eventStream.open(
+      (common::joinPaths(this->dataPtr->logPath, "events.yml")).c_str(),
+      std::ios::out);
+
+  // Get the duration seconds.
+  if (_sdf->HasElement("run_duration_seconds"))
+  {
+    this->dataPtr->runDuration = std::chrono::seconds(
+        _sdf->Get<int>("run_duration_seconds"));
+
+    ignmsg << "Run duration set to " << this->dataPtr->runDuration.count()
+           << " seconds.\n";
+  }
+
+  // Get the duration seconds.
+  if (_sdf->HasElement("setup_duration_seconds"))
+  {
+    this->dataPtr->setupTimeSec = std::chrono::seconds(
+        _sdf->Get<int>("setup_duration_seconds")).count();
+
+    ignmsg << "Setup duration set to " << this->dataPtr->setupTimeSec
+           << " seconds.\n";
+  }
+
+
+
+  this->dataPtr->node.Advertise("/mbzirc/start",
+      &GameLogicPluginPrivate::OnStartCall, this->dataPtr.get());
+
+  this->dataPtr->node.Advertise("/mbzirc/finish",
+      &GameLogicPluginPrivate::OnFinishCall, this->dataPtr.get());
+
+  this->dataPtr->competitionClockPub =
+    this->dataPtr->node.Advertise<ignition::msgs::Clock>("/mbzirc/run_clock");
+
+  ignmsg << "Starting MBZIRC" << std::endl;
+
+  // Make sure that there are score files.
+  this->dataPtr->UpdateScoreFiles(this->dataPtr->simTime);
+}
+
+//////////////////////////////////////////////////
+void GameLogicPluginPrivate::OnBatteryMsg(
+    const ignition::msgs::BatteryState &_msg,
+    const transport::MessageInfo &_info)
+{
+  ignition::msgs::Time localSimTime(this->simTime);
+  if (_msg.percentage() <= 0)
+  {
+    std::vector<std::string> topicParts = common::split(_info.Topic(), "/");
+    std::string name = "_unknown_";
+
+    // Get the name of the model from the topic name, where the topic name
+    // look like '/model/{model_name}/detach'.
+    if (topicParts.size() > 1)
+      name = topicParts[1];
+
+    // Make sure the event is logged once.
+    if (this->deadBatteries.find(name) == this->deadBatteries.end())
+    {
+      this->deadBatteries.emplace(name);
+      {
+        std::lock_guard<std::mutex> lock(this->eventCounterMutex);
+        std::ostringstream stream;
+        stream
+          << "- event:\n"
+          << "  id: " << this->eventCounter << "\n"
+          << "  type: dead_battery\n"
+          << "  time_sec: " << localSimTime.sec() << "\n"
+          << "  robot: " << name << std::endl;
+
+        this->LogEvent(stream.str());
+      }
+    }
+  }
+}
+
+//////////////////////////////////////////////////
+void GameLogicPlugin::PreUpdate(const UpdateInfo &_info,
+    EntityComponentManager &_ecm)
+{
+}
+
+//////////////////////////////////////////////////
+void GameLogicPlugin::PostUpdate(
+    const ignition::gazebo::UpdateInfo &_info,
+    const ignition::gazebo::EntityComponentManager &_ecm)
+{
+  // Store sim time
+  int64_t s, ns;
+  std::tie(s, ns) = ignition::math::durationToSecNsec(_info.simTime);
+  this->dataPtr->simTime.set_sec(s);
+  this->dataPtr->simTime.set_nsec(ns);
+
+  // Capture the names of the robots. We only do this until the team
+  // triggers the start signal.
+  if (!this->dataPtr->started)
+  {
+    _ecm.Each<gazebo::components::Sensor,
+              gazebo::components::ParentEntity>(
+        [&](const gazebo::Entity &,
+            const gazebo::components::Sensor *,
+            const gazebo::components::ParentEntity *_parent) -> bool
+        {
+          // Get the model. We are assuming that a sensor is attached to
+          // a link.
+          auto parent = _ecm.Component<gazebo::components::ParentEntity>(
+              _parent->Data());
+          auto model = parent;
+
+          // find top level model
+          while (parent && _ecm.Component<gazebo::components::Model>(
+                 parent->Data()))
+          {
+            model = parent;
+            parent = _ecm.Component<gazebo::components::ParentEntity>(
+                parent->Data());
+          }
+
+          if (model)
+          {
+            // \todo(anyone)
+            // Check if the robot has beyond the staging area.
+            // we need to trigger the /mbzirc/start.
+
+            // Get the model name
+            auto mName =
+              _ecm.Component<gazebo::components::Name>(model->Data());
+            if (this->dataPtr->robotNames.find(mName->Data()) ==
+                this->dataPtr->robotNames.end())
+            {
+              this->dataPtr->robotNames.insert(mName->Data());
+
+              // Subscribe to battery state in order to log battery events.
+              std::string batteryTopic = std::string("/model/") +
+                mName->Data() + "/battery/linear_battery/state";
+              this->dataPtr->node.Subscribe(batteryTopic,
+                  &GameLogicPluginPrivate::OnBatteryMsg, this->dataPtr.get());
+            }
+          }
+          return true;
+        });
+
+    // Start automatically if setup time has elapsed.
+    if (this->dataPtr->simTime.sec() >= this->dataPtr->setupTimeSec)
+    {
+      this->dataPtr->Start(this->dataPtr->simTime);
+    }
+  }
+
+  // Get the start sim time in nanoseconds.
+  auto startSimTime = std::chrono::nanoseconds(
+      this->dataPtr->startSimTime.sec() * 1000000000 +
+      this->dataPtr->startSimTime.nsec());
+
+  // Compute the elapsed competition time.
+  auto elapsedCompetitionTime = this->dataPtr->started ?
+    _info.simTime - startSimTime : std::chrono::seconds(0);
+
+  // Compute the remaining competition time.
+  auto remainingCompetitionTime = this->dataPtr->started &&
+    this->dataPtr->runDuration != std::chrono::seconds(0) ?
+    this->dataPtr->runDuration - elapsedCompetitionTime :
+    std::chrono::seconds(0) ;
+
+  // Check if the allowed time has elapsed. If so, then mark as finished.
+  if ((this->dataPtr->started && !this->dataPtr->finished) &&
+      this->dataPtr->runDuration != std::chrono::seconds(0) &&
+      remainingCompetitionTime <= std::chrono::seconds(0))
+  {
+    ignmsg << "Time limit[" <<  this->dataPtr->runDuration.count()
+      << "s] reached.\n";
+    this->dataPtr->Finish(this->dataPtr->simTime);
+  }
+
+  auto currentTime = std::chrono::steady_clock::now();
+  if (currentTime - this->dataPtr->lastStatusPubTime > std::chrono::seconds(1))
+  {
+    ignition::msgs::Clock competitionClockMsg;
+    ignition::msgs::Header::Map *mapData =
+      competitionClockMsg.mutable_header()->add_data();
+    mapData->set_key("phase");
+    if (this->dataPtr->started)
+    {
+      mapData->add_value(this->dataPtr->finished ? "finished" : "run");
+      auto secondsRemaining = std::chrono::duration_cast<std::chrono::seconds>(
+          remainingCompetitionTime);
+      competitionClockMsg.mutable_sim()->set_sec(secondsRemaining.count());
+    }
+    else if (!this->dataPtr->finished)
+    {
+      mapData->add_value("setup");
+      competitionClockMsg.mutable_sim()->set_sec(
+          this->dataPtr->setupTimeSec - this->dataPtr->simTime.sec());
+    }
+    else
+    {
+      // It's possible for a team to call Finish before starting.
+      mapData->add_value("finished");
+    }
+
+    this->dataPtr->competitionClockPub.Publish(competitionClockMsg);
+
+    this->dataPtr->lastStatusPubTime = currentTime;
+  }
+
+  // Periodically update the score file.
+  if (!this->dataPtr->finished && currentTime -
+      this->dataPtr->lastUpdateScoresTime > std::chrono::seconds(30))
+  {
+    this->dataPtr->UpdateScoreFiles(this->dataPtr->simTime);
+  }
+}
+
+/////////////////////////////////////////////////
+void GameLogicPluginPrivate::PublishScore()
+{
+  transport::Node::Publisher scorePub =
+    this->node.Advertise<ignition::msgs::Float>("/mbzirc/score");
+  ignition::msgs::Float msg;
+
+  while (!this->finished)
+  {
+    msg.set_data(this->totalScore);
+
+    scorePub.Publish(msg);
+    IGN_SLEEP_S(1);
+  }
+}
+
+/////////////////////////////////////////////////
+bool GameLogicPluginPrivate::OnFinishCall(const ignition::msgs::Boolean &_req,
+  ignition::msgs::Boolean &_res)
+{
+  ignition::msgs::Time localSimTime(this->simTime);
+  if (this->started && _req.data() && !this->finished)
+  {
+    ignmsg << "User triggered OnFinishCall." << std::endl;
+    this->Log(localSimTime) << "User triggered OnFinishCall." << std::endl;
+    this->logStream.flush();
+
+    this->Finish(localSimTime);
+    _res.set_data(true);
+  }
+  else
+    _res.set_data(false);
+
+  return true;
+}
+
+/////////////////////////////////////////////////
+bool GameLogicPluginPrivate::OnStartCall(const ignition::msgs::Boolean &_req,
+  ignition::msgs::Boolean &_res)
+{
+  ignition::msgs::Time localSimTime(this->simTime);
+  if (_req.data())
+    _res.set_data(this->Start(localSimTime));
+  else
+    _res.set_data(false);
+
+  return true;
+}
+
+/////////////////////////////////////////////////
+bool GameLogicPluginPrivate::Start(const ignition::msgs::Time &_simTime)
+{
+  bool result = false;
+
+  if (!this->started && !this->finished)
+  {
+    result = true;
+    this->started = true;
+    this->startTime = std::chrono::steady_clock::now();
+    this->startSimTime = _simTime;
+    ignmsg << "Scoring has Started" << std::endl;
+    this->Log(_simTime) << "scoring_started" << std::endl;
+    {
+      std::lock_guard<std::mutex> lock(this->eventCounterMutex);
+      std::ostringstream stream;
+      stream
+        << "- event:\n"
+        << "  id: " << this->eventCounter << "\n"
+        << "  type: started\n"
+        << "  time_sec: " << _simTime.sec() << std::endl;
+      this->LogEvent(stream.str());
+
+      this->eventCounter++;
+    }
+  }
+
+  // Update files when scoring has started.
+  this->UpdateScoreFiles(_simTime);
+
+  return result;
+}
+
+/////////////////////////////////////////////////
+void GameLogicPluginPrivate::Finish(const ignition::msgs::Time &_simTime)
+{
+  // Pause simulation when finished. Always send this request, just to be
+  // safe.
+  if (this->eventManager)
+    this->eventManager->Emit<events::Pause>(true);
+
+  if (this->finished)
+    return;
+
+  // Elapsed time
+  int realElapsed = 0;
+  int simElapsed = 0;
+
+  // Update the score.yml and summary.yml files. This function also
+  // returns the time point used to calculate the elapsed real time. By
+  // returning this time point, we can make sure that this function (the
+  // ::Finish function) uses the same time point.
+  std::chrono::steady_clock::time_point currTime =
+    this->UpdateScoreFiles(_simTime);
+
+  if (this->started)
+  {
+    realElapsed = std::chrono::duration_cast<std::chrono::seconds>(
+        currTime - this->startTime).count();
+
+    simElapsed = _simTime.sec() - this->startSimTime.sec();
+
+    ignmsg << "Scoring has finished. Elapsed real time: "
+          << realElapsed << " seconds. Elapsed sim time: "
+          << simElapsed << " seconds. " << std::endl;
+
+    this->Log(_simTime) << "finished_elapsed_real_time " << realElapsed
+      << " s." << std::endl;
+    this->Log(_simTime) << "finished_elapsed_sim_time " << simElapsed
+      << " s." << std::endl;
+    this->Log(_simTime) << "finished_score " << this->totalScore << std::endl;
+    this->logStream.flush();
+
+    {
+      std::lock_guard<std::mutex> lock(this->eventCounterMutex);
+      std::ostringstream stream;
+      stream
+        << "- event:\n"
+        << "  id: " << this->eventCounter << "\n"
+        << "  type: finished\n"
+        << "  time_sec: " << _simTime.sec() << "\n"
+        << "  elapsed_real_time: " << realElapsed << "\n"
+        << "  elapsed_sim_time: " << simElapsed << "\n"
+        << "  total_score: " << this->totalScore << std::endl;
+      this->LogEvent(stream.str());
+      this->eventCounter++;
+    }
+  }
+
+  this->finished = true;
+}
+
+/////////////////////////////////////////////////
+std::chrono::steady_clock::time_point GameLogicPluginPrivate::UpdateScoreFiles(
+    const ignition::msgs::Time &_simTime)
+{
+  std::lock_guard<std::mutex> lock(this->logMutex);
+
+  // Elapsed time
+  int realElapsed = 0;
+  int simElapsed = 0;
+  std::chrono::steady_clock::time_point currTime =
+    std::chrono::steady_clock::now();
+
+  if (this->started)
+  {
+    simElapsed = _simTime.sec() - this->startSimTime.sec();
+    realElapsed = std::chrono::duration_cast<std::chrono::seconds>(
+        currTime - this->startTime).count();
+  }
+
+  // Output a run summary
+  std::ofstream summary(this->logPath + "/summary.yml", std::ios::out);
+
+  summary << "was_started: " << this->started << std::endl;
+  summary << "sim_time_duration_sec: " << simElapsed << std::endl;
+  summary << "real_time_duration_sec: " << realElapsed << std::endl;
+  summary << "model_count: " << this->robotNames.size() << std::endl;
+  summary.flush();
+
+  // Output a score file with just the final score
+  std::ofstream score(this->logPath + "/score.yml", std::ios::out);
+  score << totalScore << std::endl;
+  score.flush();
+
+  this->lastUpdateScoresTime = currTime;
+  return currTime;
+}
+
+/////////////////////////////////////////////////
+void GameLogicPluginPrivate::LogEvent(const std::string &_event)
+{
+  std::lock_guard<std::mutex> lock(this->eventMutex);
+  this->eventStream << _event;
+  this->eventStream.flush();
+}
+
+/////////////////////////////////////////////////
+std::ofstream &GameLogicPluginPrivate::Log(
+    const ignition::msgs::Time &_simTime)
+{
+  this->logStream << _simTime.sec()
+                  << " " << _simTime.nsec() << " ";
+  return this->logStream;
+}
+
+

--- a/mbzirc_ign/src/GameLogicPlugin.hh
+++ b/mbzirc_ign/src/GameLogicPlugin.hh
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+#ifndef MBZIRC_IGN_GAMELOGICPLUGIN_HH_
+#define MBZIRC_IGN_GAMELOGICPLUGIN_HH_
+
+#include <memory>
+#include <ignition/gazebo/System.hh>
+
+namespace mbzirc
+{
+  class GameLogicPluginPrivate;
+
+  /// \brief A plugin that takes care of all the MBZIRC logic.
+  class GameLogicPlugin:
+    public ignition::gazebo::System,
+    public ignition::gazebo::ISystemConfigure,
+    public ignition::gazebo::ISystemPreUpdate,
+    public ignition::gazebo::ISystemPostUpdate
+  {
+    /// \brief Constructor
+    public: GameLogicPlugin();
+
+    /// \brief Destructor
+    public: ~GameLogicPlugin() override;
+
+    // Documentation inherited
+    public: void Configure(const ignition::gazebo::Entity &_entity,
+                           const std::shared_ptr<const sdf::Element> &_sdf,
+                           ignition::gazebo::EntityComponentManager &_ecm,
+                           ignition::gazebo::EventManager &_eventMgr) override;
+
+    // Documentation inherited
+    public: void PreUpdate(const ignition::gazebo::UpdateInfo &_info,
+                ignition::gazebo::EntityComponentManager &_ecm) override;
+
+    // Documentation inherited
+    public: void PostUpdate(const ignition::gazebo::UpdateInfo &_info,
+                const ignition::gazebo::EntityComponentManager &_ecm) override;
+
+    /// \brief Private data pointer.
+    private: std::unique_ptr<GameLogicPluginPrivate> dataPtr;
+  };
+}
+
+#endif

--- a/mbzirc_ign/test/test_game_logic.cc
+++ b/mbzirc_ign/test/test_game_logic.cc
@@ -1,0 +1,357 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include <gtest/gtest.h>
+
+#include <ignition/common/Filesystem.hh>
+
+#include <ignition/transport/Node.hh>
+
+#include <ignition/msgs.hh>
+#include <ignition/gazebo/TestFixture.hh>
+#include <ignition/gazebo/Util.hh>
+#include <ignition/gazebo/World.hh>
+#include <ignition/transport/Node.hh>
+
+#include "helper/TestFixture.hh"
+
+TEST_F(MBZIRCTestFixture, GameLogicTestStartStop)
+{
+  using namespace std::literals::chrono_literals;
+
+  /// This test checks that the start and stop events are logged
+  LoadWorld("faster_than_realtime.sdf");
+
+  StartSim();
+
+  std::string logPath = "mbzirc_logs";
+
+  int sleep = 0;
+  int maxSleep = 10;
+  while(!ignition::common::exists(logPath) && sleep++ < maxSleep)
+  {
+    std::this_thread::sleep_for(1000ms);
+  }
+
+  EXPECT_TRUE(ignition::common::exists(logPath));
+  std::string eventsLogPath =
+      ignition::common::joinPaths(logPath, "events.yml");
+  EXPECT_TRUE(ignition::common::isFile(eventsLogPath));
+  std::string summaryLogPath =
+      ignition::common::joinPaths(logPath, "summary.yml");
+  EXPECT_TRUE(ignition::common::isFile(summaryLogPath));
+
+  // verify initial state of logs
+  {
+    std::ifstream eventsLog;
+    eventsLog.open(eventsLogPath);
+    std::stringstream eventsBuffer;
+    eventsBuffer << eventsLog.rdbuf();
+
+    // events log should be empty
+    EXPECT_TRUE(eventsBuffer.str().empty());
+
+    // summary log should say the competition has not started yet
+    std::ifstream summaryLog;
+    summaryLog.open(summaryLogPath);
+    std::stringstream summaryBuffer;
+    summaryBuffer << summaryLog.rdbuf();
+    EXPECT_NE(std::string::npos, summaryBuffer.str().find("was_started: 0"));
+  }
+
+  ignition::transport::Node node;
+
+  unsigned int timeout = 5000;
+
+  // publish finish event
+  {
+    ignition::msgs::Boolean rep;
+    ignition::msgs::Boolean req;
+    req.set_data(true);
+    bool result = false;
+    const unsigned int timeout = 5000;
+    bool executed = node.Request("/mbzirc/finish",
+          req, timeout, rep, result);
+    EXPECT_TRUE(result);
+    EXPECT_FALSE(rep.data());
+  }
+
+  // Verify that competition is not finished because it has not been
+  // started yet. Log content should be the same as initial state
+  {
+    std::ifstream eventsLog;
+    eventsLog.open(eventsLogPath);
+    std::stringstream eventsBuffer;
+    eventsBuffer << eventsLog.rdbuf();
+
+    // events log should be empty
+    EXPECT_TRUE(eventsBuffer.str().empty());
+
+    // summary log should say the competition has not started yet
+    std::ifstream summaryLog;
+    summaryLog.open(summaryLogPath);
+    std::stringstream summaryBuffer;
+    summaryBuffer << summaryLog.rdbuf();
+    EXPECT_NE(std::string::npos, summaryBuffer.str().find("was_started: 0"));
+  }
+
+  // publish start event
+  {
+    ignition::msgs::Boolean rep;
+    ignition::msgs::Boolean req;
+    req.set_data(true);
+    bool result = false;
+    const unsigned int timeout = 5000;
+    bool executed = node.Request("/mbzirc/start",
+          req, timeout, rep, result);
+    EXPECT_TRUE(result);
+    EXPECT_TRUE(rep.data());
+  }
+
+  // verify that start event is logged
+  bool started = false;
+  sleep = 0;
+  while(!started && sleep++ < maxSleep)
+  {
+    std::this_thread::sleep_for(1000ms);
+
+    std::ifstream eventsLog;
+    eventsLog.open(eventsLogPath);
+    std::stringstream eventsBuffer;
+    eventsBuffer << eventsLog.rdbuf();
+
+    std::ifstream summaryLog;
+    summaryLog.open(summaryLogPath);
+    std::stringstream summaryBuffer;
+    summaryBuffer << summaryLog.rdbuf();
+
+    started = eventsBuffer.str().find("type: started") != std::string::npos
+        && summaryBuffer.str().find("was_started: 1") != std::string::npos;
+  }
+
+  EXPECT_TRUE(started);
+
+  // publish finish event
+  {
+    ignition::msgs::Boolean rep;
+    ignition::msgs::Boolean req;
+    req.set_data(true);
+    bool result = false;
+    const unsigned int timeout = 5000;
+    bool executed = node.Request("/mbzirc/finish",
+          req, timeout, rep, result);
+    EXPECT_TRUE(result);
+    EXPECT_TRUE(rep.data());
+  }
+
+  // verify that finish event is logged
+  bool finished = false;
+  sleep = 0;
+  while(!finished && sleep++ < maxSleep)
+  {
+    std::this_thread::sleep_for(1000ms);
+
+    std::ifstream eventsLog;
+    eventsLog.open(eventsLogPath);
+    std::stringstream eventsBuffer;
+    eventsBuffer << eventsLog.rdbuf();
+
+    std::ifstream summaryLog;
+    summaryLog.open(summaryLogPath);
+    std::stringstream summaryBuffer;
+    summaryBuffer << summaryLog.rdbuf();
+
+    finished = eventsBuffer.str().find("type: finished") != std::string::npos
+        && summaryBuffer.str().find("was_started: 1") != std::string::npos;
+  }
+  ignition::common::removeAll(logPath);
+}
+
+TEST_F(MBZIRCTestFixture, GameLogicPhase)
+{
+  using namespace std::literals::chrono_literals;
+
+  /// This test checks that the competition run clock topic publishes
+  // the right statuses
+  LoadWorld("faster_than_realtime.sdf");
+
+  StartSim();
+
+  ignition::transport::Node node;
+
+  // Run clock callback to keep track of current competition state
+  std::mutex runClockMutex;
+  std::string phaseData;
+  std::function<void(const ignition::msgs::Clock &_msg)> runClockCb =
+    [&](const ignition::msgs::Clock &_msg)
+    {
+      std::lock_guard<std::mutex> lock(runClockMutex);
+      EXPECT_EQ(1, _msg.header().data_size());
+      auto data = _msg.header().data(0);
+      EXPECT_EQ(1, data.value_size());
+      EXPECT_EQ("phase", data.key());
+      phaseData = data.value(0);
+    };
+  node.Subscribe("/mbzirc/run_clock", runClockCb);
+
+  // verify that initial phase is "setup"
+  int sleep = 0;
+  int maxSleep = 10;
+  bool reachedPhase = false;
+  while(!reachedPhase && sleep++ < maxSleep)
+  {
+    std::this_thread::sleep_for(1000ms);
+    Step(10);
+    std::lock_guard<std::mutex> lock(runClockMutex);
+    reachedPhase = phaseData == "setup";
+  }
+  EXPECT_EQ("setup", phaseData);
+
+  // publish start event
+  {
+    ignition::msgs::Boolean rep;
+    ignition::msgs::Boolean req;
+    req.set_data(true);
+    bool result = false;
+    const unsigned int timeout = 5000;
+    bool executed = node.Request("/mbzirc/start",
+          req, timeout, rep, result);
+    EXPECT_TRUE(result);
+    EXPECT_TRUE(rep.data());
+  }
+
+  // check that phase is now "run"
+  sleep = 0;
+  reachedPhase = false;
+  while(!reachedPhase && sleep++ < maxSleep)
+  {
+    std::this_thread::sleep_for(1000ms);
+    Step(10);
+    std::lock_guard<std::mutex> lock(runClockMutex);
+    reachedPhase = phaseData == "run";
+  }
+  EXPECT_EQ("run", phaseData);
+
+  // publish finish event
+  {
+    ignition::msgs::Boolean rep;
+    ignition::msgs::Boolean req;
+    req.set_data(true);
+    bool result = false;
+    const unsigned int timeout = 5000;
+    bool executed = node.Request("/mbzirc/finish",
+          req, timeout, rep, result);
+    EXPECT_TRUE(result);
+    EXPECT_TRUE(rep.data());
+  }
+
+  // check that phase is now "finished"
+  sleep = 0;
+  reachedPhase = false;
+  while(!reachedPhase && sleep++ < maxSleep)
+  {
+    std::this_thread::sleep_for(1000ms);
+    Step(10);
+    std::lock_guard<std::mutex> lock(runClockMutex);
+    reachedPhase = phaseData == "finished";
+  }
+  EXPECT_EQ("finished", phaseData);
+
+  std::string logPath = "mbzirc_logs";
+  ignition::common::removeAll(logPath);
+}
+
+TEST_F(MBZIRCTestFixture, GameLogicRobotModels)
+{
+  using namespace std::literals::chrono_literals;
+
+  /// This test checks the robot count is correct in logs
+  std::vector<std::pair<std::string,std::string>> params{
+    {"name", "quadrotor"},
+    {"world", "faster_than_realtime"},
+    {"model", "mbzirc_quadrotor"},
+    {"type",  "uav"},
+    {"x", "1"},
+    {"y", "2"},
+    {"z", "0.05"},
+    {"flightTime", "10"}
+  };
+
+  bool spawnedSuccessfully = false;
+  SetMaxIter(1000);
+
+  LoadWorld("faster_than_realtime.sdf");
+
+  OnPostupdate([&](const ignition::gazebo::UpdateInfo &_info,
+          const ignition::gazebo::EntityComponentManager &_ecm)
+  {
+    auto worldEntity = ignition::gazebo::worldEntity(_ecm);
+    ignition::gazebo::World world(worldEntity);
+
+    /// Check for model
+    auto modelEntity = world.ModelByName(_ecm, "quadrotor");
+    if (modelEntity != ignition::gazebo::kNullEntity)
+    {
+      spawnedSuccessfully = true;
+    }
+
+    if (Iter() % 1000 == 0)
+      ignmsg << Iter() <<std::endl;
+
+  });
+
+  StartSim();
+  auto launchHandle = LaunchWithParams("spawn.launch.py", params);
+  WaitForMaxIter();
+
+  // Wait for a maximum of 50K iterations or till the vehicle has been spawned.
+  while(!spawnedSuccessfully && Iter() < 50000)
+  {
+    Step(100);
+  }
+
+  StopLaunchFile(launchHandle);
+
+  // summary log is updated every 30 seconds
+  ignmsg << "Waiting 30 seconds for summary.yml to update" << std::endl;
+  std::this_thread::sleep_for(30000ms);
+
+  // check that robot count in summary log is correct
+  std::string logPath = "mbzirc_logs";
+  std::string summaryLogPath =
+      ignition::common::joinPaths(logPath, "summary.yml");
+  EXPECT_TRUE(ignition::common::isFile(summaryLogPath));
+  int sleep = 0;
+  int maxSleep = 10;
+  bool robotCountReached = false;
+  while(!robotCountReached && sleep++ < maxSleep)
+  {
+    Step(1000);
+    std::this_thread::sleep_for(1000ms);
+
+    std::ifstream summaryLog;
+    summaryLog.open(summaryLogPath);
+    std::stringstream summaryBuffer;
+    summaryBuffer << summaryLog.rdbuf();
+    robotCountReached = summaryBuffer.str().find("model_count: 1")
+        != std::string::npos;
+  }
+  EXPECT_TRUE(robotCountReached);
+
+  ignition::common::removeAll(logPath);
+  return;
+}

--- a/mbzirc_ign/test/test_spawn_uav_battery.cc
+++ b/mbzirc_ign/test/test_spawn_uav_battery.cc
@@ -41,7 +41,7 @@ TEST_F(MBZIRCTestFixture, SpawnUAVTest)
 
   bool spawnedSuccessfully = false;
 
-  SetMaxIter(1000);
+  SetMaxIter(10000);
 
   LoadWorld("faster_than_realtime.sdf");
 
@@ -121,7 +121,7 @@ TEST_F(MBZIRCTestFixture, TestBatteryDuration)
     };
   node.Subscribe("/model/quadrotor/battery/linear_battery/state", batteryCb);
 
-  SetMaxIter(1000);
+  SetMaxIter(10000);
 
   LoadWorld("faster_than_realtime.sdf");
 

--- a/mbzirc_ign/worlds/faster_than_realtime.sdf
+++ b/mbzirc_ign/worlds/faster_than_realtime.sdf
@@ -129,5 +129,15 @@
       </uri>
     </include>
 
+    <!-- The MBZIRC competition logic plugin -->
+    <plugin filename="libGameLogicPlugin.so"
+            name="mbzirc::GameLogicPlugin">
+      <run_duration_seconds>60</run_duration_seconds>
+      <setup_duration_seconds>30</setup_duration_seconds>
+      <logging>
+        <path>mbzirc_logs</path>
+      </logging>
+    </plugin>
+
   </world>
 </sdf>

--- a/mbzirc_ign/worlds/simple_demo.sdf
+++ b/mbzirc_ign/worlds/simple_demo.sdf
@@ -161,5 +161,18 @@
       <pose>25 25 -1 0 0.0 -1.0</pose>
       <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Vessel A</uri>
     </include>
+
+    <!-- The MBZIRC competition logic plugin -->
+    <plugin filename="libGameLogicPlugin.so"
+            name="mbzirc::GameLogicPlugin">
+      <run_duration_seconds>3600</run_duration_seconds>
+      <setup_duration_seconds>120</setup_duration_seconds>
+      <logging>
+        <!-- Use the <path> element to control where to record the log file.
+             The HOME path is used by default -->
+        <path>/tmp/ign/mbzirc/logs</path>
+      </logging>
+    </plugin>
+
   </world>
 </sdf>


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

Added `GameLogicPlugin` with basic functionality for logging, starting and stopping a run, and publishing run status.

Added `test_game_logic` integration test.

Scoring functionality is not implemented yet.

There are 3 main plugin params:

* `<setup_duration_seconds>`: time allowed for teams to set up before starting a run
* `<run_duration_seconds>`: time limit for each run (count down starts when a run is "started")
* `<logging><path>`: Path to log files

**Starting and and finishing a run**

The actual procedure for starting  and stopping a run is still TBD. Currently service calls are provided to manually start and stop the run. To test:

```
ign service -s /mbzirc/start --reqtype ignition.msgs.Boolean --reptype ignition.msgs.Boolean --req 'data: true' --timeout 1000
```

```
ign service -s /mbzirc/finish --reqtype ignition.msgs.Boolean --reptype ignition.msgs.Boolean --req 'data: true' --timeout 1000
```

Invoking these service call should change the status of the run, which is published to the `/mbzirc/run_clock` topic:

```
ign topic -e -t /mbzirc/run_clock
```

Phases are: `setup` -> `run` -> `finished`.

**Logging**

4 logs are generated. They are stored in `/tmp/ign/mbzirc/logs` directory

* `events.yml`: Currently logs these events:
  * start
  * finish
  * dead battery
* `summary.yml`: Records whether the run was started, number of robots, total sim and real time of the run. This log file is updated periodically (30 seconds)
*  `score.yml`: scoring logic still need to be implemented so the log currently just outputs a score of `0`
* `mbzirc_<timestamp>.log`: general log msgs. Intended to be used for introspection, debugging, etc


