### PR TITLE
Add pause check to Surface plugin.

### DIFF
--- a/mbzirc_ign/src/Surface.cc
+++ b/mbzirc_ign/src/Surface.cc
@@ -175,6 +175,9 @@ void Surface::PreUpdate(const ignition::gazebo::UpdateInfo &_info,
 {
   IGN_PROFILE("Surface::PreUpdate");
 
+  if (_info.paused)
+    return;
+
   // Vehicle frame transform
   const auto kPose = this->dataPtr->link.WorldPose(_ecm);
   // std::optional<ignition::math::Pose3d> kPose;


### PR DESCRIPTION
The surface plugin was misbehaving when we pause: 
![waves_pause_problems](https://user-images.githubusercontent.com/542272/152746975-1c358555-a2e7-4580-9042-18d9c1e9292c.gif)

This is because we continue to add forces when the plugin is paused.

After fix:
![pause-fixed](https://user-images.githubusercontent.com/542272/152747139-3a2d9175-4840-47ae-b4a8-f01dabb8f6d4.gif)


Signed-off-by: Arjo Chakravarty <arjo@openrobotics.org>