### PR TITLE
Enable more tests in CI

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -11,10 +11,6 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v2
-      - name: Install and run xvfb
-        run: |
-          sudo apt-get install -y xvfb
-          Xvfb :1 -ac -noreset -core -screen 0 1280x1024x24 &
       - name: Run build script
         id: build_docker
         run: |
@@ -22,10 +18,12 @@ jobs:
             echo "::set-output name=name::${{ matrix.image_name }}:latest"
       - name: Run tests
         run: |
-          docker run -e DISPLAY=:1 -v /tmp/.X11-unix:/tmp/.X11-unix \
-              ${{ steps.build_docker.outputs.name }} \
-              /bin/bash -c \
-                'source /home/$USERNAME/mbzirc_ws/install/setup.bash && \
+          docker run \
+              mbzirc_sim /bin/bash -c \
+                'Xvfb :1 -ac -noreset -core -screen 0 1280x1024x24 & \
+                 export DISPLAY=:1.0 && \
+                 export RENDER_ENGINE_VALUES=ogre2 && \
+                 source /home/$USERNAME/mbzirc_ws/install/setup.bash && \
                  colcon test --merge-install \
                              --event-handlers console_direct+ \
                              --packages-select mbzirc_ros && \

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -27,5 +27,5 @@ jobs:
                  source /home/$USERNAME/mbzirc_ws/install/setup.bash && \
                  colcon test --merge-install \
                              --event-handlers console_direct+ \
-                             --packages-select mbzirc_ros && \
+                             --packages-select mbzirc_ros mbzirc_ign && \
                  colcon test-result'

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -22,7 +22,6 @@ jobs:
               mbzirc_sim /bin/bash -c \
                 'Xvfb :1 -ac -noreset -core -screen 0 1280x1024x24 & \
                  export DISPLAY=:1.0 && \
-                 export DISPLAY_TEST=1 && \
                  export RENDER_ENGINE_VALUES=ogre2 && \
                  source /home/$USERNAME/mbzirc_ws/install/setup.bash && \
                  colcon test --merge-install \

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -22,6 +22,7 @@ jobs:
               mbzirc_sim /bin/bash -c \
                 'Xvfb :1 -ac -noreset -core -screen 0 1280x1024x24 & \
                  export DISPLAY=:1.0 && \
+                 export DISPLAY_TEST=1 && \
                  export RENDER_ENGINE_VALUES=ogre2 && \
                  source /home/$USERNAME/mbzirc_ws/install/setup.bash && \
                  colcon test --merge-install \

--- a/mbzirc_ign/worlds/empty_platform.sdf
+++ b/mbzirc_ign/worlds/empty_platform.sdf
@@ -1,0 +1,91 @@
+<?xml version="1.0" ?>
+
+<sdf version="1.6">
+  <world name="empty_platform">
+
+    <plugin
+      filename="ignition-gazebo-physics-system"
+      name="ignition::gazebo::systems::Physics">
+    </plugin>
+    <plugin
+      filename="ignition-gazebo-user-commands-system"
+      name="ignition::gazebo::systems::UserCommands">
+    </plugin>
+    <plugin
+      filename="ignition-gazebo-sensors-system"
+      name="ignition::gazebo::systems::Sensors">
+      <render_engine>ogre2</render_engine>
+    </plugin>
+    <plugin
+      filename="ignition-gazebo-air-pressure-system"
+      name="ignition::gazebo::systems::AirPressure">
+    </plugin>
+    <plugin
+      filename="ignition-gazebo-altimeter-system"
+      name="ignition::gazebo::systems::Altimeter">
+    </plugin>
+    <plugin
+      filename="ignition-gazebo-imu-system"
+      name="ignition::gazebo::systems::Imu">
+    </plugin>
+    <plugin
+      filename="ignition-gazebo-magnetometer-system"
+      name="ignition::gazebo::systems::Magnetometer">
+    </plugin>
+    <plugin
+      filename="ignition-gazebo-particle-emitter2-system"
+      name="ignition::gazebo::systems::ParticleEmitter2">
+    </plugin>
+    <plugin
+      filename="ignition-gazebo-scene-broadcaster-system"
+      name="ignition::gazebo::systems::SceneBroadcaster">
+    </plugin>
+
+    <scene>
+      <grid>false</grid>
+      <ambient>1.0 1.0 1.0</ambient>
+      <background>0.8 0.8 0.8</background>
+    </scene>
+
+    <light type="directional" name="sun">
+      <cast_shadows>true</cast_shadows>
+      <pose>0 0 10 0 0 0</pose>
+      <diffuse>0.8 0.8 0.8 1</diffuse>
+      <specular>0.2 0.2 0.2 1</specular>
+      <attenuation>
+        <range>1000</range>
+        <constant>0.9</constant>
+        <linear>0.01</linear>
+        <quadratic>0.001</quadratic>
+      </attenuation>
+      <direction>-0.5 0.1 -0.9</direction>
+    </light>
+
+    <model name="ground_platform">
+      <static>true</static>
+      <pose>0 0 -1.5 0 0 0</pose>
+      <link name="link">
+        <collision name="collision">
+          <geometry>
+            <box>
+              <size>20 20 3</size>
+            </box>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>20 20 3</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0.8 0.8 0.8 1</ambient>
+            <diffuse>0.8 0.8 0.8 1</diffuse>
+            <specular>0.8 0.8 0.8 1</specular>
+          </material>
+        </visual>
+      </link>
+    </model>
+
+  </world>
+</sdf>

--- a/mbzirc_ros/test/launch/test_ros_api.launch.py
+++ b/mbzirc_ros/test/launch/test_ros_api.launch.py
@@ -21,8 +21,11 @@ from ament_index_python import get_package_share_directory
 from launch import LaunchDescription
 
 from launch.actions import IncludeLaunchDescription
+from launch.actions import EmitEvent
 from launch.actions import ExecuteProcess
 from launch.actions import TimerAction
+from launch.events import matches_action
+from launch.events.process import ShutdownProcess
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_ros.actions import Node
 
@@ -84,11 +87,21 @@ def generate_test_description():
             period=10.0,
             actions=[spawn_hexrotor])
 
+    kill_proc = EmitEvent(
+        event=ShutdownProcess(
+            process_matcher=matches_action(gazebo)
+        )
+    )
+    delay_kill_proc = TimerAction(
+            period=40.0,
+            actions=[kill_proc])
+
     return LaunchDescription([
         gazebo,
         delay_launch_quadrotor,
         delay_launch_hexrotor,
         process_under_test,
+        delay_kill_proc,
         launch_testing.util.KeepAliveProc(),
         launch_testing.actions.ReadyToTest(),
     ]), locals()

--- a/mbzirc_ros/test/launch/test_ros_api.launch.py
+++ b/mbzirc_ros/test/launch/test_ros_api.launch.py
@@ -93,7 +93,7 @@ def generate_test_description():
         )
     )
     delay_kill_proc = TimerAction(
-            period=40.0,
+            period=120.0,
             actions=[kill_proc])
 
     return LaunchDescription([

--- a/mbzirc_ros/test/launch/test_ros_api.launch.py
+++ b/mbzirc_ros/test/launch/test_ros_api.launch.py
@@ -28,7 +28,7 @@ from launch_ros.actions import Node
 
 import launch_testing
 
-# launch simple_demo and spawn quadrotor and hexrotor UAVs
+# launch empty_platform and spawn quadrotor and hexrotor UAVs
 def generate_test_description():
 
     process_under_test = Node(
@@ -37,9 +37,9 @@ def generate_test_description():
         output='screen'
     )
 
-    # launch simple_demo world
+    # launch empty_platform world
     gazebo = ExecuteProcess(
-        cmd=['ign gazebo --headless-rendering -v 4 --iterations 20000 -s -r simple_demo.sdf'],
+        cmd=['ign gazebo --headless-rendering -v 4 --iterations 20000 -s -r empty_platform.sdf'],
         output='screen',
         shell=True
     )
@@ -47,12 +47,12 @@ def generate_test_description():
     display_test = os.getenv('DISPLAY_TEST')
     # spawn quadrotor
     arguments={'name'  : 'quadrotor',
-               'world' : 'simple_demo',
+               'world' : 'empty_platform',
                'model' : 'mbzirc_quadrotor',
                'type'  : 'uav',
                'z'     : '0.08',}
-#    if display_test == '1':
-    arguments['slot0'] = 'mbzirc_hd_camera'
+    if display_test == '1':
+        arguments['slot0'] = 'mbzirc_hd_camera'
     spawn_quadrotor = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
             os.path.join(
@@ -66,13 +66,13 @@ def generate_test_description():
 
     # spawn hexrotor
     arguments={'name'  : 'hexrotor',
-               'world' : 'simple_demo',
+               'world' : 'empty_platform',
                'model' : 'mbzirc_hexrotor',
                'type'  : 'uav',
                'x'     : '2',
                'z'     : '0.08',}
-    #if display_test == '1':
-    #    arguments['slot0'] = 'mbzirc_rgbd_camera'
+    if display_test == '1':
+        arguments['slot0'] = 'mbzirc_rgbd_camera'
     spawn_hexrotor = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
             os.path.join(

--- a/mbzirc_ros/test/launch/test_ros_api.launch.py
+++ b/mbzirc_ros/test/launch/test_ros_api.launch.py
@@ -51,8 +51,8 @@ def generate_test_description():
                'model' : 'mbzirc_quadrotor',
                'type'  : 'uav',
                'z'     : '0.08',}
-    if display_test == '1':
-        arguments['slot0'] = 'mbzirc_hd_camera'
+#    if display_test == '1':
+    arguments['slot0'] = 'mbzirc_hd_camera'
     spawn_quadrotor = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
             os.path.join(
@@ -71,8 +71,8 @@ def generate_test_description():
                'type'  : 'uav',
                'x'     : '2',
                'z'     : '0.08',}
-    if display_test == '1':
-        arguments['slot0'] = 'mbzirc_rgbd_camera'
+    #if display_test == '1':
+    #    arguments['slot0'] = 'mbzirc_rgbd_camera'
     spawn_hexrotor = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
             os.path.join(
@@ -87,7 +87,7 @@ def generate_test_description():
     return LaunchDescription([
         gazebo,
         delay_launch_quadrotor,
-        delay_launch_hexrotor,
+        # delay_launch_hexrotor,
         process_under_test,
         launch_testing.util.KeepAliveProc(),
         launch_testing.actions.ReadyToTest(),

--- a/mbzirc_ros/test/launch/test_ros_api.launch.py
+++ b/mbzirc_ros/test/launch/test_ros_api.launch.py
@@ -39,7 +39,7 @@ def generate_test_description():
 
     # launch empty_platform world
     gazebo = ExecuteProcess(
-        cmd=['ign gazebo --headless-rendering -v 4 --iterations 20000 -s -r empty_platform.sdf'],
+        cmd=['ign gazebo --headless-rendering -v 4 --iterations 15000 -s -r empty_platform.sdf'],
         output='screen',
         shell=True
     )
@@ -61,7 +61,7 @@ def generate_test_description():
         ),
         launch_arguments=arguments.items())
     delay_launch_quadrotor = TimerAction(
-            period=10.0,
+            period=8.0,
             actions=[spawn_quadrotor])
 
     # spawn hexrotor
@@ -81,7 +81,7 @@ def generate_test_description():
         ),
         launch_arguments=arguments.items())
     delay_launch_hexrotor = TimerAction(
-            period=13.0,
+            period=10.0,
             actions=[spawn_hexrotor])
 
     return LaunchDescription([
@@ -97,8 +97,8 @@ def generate_test_description():
 class RosApiTest(unittest.TestCase):
 
     def test_termination(self, process_under_test, gazebo, proc_info):
-        proc_info.assertWaitForShutdown(process=process_under_test, timeout=300)
-        proc_info.assertWaitForShutdown(process=gazebo, timeout=300)
+        proc_info.assertWaitForShutdown(process=process_under_test, timeout=200)
+        proc_info.assertWaitForShutdown(process=gazebo, timeout=200)
 
 
 @launch_testing.post_shutdown_test()

--- a/mbzirc_ros/test/launch/test_ros_api.launch.py
+++ b/mbzirc_ros/test/launch/test_ros_api.launch.py
@@ -50,15 +50,14 @@ def generate_test_description():
         ),
         launch_arguments=arguments.items())
 
-    display_test = os.getenv('DISPLAY_TEST')
     # spawn quadrotor
     arguments={'name'  : 'quadrotor',
                'world' : 'empty_platform',
                'model' : 'mbzirc_quadrotor',
                'type'  : 'uav',
                'z'     : '0.08',}
-    if display_test == '1':
-        arguments['slot0'] = 'mbzirc_hd_camera'
+    # add hd camera
+    arguments['slot0'] = 'mbzirc_hd_camera'
     spawn_quadrotor = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
             os.path.join(
@@ -77,8 +76,8 @@ def generate_test_description():
                'type'  : 'uav',
                'x'     : '2',
                'z'     : '0.08',}
-    if display_test == '1':
-        arguments['slot0'] = 'mbzirc_rgbd_camera'
+    # add rgbd camera
+    arguments['slot0'] = 'mbzirc_rgbd_camera'
     spawn_hexrotor = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
             os.path.join(

--- a/mbzirc_ros/test/launch/test_ros_api.launch.py
+++ b/mbzirc_ros/test/launch/test_ros_api.launch.py
@@ -87,7 +87,7 @@ def generate_test_description():
     return LaunchDescription([
         gazebo,
         delay_launch_quadrotor,
-        # delay_launch_hexrotor,
+        delay_launch_hexrotor,
         process_under_test,
         launch_testing.util.KeepAliveProc(),
         launch_testing.actions.ReadyToTest(),

--- a/mbzirc_ros/test/ros_api/test_ros_api.cc
+++ b/mbzirc_ros/test/ros_api/test_ros_api.cc
@@ -15,6 +15,7 @@
  *
  */
 
+#include <fstream>
 #include <gtest/gtest.h>
 
 #include <rclcpp/rclcpp.hpp>
@@ -133,8 +134,8 @@ TEST(RosApiTest, UAVTopics)
 
   // rendering tests are disabled as it causes a crash on CI
   // \todo enable
-  const char *var = std::getenv("DISPLAY_TEST");
-  if (var && std::string(var) == "1")
+//  const char *var = std::getenv("DISPLAY_TEST");
+//  if (var && std::string(var) == "1")
   {
     // image_raw
     MyTestClass<sensor_msgs::msg::Image> image(
@@ -212,6 +213,16 @@ TEST(RosApiTest, UAVTopics)
     waitUntilBoolVarAndSpin(
       node, rgbdOpticalDepth.callbackExecuted, 10ms, 500);
     EXPECT_TRUE(rgbdOpticalDepth.callbackExecuted);
+  }
+
+  const char *env = std::getenv("HOME");
+  if (env)
+  {
+    std::ifstream file;
+    file.open(std::string(env) + "/.ignition/rendering/ogre2.log");
+    std::stringstream ss;
+    ss << file.rdbuf();
+    std::cerr << ss.str() << std::endl;
   }
 
   // \todo check cmd_vel and points (lidar) topics

--- a/mbzirc_ros/test/ros_api/test_ros_api.cc
+++ b/mbzirc_ros/test/ros_api/test_ros_api.cc
@@ -15,7 +15,6 @@
  *
  */
 
-#include <fstream>
 #include <gtest/gtest.h>
 
 #include <rclcpp/rclcpp.hpp>

--- a/mbzirc_ros/test/ros_api/test_ros_api.cc
+++ b/mbzirc_ros/test/ros_api/test_ros_api.cc
@@ -215,16 +215,6 @@ TEST(RosApiTest, UAVTopics)
     EXPECT_TRUE(rgbdOpticalDepth.callbackExecuted);
   }
 
-  const char *env = std::getenv("HOME");
-  if (env)
-  {
-    std::ifstream file;
-    file.open(std::string(env) + "/.ignition/rendering/ogre2.log");
-    std::stringstream ss;
-    ss << file.rdbuf();
-    std::cerr << ss.str() << std::endl;
-  }
-
   // \todo check cmd_vel and points (lidar) topics
 }
 

--- a/mbzirc_ros/test/ros_api/test_ros_api.cc
+++ b/mbzirc_ros/test/ros_api/test_ros_api.cc
@@ -133,86 +133,82 @@ TEST(RosApiTest, UAVTopics)
 
   // rendering tests are disabled as it causes a crash on CI
   // \todo enable
-  const char *var = std::getenv("DISPLAY_TEST");
-  if (var && std::string(var) == "1")
-  {
-    // image_raw
-    MyTestClass<sensor_msgs::msg::Image> image(
-        "/quadrotor/slot0/image_raw");
-    waitUntilBoolVarAndSpin(
-      node, image.callbackExecuted, 10ms, 3000);
-    EXPECT_TRUE(image.callbackExecuted);
+  // image_raw
+  MyTestClass<sensor_msgs::msg::Image> image(
+      "/quadrotor/slot0/image_raw");
+  waitUntilBoolVarAndSpin(
+    node, image.callbackExecuted, 10ms, 3000);
+  EXPECT_TRUE(image.callbackExecuted);
 
-    // camera_info
-    MyTestClass<sensor_msgs::msg::CameraInfo> cameraInfo(
-        "/quadrotor/slot0/camera_info");
-    waitUntilBoolVarAndSpin(
-      node, cameraInfo.callbackExecuted, 10ms, 500);
-    EXPECT_TRUE(cameraInfo.callbackExecuted);
+  // camera_info
+  MyTestClass<sensor_msgs::msg::CameraInfo> cameraInfo(
+      "/quadrotor/slot0/camera_info");
+  waitUntilBoolVarAndSpin(
+    node, cameraInfo.callbackExecuted, 10ms, 500);
+  EXPECT_TRUE(cameraInfo.callbackExecuted);
 
-    // optical image
-    MyTestClass<sensor_msgs::msg::Image> imageOptical(
-        "/quadrotor/slot0/optical/image_raw");
-    waitUntilBoolVarAndSpin(
-      node, imageOptical.callbackExecuted, 10ms, 500);
-    EXPECT_TRUE(imageOptical.callbackExecuted);
+  // optical image
+  MyTestClass<sensor_msgs::msg::Image> imageOptical(
+      "/quadrotor/slot0/optical/image_raw");
+  waitUntilBoolVarAndSpin(
+    node, imageOptical.callbackExecuted, 10ms, 500);
+  EXPECT_TRUE(imageOptical.callbackExecuted);
 
-    // optical camera_info
-    MyTestClass<sensor_msgs::msg::CameraInfo> cameraInfoOptical(
-        "/quadrotor/slot0/optical/camera_info");
-    waitUntilBoolVarAndSpin(
-      node, cameraInfoOptical.callbackExecuted, 10ms, 500);
-    EXPECT_TRUE(cameraInfoOptical.callbackExecuted);
+  // optical camera_info
+  MyTestClass<sensor_msgs::msg::CameraInfo> cameraInfoOptical(
+      "/quadrotor/slot0/optical/camera_info");
+  waitUntilBoolVarAndSpin(
+    node, cameraInfoOptical.callbackExecuted, 10ms, 500);
+  EXPECT_TRUE(cameraInfoOptical.callbackExecuted);
 
-    // rgbd - color
-    MyTestClass<sensor_msgs::msg::Image> rgbdImage(
-        "/hexrotor/slot0/image_raw");
-    waitUntilBoolVarAndSpin(
-      node, rgbdImage.callbackExecuted, 10ms, 500);
-    EXPECT_TRUE(rgbdImage.callbackExecuted);
+  // rgbd - color
+  MyTestClass<sensor_msgs::msg::Image> rgbdImage(
+      "/hexrotor/slot0/image_raw");
+  waitUntilBoolVarAndSpin(
+    node, rgbdImage.callbackExecuted, 10ms, 500);
+  EXPECT_TRUE(rgbdImage.callbackExecuted);
 
-    // rgbd - camera_info
-    MyTestClass<sensor_msgs::msg::CameraInfo> rgbdCameraInfo(
-        "/hexrotor/slot0/camera_info");
-    waitUntilBoolVarAndSpin(
-      node, rgbdCameraInfo.callbackExecuted, 10ms, 500);
-    EXPECT_TRUE(rgbdCameraInfo.callbackExecuted);
+  // rgbd - camera_info
+  MyTestClass<sensor_msgs::msg::CameraInfo> rgbdCameraInfo(
+      "/hexrotor/slot0/camera_info");
+  waitUntilBoolVarAndSpin(
+    node, rgbdCameraInfo.callbackExecuted, 10ms, 500);
+  EXPECT_TRUE(rgbdCameraInfo.callbackExecuted);
 
-    // rgbd - depth
-    MyTestClass<sensor_msgs::msg::Image> rgbdDepth(
-        "/hexrotor/slot0/depth");
-    waitUntilBoolVarAndSpin(
-      node, rgbdDepth.callbackExecuted, 10ms, 500);
-    EXPECT_TRUE(rgbdDepth.callbackExecuted);
+  // rgbd - depth
+  MyTestClass<sensor_msgs::msg::Image> rgbdDepth(
+      "/hexrotor/slot0/depth");
+  waitUntilBoolVarAndSpin(
+    node, rgbdDepth.callbackExecuted, 10ms, 500);
+  EXPECT_TRUE(rgbdDepth.callbackExecuted);
 
-    // rgbd - points
-    MyTestClass<sensor_msgs::msg::PointCloud2> rgbdPoints(
-        "/hexrotor/slot0/points");
-    waitUntilBoolVarAndSpin(
-      node, rgbdPoints.callbackExecuted, 10ms, 500);
-    EXPECT_TRUE(rgbdPoints.callbackExecuted);
+  // rgbd - points
+  MyTestClass<sensor_msgs::msg::PointCloud2> rgbdPoints(
+      "/hexrotor/slot0/points");
+  waitUntilBoolVarAndSpin(
+    node, rgbdPoints.callbackExecuted, 10ms, 500);
+  EXPECT_TRUE(rgbdPoints.callbackExecuted);
 
-    // rgbd optical - color
-    MyTestClass<sensor_msgs::msg::Image> rgbdOpticalImage(
-        "/hexrotor/slot0/optical/image_raw");
-    waitUntilBoolVarAndSpin(
-      node, rgbdOpticalImage.callbackExecuted, 10ms, 500);
-    EXPECT_TRUE(rgbdOpticalImage.callbackExecuted);
+  // rgbd optical - color
+  MyTestClass<sensor_msgs::msg::Image> rgbdOpticalImage(
+      "/hexrotor/slot0/optical/image_raw");
+  waitUntilBoolVarAndSpin(
+    node, rgbdOpticalImage.callbackExecuted, 10ms, 500);
+  EXPECT_TRUE(rgbdOpticalImage.callbackExecuted);
 
-    // rgbd optical - camera_info
-    MyTestClass<sensor_msgs::msg::CameraInfo> rgbdOpticalCameraInfo(
-        "/hexrotor/slot0/optical/camera_info");
-    waitUntilBoolVarAndSpin(
-      node, rgbdOpticalCameraInfo.callbackExecuted, 10ms, 500);
-    EXPECT_TRUE(rgbdOpticalCameraInfo.callbackExecuted);
+  // rgbd optical - camera_info
+  MyTestClass<sensor_msgs::msg::CameraInfo> rgbdOpticalCameraInfo(
+      "/hexrotor/slot0/optical/camera_info");
+  waitUntilBoolVarAndSpin(
+    node, rgbdOpticalCameraInfo.callbackExecuted, 10ms, 500);
+  EXPECT_TRUE(rgbdOpticalCameraInfo.callbackExecuted);
 
-    // rgbd optical - depth
-    MyTestClass<sensor_msgs::msg::Image> rgbdOpticalDepth(
-        "/hexrotor/slot0/optical/depth");
-    waitUntilBoolVarAndSpin(
-      node, rgbdOpticalDepth.callbackExecuted, 10ms, 500);
-    EXPECT_TRUE(rgbdOpticalDepth.callbackExecuted);
-  }
+  // rgbd optical - depth
+  MyTestClass<sensor_msgs::msg::Image> rgbdOpticalDepth(
+      "/hexrotor/slot0/optical/depth");
+  waitUntilBoolVarAndSpin(
+    node, rgbdOpticalDepth.callbackExecuted, 10ms, 500);
+  EXPECT_TRUE(rgbdOpticalDepth.callbackExecuted);
 
   // \todo check cmd_vel and points (lidar) topics
 }

--- a/mbzirc_ros/test/ros_api/test_ros_api.cc
+++ b/mbzirc_ros/test/ros_api/test_ros_api.cc
@@ -134,8 +134,8 @@ TEST(RosApiTest, UAVTopics)
 
   // rendering tests are disabled as it causes a crash on CI
   // \todo enable
-//  const char *var = std::getenv("DISPLAY_TEST");
-//  if (var && std::string(var) == "1")
+  const char *var = std::getenv("DISPLAY_TEST");
+  if (var && std::string(var) == "1")
   {
     // image_raw
     MyTestClass<sensor_msgs::msg::Image> image(


### PR DESCRIPTION
Enabled rendering tests and mbzirc_ign integration tests.

Found that the rendering test segfault was due to issue with heightmap in CI machine. So I created a simpler world for testing that contains just a ground platform and loads all  ign-gazebo systems needed by the UAVs.