### PR TITLE
Publish USV transforms

### DIFF
--- a/mbzirc_ign/launch/spawn.launch.py
+++ b/mbzirc_ign/launch/spawn.launch.py
@@ -417,10 +417,41 @@ def spawn_usv(context, model_path, world_name, model_name):
                   (right_joint_topic, 'right/thrust/joint/cmd_pos')]
   )
 
+  # pose
+  ros2_ign_pose_bridge = Node(
+      package='ros_ign_bridge',
+      executable='parameter_bridge',
+      output='screen',
+      arguments=['/model/' + model_name + '/pose@tf2_msgs/msg/TFMessage@ignition.msgs.Pose_V'],
+      remappings=[('/model/' + model_name +'/pose', 'pose')]
+  )
+
+  # pose static
+  ros2_ign_pose_static_bridge = Node(
+      package='ros_ign_bridge',
+      executable='parameter_bridge',
+      output='screen',
+      arguments=['/model/' + model_name + '/pose_static@tf2_msgs/msg/TFMessage@ignition.msgs.Pose_V'],
+      remappings=[('/model/' + model_name +'/pose_static', 'pose_static')]
+  )
+
+  # tf broadcaster
+  ros2_tf_broadcaster = Node(
+      package='mbzirc_ros',
+      executable='pose_tf_broadcaster',
+      output='screen',
+      parameters=[
+          {"world_frame": world_name}
+      ]
+  )
+
   group_action = GroupAction([
         PushRosNamespace(model_name),
         ros2_ign_thrust_bridge,
         ros2_ign_thrust_joint_bridge,
+        ros2_ign_pose_bridge,
+        ros2_ign_pose_static_bridge,
+        ros2_tf_broadcaster,
   ])
 
   handler = RegisterEventHandler(

--- a/mbzirc_ign/models/usv/model.sdf.erb
+++ b/mbzirc_ign/models/usv/model.sdf.erb
@@ -614,5 +614,18 @@ end
     <nRR>0.0</nRR>
   </plugin>
 
+  <!-- Publish robot state information -->
+  <plugin filename="libignition-gazebo-pose-publisher-system.so"
+    name="ignition::gazebo::systems::PosePublisher">
+    <publish_link_pose>true</publish_link_pose>
+    <publish_sensor_pose>true</publish_sensor_pose>
+    <publish_collision_pose>false</publish_collision_pose>
+    <publish_visual_pose>false</publish_visual_pose>
+    <publish_nested_model_pose>true</publish_nested_model_pose>
+    <use_pose_vector_msg>true</use_pose_vector_msg>
+    <static_publisher>true</static_publisher>
+    <static_update_frequency>1</static_update_frequency>
+  </plugin>
+
 </model>
 </sdf>

--- a/mbzirc_ign/models/wam-v/model.sdf.erb
+++ b/mbzirc_ign/models/wam-v/model.sdf.erb
@@ -347,5 +347,18 @@ end
     <nRR>0.0</nRR>
   </plugin>
 
+  <!-- Publish robot state information -->
+  <plugin filename="libignition-gazebo-pose-publisher-system.so"
+    name="ignition::gazebo::systems::PosePublisher">
+    <publish_link_pose>true</publish_link_pose>
+    <publish_sensor_pose>true</publish_sensor_pose>
+    <publish_collision_pose>false</publish_collision_pose>
+    <publish_visual_pose>false</publish_visual_pose>
+    <publish_nested_model_pose>true</publish_nested_model_pose>
+    <use_pose_vector_msg>true</use_pose_vector_msg>
+    <static_publisher>true</static_publisher>
+    <static_update_frequency>1</static_update_frequency>
+  </plugin>
+
 </model>
 </sdf>


### PR DESCRIPTION
Transforms for the USV model were missing. I added the pose publisher system to the USV models and bridged them to the `/tf` and `/tf_static` topics

After spawning a USV, you should now see the `tf` topics.

To test:

```bash
# launch the simple demo world
ros2 launch ros_ign_gazebo ign_gazebo.launch.py ign_args:="-v 4 -r simple_demo.sdf"

# spawn a USV
ros2 launch mbzirc_ign spawn.launch.py name:=usv world:=simple_demo model:=usv type:=usv x:=15 y:=0 z:=0.3 R:=0 P:=0 Y:=0

# make sure the `/tf` and `/tf_static` topics exist
ros2 topic list

# this generates frames.pdf
ros2 run tf2_tools view_frames

# view the TF tree using your favorite PDF viewer, e.g.
evince frames.pdf
```

![frames](https://user-images.githubusercontent.com/4000684/154162913-1ca69e5c-a7f9-4292-b6f5-d6a434f6f32e.png)



Signed-off-by: Ian Chen <ichen@osrfoundation.org>