### PR TITLE
Update USV thruster joint rotation velocity

### DIFF
--- a/mbzirc_ign/models/usv/model.sdf.erb
+++ b/mbzirc_ign/models/usv/model.sdf.erb
@@ -454,7 +454,7 @@ end
         <lower>-1.57079</lower>
         <upper>1.57079</upper>
         <effort>10</effort>
-        <velocity>10</velocity>
+        <velocity>0.2618</velocity>
       </limit>
     </axis>
     <parent>base_link</parent>
@@ -484,7 +484,7 @@ end
         <lower>-1.57079</lower>
         <upper>1.57079</upper>
         <effort>10</effort>
-        <velocity>10</velocity>
+        <velocity>0.2618</velocity>
       </limit>
     </axis>
     <parent>base_link</parent>

--- a/mbzirc_ign/models/wam-v/model.sdf.erb
+++ b/mbzirc_ign/models/wam-v/model.sdf.erb
@@ -145,7 +145,7 @@ end
         <lower>-1.57079</lower>
         <upper>1.57079</upper>
         <effort>10</effort>
-        <velocity>10</velocity>
+        <velocity>0.2618</velocity>
       </limit>
     </axis>
     <parent>base_link</parent>
@@ -233,7 +233,7 @@ end
         <lower>-1.57079</lower>
         <upper>1.57079</upper>
         <effort>10</effort>
-        <velocity>10</velocity>
+        <velocity>0.2618</velocity>
       </limit>
     </axis>
     <parent>base_link</parent>


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

Updated rate of rotation to 15 degrees/s (0.2618 rad/s) based on spec: 
https://www.mbzirc.com/usv-details

To test:

```
# spawn usv
ros2 launch mbzirc_ign spawn.launch.py name:=usv world:=simple_demo model:=usv type:=usv x:=15 y:=0 z:=-0.1 R:=0 P:=0 Y:=0

# test joint pos cmd - It should take ~6s to rotate 90 degrees
ros2 topic pub --once /usv/left/thrust/joint/cmd_pos std_msgs/msg/Float64 'data: -1.57079'
```