### PR TITLE
Support mounting sensors on fixed wing UAV

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ See Installation instructions for:
     git clone https://github.com/osrf/mbzirc.git
     ```
 
+1. Install dependencies using [rosdep](https://docs.ros.org/en/galactic/Installation/Ubuntu-Install-Binary.html#installing-and-initializing-rosdep)
+
+    ```
+    cd ~/mbzirc_ws
+    rosdep install -r --from-paths src -i -y --rosdistro galactic
+    ```
+
 1. Build the workspace
 
     ```

--- a/mbzirc_ign/models/mbzirc_fixed_wing/model.sdf.erb
+++ b/mbzirc_ign/models/mbzirc_fixed_wing/model.sdf.erb
@@ -1,9 +1,76 @@
 <%
 if !defined?(name) || name== nil || name.empty?
-  $model_name = 'mbzirc_quadrotor'
+  $model_name = 'mbzirc_fixed_wing'
 else
   $model_name = name
 end
+
+$slot0_payload = nil
+$slot0_rpy = '0 0 0'
+$slot1_payload = nil
+$slot1_rpy = '0 0 0'
+$slot2_payload = nil
+$slot2_rpy = '0 0 0'
+$slot3_payload = nil
+$slot3_rpy = '0 0 0'
+$slot4_payload = nil
+$slot4_rpy = '0 0 0'
+$slot5_payload = nil
+$slot5_rpy = '0 0 0'
+$slot6_payload = nil
+$slot6_rpy = '0 0 0'
+$slot7_payload = nil
+$slot7_rpy = '0 0 0'
+
+if defined?(slot0)
+  $slot0_payload = slot0
+end
+if defined?(slot0_pos)
+  $slot0_rpy = slot0_pos
+end
+if defined?(slot1)
+  $slot1_payload = slot1
+end
+if defined?(slot1_pos)
+  $slot1_rpy = slot1_pos
+end
+if defined?(slot2)
+  $slot2_payload = slot2
+end
+if defined?(slot2_pos)
+  $slot2_rpy = slot2_pos
+end
+if defined?(slot3)
+  $slot3_payload = slot3
+end
+if defined?(slot3_pos)
+  $slot3_rpy = slot3_pos
+end
+if defined?(slot4)
+  $slot4_payload = slot4
+end
+if defined?(slot4_pos)
+  $slot4_rpy = slot4_pos
+end
+if defined?(slot5)
+  $slot5_payload = slot5
+end
+if defined?(slot5_pos)
+  $slot5_rpy = slot5_pos
+end
+if defined?(slot6)
+  $slot6_payload = slot6
+end
+if defined?(slot6_pos)
+  $slot6_rpy = slot6_pos
+end
+if defined?(slot7)
+  $slot7_payload = slot7
+end
+if defined?(slot7_pos)
+  $slot7_rpy = slot7_pos
+end
+
 %>
 
 <?xml version="1.0"?>
@@ -14,6 +81,135 @@ end
     <include merge="true">
       <uri>model://mbzirc_fixed_wing_base</uri>
     </include>
+
+    <% if $slot0_payload != nil%>
+    <!-- Payload slot0 -->
+    <include>
+      <name>sensor_0</name>
+      <uri>model://sensors/<%= $slot0_payload%></uri>
+      <placement_frame>mount_point</placement_frame>
+      <pose relative_to="slot_0" degrees="true">
+        0 0 0 <%= $slot0_rpy%>
+      </pose>
+    </include>
+
+    <joint name="slot_0_joint" type="fixed">
+      <parent>slot_0</parent>
+      <child>sensor_0::mount_point</child>
+    </joint>
+    <% end %>
+    <% if $slot1_payload != nil%>
+    <!-- Payload slot1 -->
+    <include>
+      <name>sensor_1</name>
+      <uri>model://sensors/<%= $slot1_payload%></uri>
+      <placement_frame>mount_point</placement_frame>
+      <pose relative_to="slot_1" degrees="true">
+        0 0 0 <%= $slot1_rpy%>
+      </pose>
+    </include>
+
+    <joint name="slot_1_joint" type="fixed">
+      <parent>slot_1</parent>
+      <child>sensor_1::mount_point</child>
+    </joint>
+    <% end %>
+    <% if $slot2_payload != nil%>
+    <!-- Payload slot2 -->
+    <include>
+      <name>sensor_2</name>
+      <uri>model://sensors/<%= $slot2_payload%></uri>
+      <placement_frame>mount_point</placement_frame>
+      <pose relative_to="slot_2" degrees="true">
+        0 0 0 <%= $slot2_rpy%>
+      </pose>
+    </include>
+
+    <joint name="slot_2_joint" type="fixed">
+      <parent>slot_2</parent>
+      <child>sensor_2::mount_point</child>
+    </joint>
+    <% end %>
+    <% if $slot3_payload != nil%>
+    <!-- Payload slot3 -->
+    <include>
+      <name>sensor_3</name>
+      <uri>model://sensors/<%= $slot3_payload%></uri>
+      <placement_frame>mount_point</placement_frame>
+      <pose relative_to="slot_3" degrees="true">
+        0 0 0 <%= $slot3_rpy%>
+      </pose>
+    </include>
+
+    <joint name="slot_3_joint" type="fixed">
+      <parent>slot_3</parent>
+      <child>sensor_3::mount_point</child>
+    </joint>
+    <% end %>
+    <% if $slot4_payload != nil%>
+    <!-- Payload slot4 -->
+    <include>
+      <name>sensor_4</name>
+      <uri>model://sensors/<%= $slot4_payload%></uri>
+      <placement_frame>mount_point</placement_frame>
+      <pose relative_to="slot_4" degrees="true">
+        0 0 0 <%= $slot4_rpy%>
+      </pose>
+    </include>
+
+    <joint name="slot_4_joint" type="fixed">
+      <parent>slot_4</parent>
+      <child>sensor_4::mount_point</child>
+    </joint>
+    <% end %>
+    <% if $slot5_payload != nil%>
+    <!-- Payload slot5 -->
+    <include>
+      <name>sensor_5</name>
+      <uri>model://sensors/<%= $slot5_payload%></uri>
+      <placement_frame>mount_point</placement_frame>
+      <pose relative_to="slot_5" degrees="true">
+        0 0 0 <%= $slot5_rpy%>
+      </pose>
+    </include>
+
+    <joint name="slot_5_joint" type="fixed">
+      <parent>slot_5</parent>
+      <child>sensor_5::mount_point</child>
+    </joint>
+    <% end %>
+    <% if $slot6_payload != nil%>
+    <!-- Payload slot6 -->
+    <include>
+      <name>sensor_6</name>
+      <uri>model://sensors/<%= $slot6_payload%></uri>
+      <placement_frame>mount_point</placement_frame>
+      <pose relative_to="slot_6" degrees="true">
+        0 0 0 <%= $slot6_rpy%>
+      </pose>
+    </include>
+
+    <joint name="slot_6_joint" type="fixed">
+      <parent>slot_6</parent>
+      <child>sensor_6::mount_point</child>
+    </joint>
+    <% end %>
+    <% if $slot7_payload != nil%>
+    <!-- Payload slot7 -->
+    <include>
+      <name>sensor_7</name>
+      <uri>model://sensors/<%= $slot7_payload%></uri>
+      <placement_frame>mount_point</placement_frame>
+      <pose relative_to="slot_7" degrees="true">
+        0 0 0 <%= $slot7_rpy%>
+      </pose>
+    </include>
+
+    <joint name="slot_7_joint" type="fixed">
+      <parent>slot_7</parent>
+      <child>sensor_7::mount_point</child>
+    </joint>
+    <% end %>
 
     <!-- Joints -->
     <plugin

--- a/mbzirc_ign/models/mbzirc_fixed_wing_base/model.sdf
+++ b/mbzirc_ign/models/mbzirc_fixed_wing_base/model.sdf
@@ -174,13 +174,27 @@
     facing slightly upwards-->
     <link name="skid">
       <pose>0 -0.3 -0.1 0 0 0</pose>
-      <!--<visual name="visual">
+      <inertial>
+        <pose>0 0 0 0 0 0</pose>
+        <mass>0.1</mass>
+        <inertia>
+          <ixx>0.00016667</ixx>
+          <ixy>0</ixy>
+          <iyy>0.00016667</iyy>
+          <ixz>0</ixz>
+          <iyz>0</iyz>
+          <izz>0.00016667</izz>
+        </inertia>
+      </inertial>
+      <!--
+      <visual name="visual">
         <geometry>
           <sphere>
             <radius>0.3</radius>
           </sphere>
         </geometry>
-      </visual>-->
+      </visual>
+      -->
       <collision name="collision">
         <geometry>
           <sphere>
@@ -393,5 +407,142 @@
       <link_name>propeller</link_name>
     </plugin>
 
+    <!-- Front payload slot -->
+    <frame name="slot_0">
+      <pose>0.0 -0.2 -0.03 0 0 -1.5708</pose>
+    </frame>
+
+    <!-- Rear payload slot -->
+    <frame name="slot_1">
+      <pose>0.0 0.1 0.0 0 0 1.5708</pose>
+    </frame>
+
+    <!-- Top payload slot -->
+    <frame name="slot_2">
+      <pose>0.0 0 0.03 0 -1.57 -1.5708</pose>
+    </frame>
+
+    <!-- Bottom payload slot -->
+    <frame name="slot_3">
+      <pose>0.0 0 -0.05 0 1.57 -1.5708</pose>
+    </frame>
+
+    <!-- Left payload slot -->
+    <frame name="slot_4">
+      <pose>0.08 0.0 -0.03 0 0 0</pose>
+    </frame>
+
+    <!-- Right payload slot -->
+    <frame name="slot_5">
+      <pose>-0.08 0.0 -0.03 0 0 3.14159</pose>
+    </frame>
+
+    <!-- Bottom left payload slot -->
+    <frame name="slot_6">
+      <pose>0.05 0 -0.05 0 1.5708 -1.5708</pose>
+    </frame>
+
+    <!-- Bottom right payload slot -->
+    <frame name="slot_7">
+      <pose>-0.05 0.0 -0.05 0 1.5708 -1.5708</pose>
+    </frame>
+
+    <!-- uncomment to debug sensor slot frames -->
+    <!--
+    <link name="debug_link">
+      <visual name="sensor_slot0">
+        <pose relative_to="slot_0">0 0 0 0 0 0</pose>
+        <geometry>
+          <box>
+            <size>0.01 0.01 0.01</size>
+          </box>
+        </geometry>
+        <material>
+          <diffuse>0.0 1 0 1</diffuse>
+        </material>
+      </visual>
+      <visual name="sensor_slot1">
+        <pose relative_to="slot_1">0 0 0 0 0 0</pose>
+        <geometry>
+          <box>
+            <size>0.01 0.01 0.01</size>
+          </box>
+        </geometry>
+        <material>
+          <diffuse>0.0 1 0 1</diffuse>
+        </material>
+      </visual>
+      <visual name="sensor_slot2">
+        <pose relative_to="slot_2">0 0 0 0 0 0</pose>
+        <geometry>
+          <box>
+            <size>0.01 0.01 0.01</size>
+          </box>
+        </geometry>
+        <material>
+          <diffuse>0.0 1 0 1</diffuse>
+        </material>
+      </visual>
+      <visual name="sensor_slot3">
+        <pose relative_to="slot_3">0 0 0 0 0 0</pose>
+        <geometry>
+          <box>
+            <size>0.01 0.01 0.01</size>
+          </box>
+        </geometry>
+        <material>
+          <diffuse>0.0 1 0 1</diffuse>
+        </material>
+      </visual>
+      <visual name="sensor_slot4">
+        <pose relative_to="slot_4">0 0 0 0 0 0</pose>
+        <geometry>
+          <box>
+            <size>0.01 0.01 0.01</size>
+          </box>
+        </geometry>
+        <material>
+          <diffuse>0.0 1 0 1</diffuse>
+        </material>
+      </visual>
+      <visual name="sensor_slot5">
+        <pose relative_to="slot_5">0 0 0 0 0 0</pose>
+        <geometry>
+          <box>
+            <size>0.01 0.01 0.01</size>
+          </box>
+        </geometry>
+        <material>
+          <diffuse>0.0 1 0 1</diffuse>
+        </material>
+      </visual>
+      <visual name="sensor_slot6">
+        <pose relative_to="slot_6">0 0 0 0 0 0</pose>
+        <geometry>
+          <box>
+            <size>0.01 0.01 0.01</size>
+          </box>
+        </geometry>
+        <material>
+          <diffuse>0.0 1 0 1</diffuse>
+        </material>
+      </visual>
+      <visual name="sensor_slot7">
+        <pose relative_to="slot_7">0 0 0 0 0 0</pose>
+        <geometry>
+          <box>
+            <size>0.01 0.01 0.01</size>
+          </box>
+        </geometry>
+        <material>
+          <diffuse>0.0 1 0 1</diffuse>
+        </material>
+      </visual>
+    </link>
+    <joint name="debug_link_joint" type="fixed">
+      <child>debug_link</child>
+      <parent>wing</parent>
+    </joint>
+    -->
   </model>
 </sdf>

--- a/mbzirc_ign/worlds/empty_platform.sdf
+++ b/mbzirc_ign/worlds/empty_platform.sdf
@@ -3,6 +3,12 @@
 <sdf version="1.6">
   <world name="empty_platform">
 
+    <physics name="4ms" type="dart">
+      <max_step_size>0.004</max_step_size>
+      <real_time_factor>1.0</real_time_factor>
+    </physics>
+
+
     <plugin
       filename="ignition-gazebo-physics-system"
       name="ignition::gazebo::systems::Physics">


### PR DESCRIPTION
Changes:
* Added sensor mount points
* tweaked README.md instructions and added a note to run `rosdep` to make sure the user has mavros package dependency

To test:

```
# launch simple_demo world:
ros2 launch ros_ign_gazebo ign_gazebo.launch.py ign_args:="-v 4 -r simple_demo.sdf"

# spawn fixed wing UAV with all sensor slots mounted with an hd camera:
ros2 launch mbzirc_ign spawn.launch.py name:=zephyr world:=simple_demo model:=mbzirc_fixed_wing type:=uav x:=0 y:=0 z:=4 slot0:=mbzirc_hd_camera  slot1:=mbzirc_hd_camera slot2:=mbzirc_hd_camera slot3:=mbzirc_hd_camera slot4:=mbzirc_hd_camera slot5:=mbzirc_hd_camera slot6:=mbzirc_hd_camera slot7:=mbzirc_hd_camera
```

Then use the `Image Display` ign-gazebo GUI plugin to check all camera views

Signed-off-by: Ian Chen <ichen@osrfoundation.org>