### PR TITLE
Limits the maximum thrust to 8 knots

### DIFF
--- a/mbzirc_ign/CMakeLists.txt
+++ b/mbzirc_ign/CMakeLists.txt
@@ -79,7 +79,7 @@ if(BUILD_TESTING)
   configure_file(test/helper/TestConstants.hh.in TestConstants.hh @ONLY)
 
   foreach(TEST_TARGET
-    test_spawn_uav_battery test_game_logic)
+    test_spawn_uav_battery test_game_logic test_spawn_usv_maxspeed)
     ament_add_gtest(
       ${TEST_TARGET}
       test/${TEST_TARGET}.cc

--- a/mbzirc_ign/models/usv/model.sdf.erb
+++ b/mbzirc_ign/models/usv/model.sdf.erb
@@ -539,7 +539,7 @@ end
     <fluid_density>1000</fluid_density>
     <propeller_diameter>0.2</propeller_diameter>
     <velocity_control>true</velocity_control>
-    <max_thrust_cmd><%= max_total_thrust/2 %><</max_thrust_cmd>
+    <max_thrust_cmd><%= max_total_thrust/2 %></max_thrust_cmd>
   </plugin>
 
   <plugin

--- a/mbzirc_ign/models/usv/model.sdf.erb
+++ b/mbzirc_ign/models/usv/model.sdf.erb
@@ -40,7 +40,10 @@ end
         </mesh>
       </geometry>
     </visual>
+  </link>
 
+  <link name="base_collision">
+    <pose>0 0 0.0 0 0 1.57079</pose>
     <collision name="box_collision001">
       <pose>0.0 0.0 0.389269 0.0 0.0 0.0</pose>
       <geometry>
@@ -451,6 +454,11 @@ end
     </collision>
 
   </link>
+
+  <joint name="base_joint" type="fixed">
+    <parent>base_link</parent>
+    <child>base_collision</child>
+  </joint>
 
   <joint name="left_chassis_engine_joint" type="revolute">
     <axis>

--- a/mbzirc_ign/models/usv/model.sdf.erb
+++ b/mbzirc_ign/models/usv/model.sdf.erb
@@ -16,7 +16,6 @@ end
 <model name="<%= $model_name%>">
   <static>false</static>
   <link name="base_link">
-    <pose>0 0 0.0 0 0 1.57079</pose>
     <inertial>
       <mass>500.0</mass>
       <inertia>
@@ -30,6 +29,7 @@ end
     </inertial>
 
     <visual name="base_visual">
+      <pose>0 0 0.0 0 0 1.57079</pose>
       <geometry>
         <mesh>
           <uri>meshes/USV.dae</uri>

--- a/mbzirc_ign/models/usv/model.sdf.erb
+++ b/mbzirc_ign/models/usv/model.sdf.erb
@@ -4,6 +4,11 @@ if !defined?(name) || name== nil || name.empty?
 else
   $model_name = name
 end
+  x_uu = 72.4 # Hydrodynamic quadratic coefficient
+  x_u = 51.3 # Hydrodynamic linear coefficient
+  max_velocity_knots = 8 # Maximum velocity in knots. Taken from the USV specification.
+  max_velocity_mps = max_velocity_knots * 0.5144 # convert knots to m/s
+  max_total_thrust = (x_u + x_uu * max_velocity_mps) * max_velocity_mps
 %>
 <?xml version="1.0"?>
 
@@ -515,6 +520,7 @@ end
     <fluid_density>1000</fluid_density>
     <propeller_diameter>0.2</propeller_diameter>
     <velocity_control>true</velocity_control>
+    <max_thrust_cmd><%= max_total_thrust/2 %></max_thrust_cmd>
   </plugin>
 
   <plugin
@@ -533,6 +539,7 @@ end
     <fluid_density>1000</fluid_density>
     <propeller_diameter>0.2</propeller_diameter>
     <velocity_control>true</velocity_control>
+    <max_thrust_cmd><%= max_total_thrust/2 %><</max_thrust_cmd>
   </plugin>
 
   <plugin
@@ -580,8 +587,8 @@ end
     <yDotV>0.0</yDotV>
     <nDotR>0.0</nDotR>
     <!-- Linear and quadratic drag -->
-    <xU>51.3</xU>
-    <xUU>72.4</xUU>
+    <xU><%=x_u%></xU>
+    <xUU><%=x_uu%></xUU>
     <yV>40.0</yV>
     <yVV>0.0</yVV>
     <zW>500.0</zW>

--- a/mbzirc_ign/test/helper/TestFixture.hh
+++ b/mbzirc_ign/test/helper/TestFixture.hh
@@ -109,6 +109,22 @@ class MBZIRCTestFixture : public ::testing::Test
       });
   }
 
+    /// \brief Sets the OnPostupdate condition to be checked.
+  /// \param[in] func - the callback function to be run every step.
+  public: void OnPreUpdate(
+    std::function<void(
+      const ignition::gazebo::UpdateInfo &,
+      ignition::gazebo::EntityComponentManager &)> func)
+  {
+    this->preUpdateFunc = func;
+    this->fixture->OnPreUpdate(
+      [&](const ignition::gazebo::UpdateInfo &_info,
+      ignition::gazebo::EntityComponentManager &_ecm)
+      {
+        this->preUpdateFunc(_info, _ecm);
+      });
+  }
+
   /// \brief Start the simulation in a background thread and run up to maxIter
   /// steps.
   public: void StartSim()
@@ -195,6 +211,11 @@ class MBZIRCTestFixture : public ::testing::Test
   private: std::function<void(
       const ignition::gazebo::UpdateInfo &,
       const ignition::gazebo::EntityComponentManager &)> postUpdateFunc;
+
+  /// \brief Callback function for PreUpdate
+  private: std::function<void(
+      const ignition::gazebo::UpdateInfo &,
+      ignition::gazebo::EntityComponentManager &)> preUpdateFunc;
 };
 
 #endif

--- a/mbzirc_ign/test/test_spawn_usv_maxspeed.cc
+++ b/mbzirc_ign/test/test_spawn_usv_maxspeed.cc
@@ -177,6 +177,8 @@ TEST_F(MBZIRCTestFixture, USVMaxSpeedTest)
 
   ASSERT_TRUE(spawnedSuccessfully) << "USV not spawned";
   ASSERT_TRUE(startedSuccessfully) << "Model did not start moving";
-  ASSERT_NEAR(maxVel,  8 * 0.5144, 1e-2) << "Max vel exceeds 8 knots";
+  ASSERT_NEAR(currVel,  8 * 0.5144, 1e-2) << "final velocity exceeds 8 knots";
   ASSERT_LE(prevVel, currVel) << "Hydrodynamics is not being damped";
+  ASSERT_LE(maxVel, 5) << "Model is moving too fast";
+  )
 }

--- a/mbzirc_ign/test/test_spawn_usv_maxspeed.cc
+++ b/mbzirc_ign/test/test_spawn_usv_maxspeed.cc
@@ -101,7 +101,7 @@ TEST_F(MBZIRCTestFixture, USVMaxSpeedTest)
   });
 
   double maxVel{0};
-  double prevVel{0}, currVel{0};
+  double currVel{0};
 
   OnPostupdate([&](const ignition::gazebo::UpdateInfo &_info,
           const ignition::gazebo::EntityComponentManager &_ecm)
@@ -149,7 +149,6 @@ TEST_F(MBZIRCTestFixture, USVMaxSpeedTest)
     }
 
     maxVel = std::max(maxVel, linearVel->X());
-    prevVel = currVel;
     currVel = linearVel->X();
   });
 
@@ -166,7 +165,7 @@ TEST_F(MBZIRCTestFixture, USVMaxSpeedTest)
 
   ASSERT_TRUE(spawnedSuccessfully) << "USV not spawned";
   ASSERT_TRUE(startedSuccessfully) << "Model did not start moving";
-  ASSERT_NEAR(currVel,  8 * 0.5144, 1e-2) << "final velocity exceeds 8 knots";
-  ASSERT_LE(prevVel, currVel) << "Hydrodynamics is not being damped";
+  /// wide tolerance thanks to surface plugin
+  ASSERT_NEAR(currVel,  8 * 0.5144, 1e-1) << "final velocity exceeds 8 knots";
   ASSERT_LE(maxVel, 5) << "Model is moving too fast";
 }

--- a/mbzirc_ign/test/test_spawn_usv_maxspeed.cc
+++ b/mbzirc_ign/test/test_spawn_usv_maxspeed.cc
@@ -88,9 +88,6 @@ TEST_F(MBZIRCTestFixture, USVMaxSpeedTest)
       }
       auto linkVal = ignition::gazebo::Link(linkEntity);
       linkVal.EnableVelocityChecks(_ecm);
-      /// 50000N / 500 kg = 100ms^-2
-      /// 100ms^-2 * 0.02s = 2m/s
-      ///linkVal.AddWorldForce(_ecm, ignition::math::Vector3d(50000, 0, 0));
       initialVelocitySet = true;
     }
 
@@ -145,20 +142,12 @@ TEST_F(MBZIRCTestFixture, USVMaxSpeedTest)
       return;
     }
 
-    //if (linearVel->Length() >0)
-    //igndbg << linearVel.value().X() << " "
-    //       << linearVel.value().Y() << " "
-    //       << linearVel.value().Z() << std::endl;
-
     /// Check that the model is moving
     if (linearVel->X() > 0.5)
     {
       startedSuccessfully = true;
     }
 
-    /// Make sure that the model is moving forward at less than 8 knots
-    //ASSERT_TRUE(linearVel->X() <= 8 * 0.5144 + 1e-3)
-    //  << "Model is moving too fast " << linearVel->X() << "m/s\n";
     maxVel = std::max(maxVel, linearVel->X());
     prevVel = currVel;
     currVel = linearVel->X();

--- a/mbzirc_ign/test/test_spawn_usv_maxspeed.cc
+++ b/mbzirc_ign/test/test_spawn_usv_maxspeed.cc
@@ -1,0 +1,172 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include <gtest/gtest.h>
+
+#include <ignition/msgs.hh>
+#include <ignition/gazebo/TestFixture.hh>
+#include <ignition/gazebo/Util.hh>
+#include <ignition/gazebo/Link.hh>
+#include <ignition/gazebo/Model.hh>
+#include <ignition/gazebo/World.hh>
+#include <ignition/transport/Node.hh>
+
+#include "helper/TestFixture.hh"
+
+TEST_F(MBZIRCTestFixture, USVMaxSpeedTest)
+{
+  /// This test checks that the USV is spawned correctly.
+  std::vector<std::pair<std::string,std::string>> params{
+    {"name", "usv"},
+    {"world", "faster_than_realtime"},
+    {"model", "usv"},
+    {"type",  "usv"},
+    {"x", "15"},
+    {"y", "0"},
+    {"z", "-0.7"}
+  };
+
+  bool spawnedSuccessfully = false;
+  bool initialVelocitySet = false;
+  bool startedSuccessfully = false;
+
+  ignition::transport::Node node;
+  auto thruster_pub1 =
+    node.Advertise<ignition::msgs::Double>(
+      "/model/usv/joint/left_engine_propeller_joint/cmd_thrust");
+  auto thruster_pub2 =
+    node.Advertise<ignition::msgs::Double>(
+      "/model/usv/joint/right_engine_propeller_joint/cmd_thrust");
+
+
+  SetMaxIter(10000);
+
+  LoadWorld("faster_than_realtime.sdf");
+
+  OnPreUpdate([&](const ignition::gazebo::UpdateInfo &_info,
+    ignition::gazebo::EntityComponentManager &_ecm)
+  {
+    /// Not yet spawned no velocity will be recorded
+    if (!spawnedSuccessfully)
+    {
+      return;
+    }
+
+    // To speed up the test we give the vehicle an initial velocity of 4m/s
+    if (!initialVelocitySet)
+    {
+      auto worldEntity = ignition::gazebo::worldEntity(_ecm);
+      ignition::gazebo::World world(worldEntity);
+
+      auto modelEntity = world.ModelByName(_ecm, "usv");
+      if (modelEntity == ignition::gazebo::kNullEntity)
+      {
+        return;
+      }
+
+      auto modelVal = ignition::gazebo::Model(modelEntity);
+      auto linkEntity = modelVal.LinkByName(_ecm, "base_link");
+      if (linkEntity == ignition::gazebo::kNullEntity)
+      {
+        ignerr << "Could not find link" << std::endl;
+        ASSERT_TRUE(false);
+        return;
+      }
+      auto linkVal = ignition::gazebo::Link(linkEntity);
+      linkVal.EnableVelocityChecks(_ecm);
+      linkVal.SetLinearVelocity(_ecm, ignition::math::Vector3d(4, 0, 0));
+      initialVelocitySet = true;
+    }
+  });
+
+  OnPostupdate([&](const ignition::gazebo::UpdateInfo &_info,
+          const ignition::gazebo::EntityComponentManager &_ecm)
+  {
+    auto worldEntity = ignition::gazebo::worldEntity(_ecm);
+    ignition::gazebo::World world(worldEntity);
+
+    /// Check for model
+    auto modelEntity = world.ModelByName(_ecm, "usv");
+    if (modelEntity != ignition::gazebo::kNullEntity)
+    {
+      spawnedSuccessfully = true;
+    }
+
+    /// Not yet spawned no velocity will be recorded
+    if (!spawnedSuccessfully)
+    {
+      //ignerr << "No veh yet\n";
+      return;
+    }
+
+    /// Publish an arbitrarily large thrust to the thrusters, it should be
+    /// clamped down to a certain thrust
+    ignition::msgs::Double thrust;
+    thrust.set_data(1000000);
+
+    thruster_pub1.Publish(thrust);
+    thruster_pub2.Publish(thrust);
+
+    /// Try to get the model speed
+    auto modelVal = ignition::gazebo::Model(modelEntity);
+    auto linkEntity = modelVal.LinkByName(_ecm, "base_link");
+    if (linkEntity == ignition::gazebo::kNullEntity)
+    {
+      ignerr << "Could not find link" << std::endl;
+      ASSERT_TRUE(false);
+      return;
+    }
+    auto linkVal = ignition::gazebo::Link(linkEntity);
+    auto linearVel = linkVal.WorldLinearVelocity(_ecm);
+
+    ASSERT_TRUE(linearVel.has_value());
+    if(!linearVel.has_value())
+    {
+      ignerr << "No linear velocity\n";
+      return;
+    }
+
+    if (linearVel->Length() >0)
+    igndbg << linearVel.value().X() << " "
+           << linearVel.value().Y() << " "
+           << linearVel.value().Z() << std::endl;
+
+    /// Check that the model is moving
+    if (linearVel->X() > 0.5)
+    {
+      startedSuccessfully = true;
+    }
+
+    /// Make sure that the model is moving forward at less than 8 knots
+    ///ASSERT_TRUE(linearVel->X() < 8 * 0.5144)
+    ///  << "Model is moving too fast " << linearVel->X() << "m/s\n";
+  });
+
+  StartSim();
+  auto launchHandle = LaunchWithParams("spawn.launch.py", params);
+  WaitForMaxIter();
+
+  while(!startedSuccessfully && Iter() < 500000)
+  {
+    Step(100);
+  }
+
+  StopLaunchFile(launchHandle);
+
+  ASSERT_TRUE(spawnedSuccessfully);
+  //ASSERT_TRUE(startedSuccessfully);
+}

--- a/mbzirc_ign/test/test_spawn_usv_maxspeed.cc
+++ b/mbzirc_ign/test/test_spawn_usv_maxspeed.cc
@@ -169,5 +169,4 @@ TEST_F(MBZIRCTestFixture, USVMaxSpeedTest)
   ASSERT_NEAR(currVel,  8 * 0.5144, 1e-2) << "final velocity exceeds 8 knots";
   ASSERT_LE(prevVel, currVel) << "Hydrodynamics is not being damped";
   ASSERT_LE(maxVel, 5) << "Model is moving too fast";
-  )
 }

--- a/mbzirc_ign/test/test_spawn_usv_maxspeed.cc
+++ b/mbzirc_ign/test/test_spawn_usv_maxspeed.cc
@@ -166,6 +166,6 @@ TEST_F(MBZIRCTestFixture, USVMaxSpeedTest)
   ASSERT_TRUE(spawnedSuccessfully) << "USV not spawned";
   ASSERT_TRUE(startedSuccessfully) << "Model did not start moving";
   /// wide tolerance thanks to surface plugin
-  ASSERT_NEAR(currVel,  8 * 0.5144, 1e-1) << "final velocity exceeds 8 knots";
+  ASSERT_NEAR(currVel,  8 * 0.5144, 1) << "final velocity exceeds 8 knots";
   ASSERT_LE(maxVel, 5) << "Model is moving too fast";
 }

--- a/mbzirc_ign/worlds/faster_than_realtime.sdf
+++ b/mbzirc_ign/worlds/faster_than_realtime.sdf
@@ -14,7 +14,7 @@
       filename="ignition-gazebo-user-commands-system"
       name="ignition::gazebo::systems::UserCommands">
     </plugin>
-<!--
+
     <scene>
       <sky></sky>
       <grid>false</grid>
@@ -35,7 +35,7 @@
       </attenuation>
       <direction>-0.5 0.1 -0.9</direction>
     </light>
--->
+
     <model name="ground_platform">
       <static>true</static>
       <pose>0 0 -1.5 0 0 0</pose>

--- a/mbzirc_ign/worlds/faster_than_realtime.sdf
+++ b/mbzirc_ign/worlds/faster_than_realtime.sdf
@@ -14,7 +14,6 @@
       filename="ignition-gazebo-user-commands-system"
       name="ignition::gazebo::systems::UserCommands">
     </plugin>
-
     <scene>
       <sky></sky>
       <grid>false</grid>

--- a/mbzirc_ign/worlds/faster_than_realtime.sdf
+++ b/mbzirc_ign/worlds/faster_than_realtime.sdf
@@ -14,6 +14,7 @@
       filename="ignition-gazebo-user-commands-system"
       name="ignition::gazebo::systems::UserCommands">
     </plugin>
+<!--
     <scene>
       <sky></sky>
       <grid>false</grid>
@@ -34,7 +35,7 @@
       </attenuation>
       <direction>-0.5 0.1 -0.9</direction>
     </light>
-
+-->
     <model name="ground_platform">
       <static>true</static>
       <pose>0 0 -1.5 0 0 0</pose>


### PR DESCRIPTION
This PR adds a limit to the USV thruster and some unit tests to test the limit. The USV model has also been made such that only the visual is rotated so that the hydrodynamics can be reasoned about. For derivation of the math see here: https://colab.research.google.com/drive/1xV0rw1rqBSU0RdVYTVUkHir7BHADQIWn?usp=sharing
