### PR TITLE
Move xvfb to be called inside the docker container for tests

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -11,10 +11,6 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v2
-      - name: Install and run xvfb
-        run: |
-          sudo apt-get install -y xvfb
-          Xvfb :1 -ac -noreset -core -screen 0 1280x1024x24 &
       - name: Run build script
         id: build_docker
         run: |
@@ -22,10 +18,12 @@ jobs:
             echo "::set-output name=name::${{ matrix.image_name }}:latest"
       - name: Run tests
         run: |
-          docker run -e DISPLAY=:1 -v /tmp/.X11-unix:/tmp/.X11-unix \
-              ${{ steps.build_docker.outputs.name }} \
-              /bin/bash -c \
-                'source /home/$USERNAME/mbzirc_ws/install/setup.bash && \
+          docker run \
+              mbzirc_sim /bin/bash -c \
+                'Xvfb :1 -ac -noreset -core -screen 0 1280x1024x24 & \
+                 export DISPLAY=:1.0 && \
+                 export RENDER_ENGINE_VALUES=ogre2 && \
+                 source /home/$USERNAME/mbzirc_ws/install/setup.bash && \
                  colcon test --merge-install \
                              --event-handlers console_direct+ \
                              --packages-select mbzirc_ros && \


### PR DESCRIPTION
After some tests, I think that the best way of dealing with xvfb calls and containers is to call it directly in the container to avoid all the necessary mapping to make it work correctly.

The PR moves the call to be done in the docker run together with docker run that call colcon. I'm also including the same variables that we are using in ign-rendering testing.

With this setup I was able to make ign-rendering Camera test to pass https://github.com/osrf/mbzirc/runs/4982529291?check_suite_focus=true but DISPLAY test in this repository is still failing:
```
1: [ign gazebo -v 4 --iterations 20000 -s -r simple_demo.sdf-1] [Wrn] [Ogre2Heightmap.cc:118] Heightmap final sampling should be 2^n
1: [ign gazebo -v 4 --iterations 20000 -s -r simple_demo.sdf-1]  which differs from ogre1's 2^n+1
1: [ign gazebo -v 4 --iterations 20000 -s -r simple_demo.sdf-1] The last row and column will be cropped
1: [ign gazebo -v 4 --iterations 20000 -s -r simple_demo.sdf-1] size = (width * sampling) - sampling + 1
1: [ign gazebo -v 4 --iterations 20000 -s -r simple_demo.sdf-1] [257] = ([257] * [1]) - [1] + 1
1: [ign gazebo -v 4 --iterations 20000 -s -r simple_demo.sdf-1] [Wrn] [Ogre2RenderTarget.cc:573] Anti-aliasing level of '2' is not supported; valid FSAA levels are: [ 0 4 ]. Setting to 0
1: [ign gazebo -v 4 --iterations 20000 -s -r simple_demo.sdf-1] Stack trace (most recent call last) in thread 105:
````
If we use `--headless-rendering` [the result is a segfault with a more verbose stack trace](https://github.com/osrf/mbzirc/runs/4981987705?check_suite_focus=true):
```
1: [ign gazebo --headless-rendering -v 4 --iterations 20000 -s -r simple_demo.sdf-1] [Wrn] [Ogre2Heightmap.cc:118] Heightmap final sampling should be 2^n
1: [ign gazebo --headless-rendering -v 4 --iterations 20000 -s -r simple_demo.sdf-1]  which differs from ogre1's 2^n+1
1: [ign gazebo --headless-rendering -v 4 --iterations 20000 -s -r simple_demo.sdf-1] The last row and column will be cropped
1: [ign gazebo --headless-rendering -v 4 --iterations 20000 -s -r simple_demo.sdf-1] size = (width * sampling) - sampling + 1
1: [ign gazebo --headless-rendering -v 4 --iterations 20000 -s -r simple_demo.sdf-1] [257] = ([257] * [1]) - [1] + 1
1: [ign gazebo --headless-rendering -v 4 --iterations 20000 -s -r simple_demo.sdf-1] Stack trace (most recent call last) in thread 106:
1: [ign gazebo --headless-rendering -v 4 --iterations 20000 -s -r simple_demo.sdf-1] #24   Object "[0xffffffffffffffff]", at 0xffffffffffffffff, in 
1: [ign gazebo --headless-rendering -v 4 --iterations 20000 -s -r simple_demo.sdf-1] #23   Object "/usr/lib/x86_64-linux-gnu/libc.so.6", at 0x7f880ba72292, in clone
1: [ign gazebo --headless-rendering -v 4 --iterations 20000 -s -r simple_demo.sdf-1] #22   Object "/usr/lib/x86_64-linux-gnu/libpthread.so.0", at 0x7f880b936608, in 
1: [ign gazebo --headless-rendering -v 4 --iterations 20000 -s -r simple_demo.sdf-1] #21   Object "/usr/lib/x86_64-linux-gnu/libstdc++.so.6", at 0x7f8808007de3, in 
1: [ign gazebo --headless-rendering -v 4 --iterations 20000 -s -r simple_demo.sdf-1] #20   Object "/usr/lib/x86_64-linux-gnu/ign-gazebo-6/plugins/libignition-gazebo-sensors-system.so", at 0x7f87df2783a7, in ignition::gazebo::v6::systems::SensorsPrivate::RenderThread()
1: [ign gazebo --headless-rendering -v 4 --iterations 20000 -s -r simple_demo.sdf-1] #19   Object "/usr/lib/x86_64-linux-gnu/ign-gazebo-6/plugins/libignition-gazebo-sensors-system.so", at 0x7f87df277e20, in ignition::gazebo::v6::systems::SensorsPrivate::RunOnce()
1: [ign gazebo --headless-rendering -v 4 --iterations 20000 -s -r simple_demo.sdf-1] #18   Object "/usr/lib/x86_64-linux-gnu/libignition-sensors6.so.6", at 0x7f87deeaeb7e, in ignition::sensors::v6::Manager::RunOnce(std::chrono::duration<long, std::ratio<1l, 1000000000l> > const&, bool)
1: [ign gazebo --headless-rendering -v 4 --iterations 20000 -s -r simple_demo.sdf-1] #17   Object "/usr/lib/x86_64-linux-gnu/libignition-sensors6.so.6", at 0x7f87deec3b8d, in ignition::sensors::v6::Sensor::Update(std::chrono::duration<long, std::ratio<1l, 1000000000l> > const&, bool)
1: [ign gazebo --headless-rendering -v 4 --iterations 20000 -s -r simple_demo.sdf-1] #16   Object "/usr/lib/x86_64-linux-gnu/libignition-sensors6-camera.so.6", at 0x7f87def264d3, in ignition::sensors::v6::CameraSensor::Update(std::chrono::duration<long, std::ratio<1l, 1000000000l> > const&)
1: [ign gazebo --headless-rendering -v 4 --iterations 20000 -s -r simple_demo.sdf-1] #15   Object "/usr/lib/x86_64-linux-gnu/libignition-sensors6-rendering.so.6", at 0x7f87deeedb15, in ignition::sensors::v6::RenderingSensor::Render()
1: [ign gazebo --headless-rendering -v 4 --iterations 20000 -s -r simple_demo.sdf-1] #14   Object "/usr/lib/x86_64-linux-gnu/ign-rendering-6/engine-plugins/libignition-rendering-ogre2.so", at 0x7f87da6bf235, in ignition::rendering::v6::Ogre2RenderTarget::Render()
1: [ign gazebo --headless-rendering -v 4 --iterations 20000 -s -r simple_demo.sdf-1] #13   Object "/usr/lib/x86_64-linux-gnu/libOgreMain.so.2.2.6", at 0x7f87da31d7fa, in Ogre::CompositorWorkspace::_update(bool)
1: [ign gazebo --headless-rendering -v 4 --iterations 20000 -s -r simple_demo.sdf-1] #12   Object "/usr/lib/x86_64-linux-gnu/libOgreMain.so.2.2.6", at 0x7f87da31d527, in Ogre::CompositorWorkspace::_update(bool)
1: [ign gazebo --headless-rendering -v 4 --iterations 20000 -s -r simple_demo.sdf-1] #11   Object "/usr/lib/x86_64-linux-gnu/libOgreMain.so.2.2.6", at 0x7f87da30abb4, in Ogre::CompositorNode::_update(Ogre::Camera const*, Ogre::SceneManager*)
1: [ign gazebo --headless-rendering -v 4 --iterations 20000 -s -r simple_demo.sdf-1] #10   Object "/usr/lib/x86_64-linux-gnu/libOgreMain.so.2.2.6", at 0x7f87da33695f, in Ogre::CompositorPassScene::execute(Ogre::Camera const*)
1: [ign gazebo --headless-rendering -v 4 --iterations 20000 -s -r simple_demo.sdf-1] #9    Object "/usr/lib/x86_64-linux-gnu/libOgreMain.so.2.2.6", at 0x7f87da316563, in Ogre::CompositorShadowNode::_update(Ogre::Camera*, Ogre::Camera const*, Ogre::SceneManager*)
1: [ign gazebo --headless-rendering -v 4 --iterations 20000 -s -r simple_demo.sdf-1] #8    Object "/usr/lib/x86_64-linux-gnu/libOgreMain.so.2.2.6", at 0x7f87da30abb4, in Ogre::CompositorNode::_update(Ogre::Camera const*, Ogre::SceneManager*)
1: [ign gazebo --headless-rendering -v 4 --iterations 20000 -s -r simple_demo.sdf-1] #7    Object "/usr/lib/x86_64-linux-gnu/libOgreMain.so.2.2.6", at 0x7f87da336a68, in Ogre::CompositorPassScene::execute(Ogre::Camera const*)
1: [ign gazebo --headless-rendering -v 4 --iterations 20000 -s -r simple_demo.sdf-1] #6    Object "/usr/lib/x86_64-linux-gnu/libOgreMain.so.2.2.6", at 0x7f87da00702d, in Ogre::Camera::_cullScenePhase01(Ogre::Camera*, Ogre::Camera const*, Ogre::Viewport*, unsigned char, unsigned char, bool)
1: [ign gazebo --headless-rendering -v 4 --iterations 20000 -s -r simple_demo.sdf-1] #5    Object "/usr/lib/x86_64-linux-gnu/libOgreMain.so.2.2.6", at 0x7f87da1f0ca4, in Ogre::SceneManager::_cullPhase01(Ogre::Camera*, Ogre::Camera*, Ogre::Camera const*, unsigned char, unsigned char, bool)
1: [ign gazebo --headless-rendering -v 4 --iterations 20000 -s -r simple_demo.sdf-1] #4    Object "/usr/lib/x86_64-linux-gnu/libOgreMain.so.2.2.6", at 0x7f87da1ab01b, in Ogre::RenderQueue::renderPassPrepare(bool, bool)
1: [ign gazebo --headless-rendering -v 4 --iterations 20000 -s -r simple_demo.sdf-1] #3    Object "/usr/lib/x86_64-linux-gnu/libOgreHlmsPbs.so.2.2.6", at 0x7f87d9e46a12, in Ogre::HlmsPbs::preparePassHash(Ogre::CompositorShadowNode const*, bool, bool, Ogre::SceneManager*)
1: [ign gazebo --headless-rendering -v 4 --iterations 20000 -s -r simple_demo.sdf-1] #2    Object "/usr/lib/x86_64-linux-gnu/libOgreMain.so.2.2.6", at 0x7f87da347557, in Ogre::VaoManager::createConstBuffer(unsigned long, Ogre::BufferType, void*, bool)
1: [ign gazebo --headless-rendering -v 4 --iterations 20000 -s -r simple_demo.sdf-1] #1    Object "/usr/lib/x86_64-linux-gnu/OGRE-2.2/OGRE/RenderSystem_GL3Plus.so", at 0x7f87b434653d, in Ogre::GL3PlusVaoManager::createConstBufferImpl(unsigned long, Ogre::BufferType, void*, bool)
1: [ign gazebo --headless-rendering -v 4 --iterations 20000 -s -r simple_demo.sdf-1] #0    Object "/usr/lib/x86_64-linux-gnu/OGRE-2.2/OGRE/RenderSystem_GL3Plus.so", at 0x7f87b43457c0, in Ogre::GL3PlusVaoManager::allocateVbo(unsigned long, unsigned long, Ogre::BufferType, unsigned long&, unsigned long&)
1: [ign gazebo --headless-rendering -v 4 --iterations 20000 -s -r simple_demo.sdf-1] Segmentation fault (Signal sent by the kernel [(nil)])
1: [test_ros_api-2] /home/developer/mbzirc_ws/src/mbzric/mbzirc_ros/test/ros_api/test_ros_api.cc:107: Failure
```

@iche033 has commented offline about the problem with the DISPLAY test in this repo:

> The ShaderSelection is skipped but VisualAt test did run and test passed. So seems like rendering is working fine, at least for that test. The backtrace points to sensors system's RenderThread. I wonder if it's threading issue..
