### PR TITLE
Simplifying release code

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,10 +28,7 @@ jobs:
       - name: Run build script
         id: build_docker
         run: |
-            cd docker
-            bash -xe ./build.bash ${{ matrix.image_name }} \
-              ${{ github.server_url }}/${{ github.repository }} \
-              ${{ github.sha }}
+            bash -xe ./docker/build.bash ${{ matrix.image_name }}
             echo "::set-output name=name::${{ matrix.image_name }}:latest"
 
       - name: Create latest version tag

--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ To build a docker image of the simulator locally:
 1. Navigate to the `docker` directory and build the `mbzirc_sim` Docker image
 
     ```
-    cd mbzirc/docker
-    bash build.bash mbzirc_sim
+    cd mbzirc
+    bash docker/build.bash mbzirc_sim
     ```
 
 1.  The process can take a few minutes. Once it is done, you can launch the

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Docker images are available on Docker Hub: https://hub.docker.com/repository/doc
     docker pull osrf/mbzirc:mbzirc_sim_latest
     ```
 
-1. Clone the repo and launch a Docker container from the image using the `run.bash` script. Note: requires `nvidia-docker`.
+1. Clone the repo and launch a Docker container from the image using the `run.bash` script. Note: requires `nvidia-docker2`
 
     ```
     git clone https://github.com/osrf/mbzirc.git
@@ -73,7 +73,7 @@ To build a docker image of the simulator locally:
     ```
     bash run.bash mbzirc_sim
     ```
-  
+
 ## Running the simulator
 
 Please see the wiki:  https://github.com/osrf/mbzirc/wiki

--- a/docker/build.bash
+++ b/docker/build.bash
@@ -21,7 +21,7 @@
 
 if [ $# -eq 0 ]
 then
-    echo "Usage: $0 directory-name [mbzirc_repo_url] [mbzirc_sha_commit]"
+    echo "Usage: $0 directory-name"
     exit 1
 fi
 
@@ -34,8 +34,12 @@ then
   exit 2
 fi
 
-mbzirc_repo_url=${2:-https://github.com/osrf/mbzirc}
-mbzirc_sha_commit=${3}
+if [ ! -d mbzirc_ros ]; then
+  echo "mbzirc_ros directory not found in this directory. Please call the"
+  echo "script from the root directory of the mbzirc code."
+  exit 3
+fi
+
 user_id=$(id -u)
 image_name=$(basename $1)
 image_plus_tag=$image_name:latest-$(date +%F_%H%M)
@@ -45,8 +49,6 @@ shift
 docker build --rm \
   -t "$image_plus_tag" \
   --build-arg user_id="$user_id"  \
-  --build-arg mbzirc_sha_commit="${mbzirc_sha_commit}" \
-  --build-arg mbzirc_repo_url="${mbzirc_repo_url}" \
   -f "$DIR/$image_name/Dockerfile" . \
 
 docker tag $image_plus_tag $image_name:latest

--- a/docker/mbzirc_sim/Dockerfile
+++ b/docker/mbzirc_sim/Dockerfile
@@ -105,26 +105,16 @@ RUN mkdir ~/workspaces ~/other
 # When running a container start in the developer's home folder
 WORKDIR /home/$USERNAME
 
-# Input ARG mbzirc_sha_commit to build a given git ref in the source code
-ARG mbzirc_sha_commit
-# Input ARG to allow using forks for testing. Default to osrf/mbzirc
-ARG mbzirc_repo_url=https://github.com/osrf/mbzirc
-
-# clone mbzirc sim
-RUN mkdir -p mbzirc_ws/src \
- && cd mbzirc_ws/src \
- && git config --global http.postBuffer 1048576000 \
- && git clone ${mbzirc_repo_url} mbzirc \
- && if [ "${mbzirc_sha_commit}" != "" ]; then \
-       echo "Using: SHA ${mbzirc_sha_commit}" && \
-       git --git-dir mbzirc/.git checkout "${mbzirc_sha_commit}"; \
-    fi
+# Prepare the colcon workspace
+RUN mkdir -p mbzirc_ws/src
 
 # clone ros_ign bridge
 RUN cd /home/$USERNAME/mbzirc_ws/src \
  && git clone https://github.com/osrf/ros_ign.git -b ros2
 
 WORKDIR /home/$USERNAME/mbzirc_ws
+
+COPY . src/mbzric
 
 ENV IGNITION_VERSION fortress
 
@@ -134,9 +124,12 @@ RUN sudo apt-get update \
   && sudo rm -rf /var/lib/apt/lists/* \
   && sudo apt-get clean -qq
 
+# Be sure that mbzirc_ros is present in the compilation by calling info
 RUN /bin/bash -c 'source /opt/ros/galactic/setup.bash \
+  && colcon info mbzirc_ros \
   && colcon build --merge-install' \
   && rm -fr build/ log/
+
 RUN /bin/sh -c 'echo ". /opt/ros/galactic/setup.bash" >> ~/.bashrc' \
  && /bin/sh -c 'echo ". ~/mbzirc_ws/install/setup.sh" >> ~/.bashrc'
 


### PR DESCRIPTION
The PR replaces part of the code in the releasing process that was cloning the mbzirc repository inside the Docker image with the option of reusing the code present in the same local checkout of this repository.

This is useful to share the same Docker image between releasing and CI. As a side effect of this, the `build.sh` script must be called from the root of the repository so docker can `COPY` the source code.

A new release was tested in my fork https://github.com/j-rivero/mbzirc/runs/4967967660?check_suite_focus=true.