### PR TITLE
Support validating target reports through image stream

### DIFF
--- a/mbzirc_ign/models/mbzirc_quadrotor/model.sdf.erb
+++ b/mbzirc_ign/models/mbzirc_quadrotor/model.sdf.erb
@@ -75,6 +75,7 @@ end
 <?xml version="1.0"?>
 <sdf version='1.9'>
   <model name="<%= $model_name%>">
+    <static>true</static>
 
     <!-- Platform base model-->
     <include merge="true">

--- a/mbzirc_ign/models/mbzirc_quadrotor/model.sdf.erb
+++ b/mbzirc_ign/models/mbzirc_quadrotor/model.sdf.erb
@@ -75,7 +75,6 @@ end
 <?xml version="1.0"?>
 <sdf version='1.9'>
   <model name="<%= $model_name%>">
-    <static>true</static>
 
     <!-- Platform base model-->
     <include merge="true">

--- a/mbzirc_ign/src/GameLogicPlugin.cc
+++ b/mbzirc_ign/src/GameLogicPlugin.cc
@@ -429,10 +429,16 @@ class mbzirc::GameLogicPluginPrivate
   /// This variable is used later when validating reports of target objects.
   public: std::string currentTargetVessel;
 
-
+  /// \brief A set of target vessel visuals
   public: std::set<rendering::VisualPtr> targetVesselVisuals;
+
+  /// \brief A map of target vessel name and the small target object visuals
+  /// on the vessel
   public: std::map<std::string, std::set<rendering::VisualPtr>>
       targetSmallObjectVisuals;
+
+  /// \brief A map of target vessel name and the large target object visuals
+  /// on the vessel
   public: std::map<std::string, std::set<rendering::VisualPtr>>
       targetLargeObjectVisuals;
 

--- a/mbzirc_ign/src/GameLogicPlugin.cc
+++ b/mbzirc_ign/src/GameLogicPlugin.cc
@@ -96,10 +96,10 @@ class mbzirc::GameLogicPluginPrivate
     public: std::string type;
 
     /// \brief Image x position
-    public: double x = 0;
+    public: unsigned int x = 0;
 
     /// \brief Image y position
-    public: double y = 0;
+    public: unsigned int y = 0;
   };
 
   public: enum PenaltyType
@@ -1186,8 +1186,8 @@ bool GameLogicPluginPrivate::OnTargetStreamReport(
   }
 
   std::string type = _req.data(0);
-  double x = std::stof(_req.data(1));
-  double y = std::stof(_req.data(2));
+  unsigned int x = std::stoul(_req.data(1));
+  unsigned int y = std::stoul(_req.data(2));
 
   TargetInStream tis;
   tis.type = type;

--- a/mbzirc_ign/test/test_game_logic.cc
+++ b/mbzirc_ign/test/test_game_logic.cc
@@ -196,19 +196,15 @@ TEST_F(MBZIRCTestFixture, GameLogicPhase)
   ignition::transport::Node node;
 
   // Run clock callback to keep track of current competition state
-  std::mutex runClockMutex;
+  std::mutex phaseMutex;
   std::string phaseData;
-  std::function<void(const ignition::msgs::Clock &_msg)> runClockCb =
-    [&](const ignition::msgs::Clock &_msg)
+  std::function<void(const ignition::msgs::StringMsg &_msg)> phaseCb =
+    [&](const ignition::msgs::StringMsg &_msg)
     {
-      std::lock_guard<std::mutex> lock(runClockMutex);
-      EXPECT_EQ(1, _msg.header().data_size());
-      auto data = _msg.header().data(0);
-      EXPECT_EQ(1, data.value_size());
-      EXPECT_EQ("phase", data.key());
-      phaseData = data.value(0);
+      std::lock_guard<std::mutex> lock(phaseMutex);
+      phaseData = _msg.data();
     };
-  node.Subscribe("/mbzirc/run_clock", runClockCb);
+  node.Subscribe("/mbzirc/phase", phaseCb);
 
   // verify that initial phase is "setup"
   int sleep = 0;
@@ -218,7 +214,7 @@ TEST_F(MBZIRCTestFixture, GameLogicPhase)
   {
     std::this_thread::sleep_for(1000ms);
     Step(10);
-    std::lock_guard<std::mutex> lock(runClockMutex);
+    std::lock_guard<std::mutex> lock(phaseMutex);
     reachedPhase = phaseData == "setup";
   }
   EXPECT_EQ("setup", phaseData);
@@ -236,17 +232,17 @@ TEST_F(MBZIRCTestFixture, GameLogicPhase)
     EXPECT_TRUE(rep.data());
   }
 
-  // check that phase is now "run"
+  // check that phase is now "started"
   sleep = 0;
   reachedPhase = false;
   while(!reachedPhase && sleep++ < maxSleep)
   {
     std::this_thread::sleep_for(1000ms);
     Step(10);
-    std::lock_guard<std::mutex> lock(runClockMutex);
-    reachedPhase = phaseData == "run";
+    std::lock_guard<std::mutex> lock(phaseMutex);
+    reachedPhase = phaseData == "started";
   }
-  EXPECT_EQ("run", phaseData);
+  EXPECT_EQ("started", phaseData);
 
   // publish finish event
   {
@@ -268,7 +264,7 @@ TEST_F(MBZIRCTestFixture, GameLogicPhase)
   {
     std::this_thread::sleep_for(1000ms);
     Step(10);
-    std::lock_guard<std::mutex> lock(runClockMutex);
+    std::lock_guard<std::mutex> lock(phaseMutex);
     reachedPhase = phaseData == "finished";
   }
   EXPECT_EQ("finished", phaseData);
@@ -492,6 +488,7 @@ TEST_F(MBZIRCTestFixture, GameLogicBoundaryPenalty)
                != std::string::npos &&
              eventsBuffer.str().find("type: exceed_boundary_2")
                == std::string::npos;
+    Step(1);
   }
   EXPECT_TRUE(logged);
 
@@ -526,6 +523,7 @@ TEST_F(MBZIRCTestFixture, GameLogicBoundaryPenalty)
                != std::string::npos &&
              eventsBuffer.str().find("type: exceed_boundary_2")
                == std::string::npos;
+    Step(1);
   }
   EXPECT_TRUE(logged);
 
@@ -559,6 +557,7 @@ TEST_F(MBZIRCTestFixture, GameLogicBoundaryPenalty)
                != std::string::npos &&
              eventsBuffer.str().find("type: exceed_boundary_2")
                != std::string::npos;
+    Step(1);
   }
   EXPECT_TRUE(logged);
 
@@ -705,6 +704,20 @@ TEST_F(MBZIRCTestFixture, GameLogicTargetReport)
 
   ASSERT_TRUE(spawnedSuccessfully);
 
+  // create callback for verifying competition phase
+  std::string phase;
+  ignition::transport::Node node;
+  std::mutex phaseMutex;
+  auto cb = [&](const ignition::msgs::StringMsg &_msg) -> void
+  {
+    std::lock_guard<std::mutex> lock(phaseMutex);
+    phase = _msg.data();
+  };
+
+  // Subscribe to a topic by registering a callback.
+  auto cbFunc = std::function<void(const ignition::msgs::StringMsg &)>(cb);
+  EXPECT_TRUE(node.Subscribe("/mbzirc/phase", cbFunc));
+
   std::string logPath = "mbzirc_logs";
   std::string eventsLogPath =
       ignition::common::joinPaths(logPath, "events.yml");
@@ -756,9 +769,20 @@ TEST_F(MBZIRCTestFixture, GameLogicTargetReport)
   }
   EXPECT_TRUE(logged);
 
-  int startTime = simTimeSec;
+  sleep = 0;
+  bool phaseReached = false;
+  while(!phaseReached && sleep++ < maxSleep)
+  {
+    {
+      std::lock_guard<std::mutex> lock(phaseMutex);
+      phaseReached = phase == "started";
+    }
+    Step(1);
+    std::this_thread::sleep_for(1000ms);
+  }
+  EXPECT_TRUE(phaseReached);
 
-  ignition::transport::Node node;
+  int startTime = simTimeSec;
 
   // start stream
   {
@@ -978,6 +1002,19 @@ TEST_F(MBZIRCTestFixture, GameLogicTargetReport)
     EXPECT_NEAR(expectedScore, score, 1);
   }
 
+  sleep = 0;
+  phaseReached = false;
+  while(!phaseReached && sleep++ < maxSleep)
+  {
+    {
+      std::lock_guard<std::mutex> lock(phaseMutex);
+      phaseReached = phase == "vessel_id_success";
+    }
+    Step(1);
+    std::this_thread::sleep_for(1000ms);
+  }
+  EXPECT_TRUE(phaseReached);
+
   // advance time
   Step(100);
 
@@ -1141,6 +1178,19 @@ TEST_F(MBZIRCTestFixture, GameLogicTargetReport)
   // advance time
   Step(100);
 
+  sleep = 0;
+  phaseReached = false;
+  while(!phaseReached && sleep++ < maxSleep)
+  {
+    {
+      std::lock_guard<std::mutex> lock(phaseMutex);
+      phaseReached = phase == "small_object_id_success";
+    }
+    Step(1);
+    std::this_thread::sleep_for(1000ms);
+  }
+  EXPECT_TRUE(phaseReached);
+
   moveAboveTargetSmallObjectDone = true;
   moveAboveTargetLargeObject = true;
   Step(20);
@@ -1301,6 +1351,20 @@ TEST_F(MBZIRCTestFixture, GameLogicTargetReport)
   }
 
   moveAboveTargetLargeObjectDone = true;
+
+  sleep = 0;
+  phaseReached = false;
+  while(!phaseReached && sleep++ < maxSleep)
+  {
+    {
+      std::lock_guard<std::mutex> lock(phaseMutex);
+      phaseReached = phase == "large_object_id_success";
+    }
+    Step(1);
+    std::this_thread::sleep_for(1000ms);
+  }
+  EXPECT_TRUE(phaseReached);
+
 
   StopLaunchFile(launchHandle);
   ignition::common::removeAll(logPath);

--- a/mbzirc_ign/test/test_game_logic.cc
+++ b/mbzirc_ign/test/test_game_logic.cc
@@ -649,7 +649,6 @@ TEST_F(MBZIRCTestFixture, GameLogicTargetReport)
       model.SetWorldPoseCmd(_ecm, ignition::math::Pose3d(
           pose.Pos() + ignition::math::Vector3d(0, 0, 1),
           ignition::math::Quaterniond::Identity));
-      moveAboveTargetSmallObjectDone = true;
       static bool output = false;
       if (!output)
       {
@@ -668,7 +667,6 @@ TEST_F(MBZIRCTestFixture, GameLogicTargetReport)
       model.SetWorldPoseCmd(_ecm, ignition::math::Pose3d(
           pose.Pos() + ignition::math::Vector3d(0, 0, 1),
           ignition::math::Quaterniond::Identity));
-      moveAboveTargetLargeObjectDone = true;
       static bool output = false;
       if (!output)
       {

--- a/mbzirc_ign/worlds/empty_platform.sdf
+++ b/mbzirc_ign/worlds/empty_platform.sdf
@@ -93,5 +93,12 @@
       </link>
     </model>
 
+    <!-- The MBZIRC competition logic plugin -->
+    <plugin filename="libGameLogicPlugin.so"
+            name="mbzirc::GameLogicPlugin">
+      <run_duration_seconds>60</run_duration_seconds>
+      <setup_duration_seconds>30</setup_duration_seconds>
+    </plugin>
+
   </world>
 </sdf>

--- a/mbzirc_ign/worlds/faster_than_realtime.sdf
+++ b/mbzirc_ign/worlds/faster_than_realtime.sdf
@@ -4,16 +4,29 @@
 -->
 <sdf version="1.6">
   <world name="faster_than_realtime">
+    <physics name="4ms" type="dart">
+      <max_step_size>0.004</max_step_size>
+      <real_time_factor>0.0</real_time_factor>
+    </physics>
+
     <plugin
       filename="ignition-gazebo-physics-system"
       name="ignition::gazebo::systems::Physics">
-      <max_step_size>0.02</max_step_size>
-      <real_time_factor>0</real_time_factor>
     </plugin>
     <plugin
       filename="ignition-gazebo-user-commands-system"
       name="ignition::gazebo::systems::UserCommands">
     </plugin>
+    <plugin
+      filename="ignition-gazebo-sensors-system"
+      name="ignition::gazebo::systems::Sensors">
+      <render_engine>ogre2</render_engine>
+    </plugin>
+    <plugin
+      filename="ignition-gazebo-scene-broadcaster-system"
+      name="ignition::gazebo::systems::SceneBroadcaster">
+    </plugin>
+
     <scene>
       <sky></sky>
       <grid>false</grid>
@@ -56,24 +69,10 @@
             <ambient>0.8 0.8 0.8 1</ambient>
             <diffuse>0.8 0.8 0.8 1</diffuse>
             <specular>0.8 0.8 0.8 1</specular>
-              <pbr>
-                  <metal>
-                      <albedo_map>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Cave Straight Type A/tip/files/materials/textures/Gravel_Albedo.jpg</albedo_map>
-                      <normal_map>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Cave Straight Type A/tip/files/materials/textures/Gravel_Normal.jpg</normal_map>
-                      <roughness_map>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Cave Straight Type A/tip/files/materials/textures/Gravel_Roughness.jpg</roughness_map>
-                  </metal>
-              </pbr>
           </material>
         </visual>
       </link>
     </model>
-
-    <include>
-      <pose>0 0 5 0 0 0</pose>
-      <uri>
-        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Fortress heightmap
-      </uri>
-    </include>
 
     <model name="heightmap_bounds">
       <static>true</static>
@@ -129,6 +128,127 @@
       </uri>
     </include>
 
+    <include>
+      <name>Vessel A</name>
+      <pose>25 25 0.3 0 0.0 -1.0</pose>
+      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Vessel A</uri>
+      <plugin
+        filename="libSurface.so"
+        name="ignition::gazebo::systems::Surface">
+        <link_name>link</link_name>
+        <vehicle_length>6</vehicle_length>
+        <vehicle_width>3.3</vehicle_width>
+        <hull_radius>0.27</hull_radius>
+        <fluid_level>0.45</fluid_level>
+
+        <!-- Waves -->
+        <wavefield>
+          <size>1000 1000</size>
+          <cell_count>50 50</cell_count>
+          <wave>
+            <model>PMS</model>
+            <period>5</period>
+            <number>3</number>
+            <scale>1.5</scale>
+            <gain>0.3</gain>
+            <direction>1 0</direction>
+            <angle>0.4</angle>
+            <tau>2.0</tau>
+            <amplitude>0.0</amplitude>
+            <steepness>0.0</steepness>
+          </wave>
+        </wavefield>
+      </plugin>
+
+      <plugin
+        filename="libSimpleHydrodynamics.so"
+        name="ignition::gazebo::systems::SimpleHydrodynamics">
+        <link_name>link</link_name>
+        <!-- Added mass -->
+        <xDotU>0.0</xDotU>
+        <yDotV>0.0</yDotV>
+        <nDotR>0.0</nDotR>
+        <!-- Linear and quadratic drag -->
+        <xU>51.3</xU>
+        <xUU>72.4</xUU>
+        <yV>40.0</yV>
+        <yVV>0.0</yVV>
+        <zW>500.0</zW>
+        <kP>50.0</kP>
+        <mQ>50.0</mQ>
+        <nR>400.0</nR>
+        <nRR>0.0</nRR>
+      </plugin>
+    </include>
+
+    <model name="small_box_a">
+      <pose>24 26.5 0.5 0 0 0</pose>
+      <link name="link">
+        <inertial>
+          <mass>1</mass>
+          <inertia>
+          <ixx>0.0066667</ixx>
+          <ixy>0.0</ixy>
+          <ixz>0.0</ixz>
+          <iyy>0.0066667</iyy>
+          <iyz>0.0</iyz>
+          <izz>0.0066667</izz>
+          </inertia>
+        </inertial>
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>0.2 0.2 0.2</size>
+            </box>
+          </geometry>
+          <material>
+            <diffuse>0 0 1</diffuse>
+          </material>
+        </visual>
+        <collision name="collision">
+          <geometry>
+            <box>
+              <size>0.2 0.2 0.2</size>
+            </box>
+          </geometry>
+        </collision>
+      </link>
+    </model>
+
+    <model name="large_box_a">
+      <pose>24.9 24.85 0.65 0 0 0</pose>
+      <link name="link">
+        <inertial>
+          <mass>10</mass>
+          <inertia>
+          <ixx>0.26667</ixx>
+          <ixy>0.0</ixy>
+          <ixz>0.0</ixz>
+          <iyy>0.26667</iyy>
+          <iyz>0.0</iyz>
+          <izz>0.26667</izz>
+          </inertia>
+        </inertial>
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>0.4 0.4 0.4</size>
+            </box>
+          </geometry>
+          <material>
+            <diffuse>0 1 0</diffuse>
+          </material>
+        </visual>
+        <collision name="collision">
+          <geometry>
+            <box>
+              <size>0.4 0.4 0.4</size>
+            </box>
+          </geometry>
+        </collision>
+      </link>
+    </model>
+
     <!-- The MBZIRC competition logic plugin -->
     <plugin filename="libGameLogicPlugin.so"
             name="mbzirc::GameLogicPlugin">
@@ -141,6 +261,11 @@
         <center>0 0 48.46</center>
         <size>140 140 146.92</size>
       </geofence>
+      <target>
+        <vessel>Vessel A</vessel>
+        <small_object>small_box_a</small_object>
+        <large_object>large_box_a</large_object>
+      </target>
     </plugin>
 
   </world>

--- a/mbzirc_ros/CMakeLists.txt
+++ b/mbzirc_ros/CMakeLists.txt
@@ -6,6 +6,7 @@ find_package(ament_cmake REQUIRED)
 
 find_package(geometry_msgs REQUIRED)
 find_package(rclcpp REQUIRED)
+find_package(rosgraph_msgs REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(tf2_msgs REQUIRED)
@@ -34,6 +35,9 @@ install(TARGETS
   optical_frame_publisher
   pose_tf_broadcaster
   DESTINATION lib/${PROJECT_NAME})
+install(DIRECTORY
+  launch
+  DESTINATION share/${PROJECT_NAME})
 
 
 if(BUILD_TESTING)
@@ -48,6 +52,7 @@ if(BUILD_TESTING)
   ament_target_dependencies(test_ros_api
     geometry_msgs
     rclcpp
+    rosgraph_msgs
     sensor_msgs
     std_msgs
     tf2_msgs

--- a/mbzirc_ros/launch/competition.launch.py
+++ b/mbzirc_ros/launch/competition.launch.py
@@ -1,0 +1,70 @@
+# Copyright 2022 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ament_index_python.packages import get_package_share_directory
+
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
+from launch.actions import ExecuteProcess
+from launch.actions import OpaqueFunction
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import LaunchConfiguration
+
+from launch_ros.actions import Node
+
+import os
+
+def launch(context, *args, **kwargs):
+
+    ign_args = LaunchConfiguration('ign_args').perform(context)
+
+    ign_gazebo = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource([os.path.join(
+        get_package_share_directory('ros_ign_gazebo'), 'launch'),
+        '/ign_gazebo.launch.py']),
+        launch_arguments = {'ign_args': ign_args}.items())
+
+    ros2_ign_score_bridge = Node(
+        package='ros_ign_bridge',
+        executable='parameter_bridge',
+        output='screen',
+        arguments=['/mbzirc/score@std_msgs/msg/Float32@ignition.msgs.Float'],
+    )
+
+    ros2_ign_run_clock_bridge = Node(
+        package='ros_ign_bridge',
+        executable='parameter_bridge',
+        output='screen',
+        arguments=['/mbzirc/run_clock@rosgraph_msgs/msg/Clock@ignition.msgs.Clock'],
+    )
+
+    ros2_ign_phase_bridge = Node(
+        package='ros_ign_bridge',
+        executable='parameter_bridge',
+        output='screen',
+        arguments=['/mbzirc/phase@std_msgs/msg/String@ignition.msgs.StringMsg'],
+    )
+
+    return [ign_gazebo,
+            ros2_ign_score_bridge,
+            ros2_ign_run_clock_bridge,
+            ros2_ign_phase_bridge]
+
+def generate_launch_description():
+    return LaunchDescription([
+        DeclareLaunchArgument('ign_args', default_value='',
+            description='Arguments to be passed to Ignition Gazebo'),
+        OpaqueFunction(function = launch)
+        ])
+

--- a/mbzirc_ros/package.xml
+++ b/mbzirc_ros/package.xml
@@ -14,6 +14,7 @@
 
   <depend>geometry_msgs</depend>
   <depend>rclcpp</depend>
+  <depend>rosgraph_msgs</depend>
   <depend>sensor_msgs</depend>
   <depend>tf2</depend>
   <depend>tf2_ros</depend>

--- a/mbzirc_ros/test/launch/test_ros_api.launch.py
+++ b/mbzirc_ros/test/launch/test_ros_api.launch.py
@@ -45,8 +45,8 @@ def generate_test_description():
     gazebo = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
             os.path.join(
-                get_package_share_directory('ros_ign_gazebo'),
-                'launch/ign_gazebo.launch.py')
+                get_package_share_directory('mbzirc_ros'),
+                'launch/competition.launch.py')
         ),
         launch_arguments=arguments.items())
 

--- a/mbzirc_ros/test/ros_api/test_ros_api.cc
+++ b/mbzirc_ros/test/ros_api/test_ros_api.cc
@@ -18,12 +18,15 @@
 #include <gtest/gtest.h>
 
 #include <rclcpp/rclcpp.hpp>
+#include <rosgraph_msgs/msg/clock.hpp>
 #include <sensor_msgs/msg/camera_info.hpp>
 #include <sensor_msgs/msg/fluid_pressure.hpp>
 #include <sensor_msgs/msg/image.hpp>
 #include <sensor_msgs/msg/imu.hpp>
 #include <sensor_msgs/msg/magnetic_field.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
+#include <std_msgs/msg/float32.hpp>
+#include <std_msgs/msg/string.hpp>
 #include <tf2_msgs/msg/tf_message.hpp>
 
 using std::placeholders::_1;
@@ -105,6 +108,24 @@ TEST(RosApiTest, SimTopics)
   waitUntilBoolVarAndSpin(
     node, tfStatic.callbackExecuted, 10ms, 3500);
   EXPECT_TRUE(tfStatic.callbackExecuted);
+
+  // score
+  MyTestClass<std_msgs::msg::Float32> score("/mbzirc/score");
+  waitUntilBoolVarAndSpin(
+    node, score.callbackExecuted, 10ms, 500);
+  EXPECT_TRUE(score.callbackExecuted);
+
+  // phase
+  MyTestClass<std_msgs::msg::String> phase("/mbzirc/phase");
+  waitUntilBoolVarAndSpin(
+    node, phase.callbackExecuted, 10ms, 500);
+  EXPECT_TRUE(phase.callbackExecuted);
+
+  // run_clock
+  MyTestClass<rosgraph_msgs::msg::Clock> runClock("/mbzirc/run_clock");
+  waitUntilBoolVarAndSpin(
+    node, runClock.callbackExecuted, 10ms, 500);
+  EXPECT_TRUE(runClock.callbackExecuted);
 }
 
 /////////////////////////////////////////////////


### PR DESCRIPTION
Depends on https://github.com/ignitionrobotics/ign-gazebo/pull/1381

Targets are to be reported by labeling their location in a live video stream. This PR adds the following functionality:
* ign service to indicate a stream has started
* ign service for reporting the target location (image 2d pos) in the image stream
* validate the reported image pos contains a valid target

The GameLogic plugin does not actually process any incoming video images, e.g. no object recognition or image processing, etc but instead it uses the rendering engine to check if target objects are in the camera view (by checking target is within frustum and projecting ray to see if it hits the target)

To test, I find it easiest to make the UAV static first so it does not fall when we hover it over the target, e.g.

```diff
diff --git a/mbzirc_ign/models/mbzirc_quadrotor/model.sdf.erb b/mbzirc_ign/models/mbzirc_quadrotor/model.sdf.erb
index 838c1b4..51960c3 100644
--- a/mbzirc_ign/models/mbzirc_quadrotor/model.sdf.erb
+++ b/mbzirc_ign/models/mbzirc_quadrotor/model.sdf.erb
@@ -75,6 +75,7 @@ end
 <?xml version="1.0"?>
 <sdf version='1.9'>
   <model name="<%= $model_name%>">
+    <static>true</static>

```

Make sure to build and install the workspace.

1. Launch simple demo world:

    ```sh
    ros2 launch ros_ign_gazebo ign_gazebo.launch.py ign_args:="-v 4 -r simple_demo.sdf"
    ```
1. spawn quadrotor with downward looking camera:

    ```sh
    # slot3 is downward looking camera
    ros2 launch mbzirc_ign spawn.launch.py name:=quadrotor_1 world:=simple_demo model:=mbzirc_quadrotor type:=uav x:=-0 y:=0 z:=1.2 R:=0 P:=0 Y:=0 slot3:=mbzirc_hd_camera
    ```

1. Move the quadrotor above vessel:

    ```sh
    # adjust your x and y pos accordingly since vessel may move due to wave and wind
    ign service -s /world/simple_demo/set_pose --reqtype ignition.msgs.Pose --reptype ignition.msgs.Boolean --timeout 300 --req 'name: "quadrotor_1", position: {x: 25.0, y:25, z:80}'
    ```

1. Use ign service to indicate that stream is to be started

    ```sh
    # string args are: name of vehicle and sensor producing the video stream
    ign service -s /mbzirc/target/stream/start --reqtype ignition.msgs.StringMsg_V --reptype ignition.msgs.Boolean --timeout 300 --req 'data: ["quadrotor_1", "sensor_3"]'
    ```

1. Use ign service to report target vessel in stream

    ```sh
    # 640, 480 is center of image
    ign service -s /mbzirc/target/stream/report --reqtype ignition.msgs.StringMsg_V --reptype ignition.msgs.Boolean --timeout 300 --req 'data: ["vessel", "640", "480"]'
    ```

1. Open `/tmp/ign/mbzirc/logs/events.yml` to see that the vessel is successfully reported. You should see an event with data: `vessel_id_success`

1. Repeat the process for small and large target objects

    ```sh
    # adjust your x and y pos accordingly since vessel may move due to wave and wind
    # set low z pos so it can see the obj without hitting the mainsail part of the boat
    ign service -s /world/simple_demo/set_pose --reqtype ignition.msgs.Pose --reptype ignition.msgs.Boolean --timeout 300 --req 'name: "quadrotor_1", position: {x: 24.0, y:26.5, z:2}'

    ign service -s /mbzirc/target/stream/report --reqtype ignition.msgs.StringMsg_V --reptype ignition.msgs.Boolean --timeout 300 --req 'data: ["small", "640", "480"]'

    ign service -s /world/simple_demo/set_pose --reqtype ignition.msgs.Pose --reptype ignition.msgs.Boolean --timeout 300 --req 'name: "quadrotor_1", position: {x: 24.90, y:24.85, z:2}'

    ign service -s /mbzirc/target/stream/report --reqtype ignition.msgs.StringMsg_V --reptype ignition.msgs.Boolean --timeout 300 --req 'data: ["large", "640", "480"]'
    ```

1. You can also try reporting wrong image pos and you should see `*_object_id_success_*` events logged. Simulation stops after 3 invalid attempts.
