### PR TITLE
Add a ceiling collision to simple demo world

### DIFF
--- a/mbzirc_ign/worlds/simple_demo.sdf
+++ b/mbzirc_ign/worlds/simple_demo.sdf
@@ -146,6 +146,14 @@
             </box>
           </geometry>
         </collision>
+        <collision name="ceiling">
+          <pose>0 0 146.42 0 0 0</pose>
+          <geometry>
+            <box>
+              <size>5000 5000 1</size>
+            </box>
+          </geometry>
+        </collision>
       </link>
     </model>
 


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

max flight height allowed by [local regulations](https://u.ae/en/information-and-services/justice-safety-and-the-law/aviation-safety) is 400 feet / ~121.92 meters.

For this demo, we'll go with 400 ft from water plane (sea level)

The water plane in this world is at -1m, and the the collision boundary model is at -25m. So to get the ceiling collision to be at 121.92m from the water, its z pos is calculated as:

121.92 + 0.5 (half collision size) + 25 - 1 = 146.42m