### PR TITLE
Pause Hydrodynamics

### DIFF
--- a/mbzirc_ign/src/SimpleHydrodynamics.cc
+++ b/mbzirc_ign/src/SimpleHydrodynamics.cc
@@ -186,10 +186,13 @@ void SimpleHydrodynamics::Configure(const Entity &_entity,
 
 //////////////////////////////////////////////////
 void SimpleHydrodynamics::PreUpdate(
-    const ignition::gazebo::UpdateInfo &/*_info*/,
+    const ignition::gazebo::UpdateInfo &_info,
     ignition::gazebo::EntityComponentManager &_ecm)
 {
   IGN_PROFILE("SimpleHydrodynamics::PreUpdate");
+
+  if (_info.paused)
+    return;
 
   if (!this->dataPtr->link.Valid(_ecm))
     return;


### PR DESCRIPTION
Noticed that hydrodynamics also is missing a pause check. This will lead to weird behaviour when the usv is moving and we pause the simulation.

Signed-off-by: Arjo Chakravarty <arjo@openrobotics.org>