### PR TITLE
Disable publishing model ground truth pose

### DIFF
--- a/mbzirc_ign/launch/spawn.launch.py
+++ b/mbzirc_ign/launch/spawn.launch.py
@@ -417,10 +417,41 @@ def spawn_usv(context, model_path, world_name, model_name):
                   (right_joint_topic, 'right/thrust/joint/cmd_pos')]
   )
 
+  # pose
+  ros2_ign_pose_bridge = Node(
+      package='ros_ign_bridge',
+      executable='parameter_bridge',
+      output='screen',
+      arguments=['/model/' + model_name + '/pose@tf2_msgs/msg/TFMessage@ignition.msgs.Pose_V'],
+      remappings=[('/model/' + model_name +'/pose', 'pose')]
+  )
+
+  # pose static
+  ros2_ign_pose_static_bridge = Node(
+      package='ros_ign_bridge',
+      executable='parameter_bridge',
+      output='screen',
+      arguments=['/model/' + model_name + '/pose_static@tf2_msgs/msg/TFMessage@ignition.msgs.Pose_V'],
+      remappings=[('/model/' + model_name +'/pose_static', 'pose_static')]
+  )
+
+  # tf broadcaster
+  ros2_tf_broadcaster = Node(
+      package='mbzirc_ros',
+      executable='pose_tf_broadcaster',
+      output='screen',
+      parameters=[
+          {"world_frame": world_name}
+      ]
+  )
+
   group_action = GroupAction([
         PushRosNamespace(model_name),
         ros2_ign_thrust_bridge,
         ros2_ign_thrust_joint_bridge,
+        ros2_ign_pose_bridge,
+        ros2_ign_pose_static_bridge,
+        ros2_tf_broadcaster,
   ])
 
   handler = RegisterEventHandler(

--- a/mbzirc_ign/models/mbzirc_fixed_wing/model.sdf.erb
+++ b/mbzirc_ign/models/mbzirc_fixed_wing/model.sdf.erb
@@ -52,5 +52,18 @@ end
       <start_on_motion>true</start_on_motion>
       <fix_issue_225>true</fix_issue_225>
     </plugin>
+
+    <plugin filename="libignition-gazebo-pose-publisher-system.so"
+      name="ignition::gazebo::systems::PosePublisher">
+      <publish_link_pose>true</publish_link_pose>
+      <publish_sensor_pose>true</publish_sensor_pose>
+      <publish_collision_pose>false</publish_collision_pose>
+      <publish_visual_pose>false</publish_visual_pose>
+      <publish_nested_model_pose>true</publish_nested_model_pose>
+      <publish_model_pose>false</publish_model_pose>
+      <use_pose_vector_msg>true</use_pose_vector_msg>
+      <static_publisher>true</static_publisher>
+      <static_update_frequency>1</static_update_frequency>
+    </plugin>
   </model>
 </sdf>

--- a/mbzirc_ign/models/mbzirc_hexrotor/model.sdf.erb
+++ b/mbzirc_ign/models/mbzirc_hexrotor/model.sdf.erb
@@ -224,6 +224,7 @@ end
       <publish_collision_pose>false</publish_collision_pose>
       <publish_visual_pose>false</publish_visual_pose>
       <publish_nested_model_pose>true</publish_nested_model_pose>
+      <publish_model_pose>false</publish_model_pose>
       <use_pose_vector_msg>true</use_pose_vector_msg>
       <static_publisher>true</static_publisher>
       <static_update_frequency>1</static_update_frequency>

--- a/mbzirc_ign/models/mbzirc_quadrotor/model.sdf.erb
+++ b/mbzirc_ign/models/mbzirc_quadrotor/model.sdf.erb
@@ -215,6 +215,7 @@ end
       <publish_collision_pose>false</publish_collision_pose>
       <publish_visual_pose>false</publish_visual_pose>
       <publish_nested_model_pose>true</publish_nested_model_pose>
+      <publish_model_pose>false</publish_model_pose>
       <use_pose_vector_msg>true</use_pose_vector_msg>
       <static_publisher>true</static_publisher>
       <static_update_frequency>1</static_update_frequency>

--- a/mbzirc_ign/models/usv/model.sdf.erb
+++ b/mbzirc_ign/models/usv/model.sdf.erb
@@ -622,6 +622,7 @@ end
     <publish_collision_pose>false</publish_collision_pose>
     <publish_visual_pose>false</publish_visual_pose>
     <publish_nested_model_pose>true</publish_nested_model_pose>
+    <publish_model_pose>false</publish_model_pose>
     <use_pose_vector_msg>true</use_pose_vector_msg>
     <static_publisher>true</static_publisher>
     <static_update_frequency>1</static_update_frequency>

--- a/mbzirc_ign/models/usv/model.sdf.erb
+++ b/mbzirc_ign/models/usv/model.sdf.erb
@@ -614,5 +614,18 @@ end
     <nRR>0.0</nRR>
   </plugin>
 
+  <!-- Publish robot state information -->
+  <plugin filename="libignition-gazebo-pose-publisher-system.so"
+    name="ignition::gazebo::systems::PosePublisher">
+    <publish_link_pose>true</publish_link_pose>
+    <publish_sensor_pose>true</publish_sensor_pose>
+    <publish_collision_pose>false</publish_collision_pose>
+    <publish_visual_pose>false</publish_visual_pose>
+    <publish_nested_model_pose>true</publish_nested_model_pose>
+    <use_pose_vector_msg>true</use_pose_vector_msg>
+    <static_publisher>true</static_publisher>
+    <static_update_frequency>1</static_update_frequency>
+  </plugin>
+
 </model>
 </sdf>

--- a/mbzirc_ign/models/wam-v/model.sdf.erb
+++ b/mbzirc_ign/models/wam-v/model.sdf.erb
@@ -355,6 +355,7 @@ end
     <publish_collision_pose>false</publish_collision_pose>
     <publish_visual_pose>false</publish_visual_pose>
     <publish_nested_model_pose>true</publish_nested_model_pose>
+    <publish_model_pose>false</publish_model_pose>
     <use_pose_vector_msg>true</use_pose_vector_msg>
     <static_publisher>true</static_publisher>
     <static_update_frequency>1</static_update_frequency>

--- a/mbzirc_ign/models/wam-v/model.sdf.erb
+++ b/mbzirc_ign/models/wam-v/model.sdf.erb
@@ -347,5 +347,18 @@ end
     <nRR>0.0</nRR>
   </plugin>
 
+  <!-- Publish robot state information -->
+  <plugin filename="libignition-gazebo-pose-publisher-system.so"
+    name="ignition::gazebo::systems::PosePublisher">
+    <publish_link_pose>true</publish_link_pose>
+    <publish_sensor_pose>true</publish_sensor_pose>
+    <publish_collision_pose>false</publish_collision_pose>
+    <publish_visual_pose>false</publish_visual_pose>
+    <publish_nested_model_pose>true</publish_nested_model_pose>
+    <use_pose_vector_msg>true</use_pose_vector_msg>
+    <static_publisher>true</static_publisher>
+    <static_update_frequency>1</static_update_frequency>
+  </plugin>
+
 </model>
 </sdf>


### PR DESCRIPTION
Depends on https://github.com/ignitionrobotics/ign-gazebo/pull/1342

We disabled publishing model ground truth pose data in the TF broadcaster by filtering out all incoming pose with the world name frame id [here](https://github.com/osrf/mbzirc/blob/main/mbzirc_ros/src/pose_tf_broadcaster.cc#L83-L86). However, it was found that the ground truth data is also published to the `/<namespace>/pose_static` ros2 topic. 

This PR disables publishing top level model pose by configuring the pose-publisher system to publish only nested model pose by setting the parameter `publish_model_pose` (added in https://github.com/ignitionrobotics/ign-gazebo/pull/1342) to false.

to test:

```bash
# launch simple_demo world
ros2 launch ros_ign_gazebo ign_gazebo.launch.py ign_args:="-v 4 -r simple_demo.sdf"

# spawn a USV
ros2 launch mbzirc_ign spawn.launch.py name:=usv world:=simple_demo model:=usv type:=usv x:=15 y:=0 z:=0.3 R:=0 P:=0 Y:=0

# echo the /<namespace>/pose_static topic and make sure no msgs with frame_id: simple_demo is published
ros2 topic echo /usv/pose_static
```

Without the changes in this PR, the `/usv/pose_static` topic will include pose msgs with data containing ground truth, e.g.

```
---
- header:
    stamp:
      sec: 16
      nanosec: 356000000
    frame_id: simple_demo
  child_frame_id: usv
  transform:
    translation:
      x: 14.977185921308822
      y: -0.00610262396634332
      z: 0.4292703261731566
    rotation:
      x: 0.004624142421080181
      y: -0.00269840838046915
      z: 5.526672719098322e-05
      w: 0.9999856663196082
---
```






Signed-off-by: Ian Chen <ichen@osrfoundation.org>