### PR TITLE
Increase physics step size

### DIFF
--- a/mbzirc_ign/worlds/coast.sdf
+++ b/mbzirc_ign/worlds/coast.sdf
@@ -3,6 +3,11 @@
 <sdf version="1.6">
   <world name="coast.sdf">
 
+    <physics name="4ms" type="dart">
+      <max_step_size>0.004</max_step_size>
+      <real_time_factor>1.0</real_time_factor>
+    </physics>
+
     <gui fullscreen="0">
 
       <!-- 3D scene -->

--- a/mbzirc_ign/worlds/simple_demo.sdf
+++ b/mbzirc_ign/worlds/simple_demo.sdf
@@ -3,6 +3,11 @@
 <sdf version="1.6">
   <world name="simple_demo">
 
+    <physics name="4ms" type="dart">
+      <max_step_size>0.004</max_step_size>
+      <real_time_factor>1.0</real_time_factor>
+    </physics>
+
     <plugin
       filename="ignition-gazebo-physics-system"
       name="ignition::gazebo::systems::Physics">


### PR DESCRIPTION
Increased step size from 1ms to 4ms for performance reasons. Note 4ms is also the step size used in subt.

I didn't notice any unstable physics behavior. To verify update rate, you can spawn an UAV and monitor the `/tf` topic to see that it should now be  <= 250 Hz.

```bash
# launch simple demo world
ros2 launch ros_ign_gazebo ign_gazebo.launch.py ign_args:="-v 4 -r simple_demo.sdf"

# spawn a UAV
ros2 launch mbzirc_ign spawn.launch.py name:=quadrotor_1 world:=simple_demo model:=mbzirc_quadrotor type:=uav x:=0 y:=0 z:=1.05 R:=0 P:=0 Y:=0 slot0:=mbzirc_hd_camera

# monitor /tf topic publish rate
ros2 topic hz /tf
```

Signed-off-by: Ian Chen <ichen@osrfoundation.org>