### PR TITLE
Stop robot motion when it moves out of 2nd geofence 

### DIFF
--- a/mbzirc_ign/src/GameLogicPlugin.cc
+++ b/mbzirc_ign/src/GameLogicPlugin.cc
@@ -299,6 +299,14 @@ class mbzirc::GameLogicPluginPrivate
   public: rendering::VisualPtr VisualAt(
       unsigned int _x, unsigned int _y, const std::string &_type) const;
 
+  /// \brief Set the competition phase
+  /// \param[in] _phase Competition phase string
+  public: void SetPhase(const std::string &_phase);
+
+  /// \brief Get the competition phase
+  /// \return Competition phase string
+  public: std::string Phase();
+
   /// \brief Ignition Transport node.
   public: transport::Node node;
 
@@ -345,11 +353,17 @@ class mbzirc::GameLogicPluginPrivate
   /// \brief Mutex to protect target stream.
   public: std::mutex streamMutex;
 
+  /// \brief Mutex to protect phase.
+  public: std::mutex phaseMutex;
+
   /// \brief Target reports
   public: std::vector<ignition::msgs::StringMsg_V> reports;
 
   /// \brief Ignition transport competition clock publisher.
   public: transport::Node::Publisher competitionClockPub;
+
+  /// \brief Ignition transport competition phase publisher.
+  public: transport::Node::Publisher competitionPhasePub;
 
   /// \brief Logpath.
   public: std::string logPath{"/dev/null"};
@@ -485,6 +499,9 @@ class mbzirc::GameLogicPluginPrivate
 
   /// \brief Max allowed error (%) for reported target object image position
   public: const double kTargetObjInImageTol = 0.008;
+
+  /// \brief Compeition phase.
+  public: std::string phase{"setup"};
 };
 
 //////////////////////////////////////////////////
@@ -678,6 +695,9 @@ void GameLogicPlugin::Configure(const ignition::gazebo::Entity & /*_entity*/,
 
   this->dataPtr->competitionClockPub =
     this->dataPtr->node.Advertise<ignition::msgs::Clock>("/mbzirc/run_clock");
+
+  this->dataPtr->competitionPhasePub =
+    this->dataPtr->node.Advertise<ignition::msgs::StringMsg>("/mbzirc/phase");
 
   this->dataPtr->node.Advertise("/mbzirc/target/stream/start",
       &GameLogicPluginPrivate::OnTargetStreamStart, this->dataPtr.get());
@@ -895,30 +915,23 @@ void GameLogicPlugin::PostUpdate(
   if (currentTime - this->dataPtr->lastStatusPubTime > std::chrono::seconds(1))
   {
     ignition::msgs::Clock competitionClockMsg;
-    ignition::msgs::Header::Map *mapData =
-      competitionClockMsg.mutable_header()->add_data();
-    mapData->set_key("phase");
-    if (this->dataPtr->started)
+    ignition::msgs::StringMsg phaseMsg;
+    std::string p = this->dataPtr->Phase();
+    phaseMsg.set_data(p);
+    if (p == "setup")
     {
-      mapData->add_value(this->dataPtr->finished ? "finished" : "run");
-      auto secondsRemaining = std::chrono::duration_cast<std::chrono::seconds>(
-          remainingCompetitionTime);
-      competitionClockMsg.mutable_sim()->set_sec(secondsRemaining.count());
-    }
-    else if (!this->dataPtr->finished)
-    {
-      mapData->add_value("setup");
       competitionClockMsg.mutable_sim()->set_sec(
           this->dataPtr->setupTimeSec - this->dataPtr->simTime.sec());
     }
     else
     {
-      // It's possible for a team to call Finish before starting.
-      mapData->add_value("finished");
+      auto secondsRemaining = std::chrono::duration_cast<std::chrono::seconds>(
+          remainingCompetitionTime);
+      competitionClockMsg.mutable_sim()->set_sec(secondsRemaining.count());
     }
 
     this->dataPtr->competitionClockPub.Publish(competitionClockMsg);
-
+    this->dataPtr->competitionPhasePub.Publish(phaseMsg);
     this->dataPtr->lastStatusPubTime = currentTime;
   }
 
@@ -1144,6 +1157,7 @@ bool GameLogicPluginPrivate::Start(const ignition::msgs::Time &_simTime)
     ignmsg << "Scoring has Started" << std::endl;
     this->Log(_simTime) << "scoring_started" << std::endl;
     this->LogEvent("started");
+    this->SetPhase("started");
   }
 
   // Update files when scoring has started.
@@ -1201,6 +1215,7 @@ void GameLogicPluginPrivate::Finish(const ignition::msgs::Time &_simTime)
     this->logStream.flush();
 
     this->LogEvent("finished");
+    this->SetPhase("finished");
   }
 
   this->finished = true;
@@ -1382,6 +1397,7 @@ void GameLogicPluginPrivate::ValidateTargetReports()
         this->targets[vessel] = target;
         this->LogEvent("target_reported", "vessel_id_success");
         this->currentTargetVessel = vessel;
+        this->SetPhase("vessel_id_success");
         continue;
       }
       // target has already been reported
@@ -1402,6 +1418,7 @@ void GameLogicPluginPrivate::ValidateTargetReports()
               target.smallObjectsReported.insert(smallObj);
               this->targets[vessel] = target;
               this->LogEvent("target_reported", "small_object_id_success");
+              this->SetPhase("small_object_id_success");
               continue;
             }
             else
@@ -1463,6 +1480,7 @@ void GameLogicPluginPrivate::ValidateTargetReports()
                 target.largeObjectsReported.insert(largeObj);
                 this->targets[vessel] = target;
                 this->LogEvent("target_reported", "large_object_id_success");
+                this->SetPhase("large_object_id_success");
                 continue;
               }
               else
@@ -1991,4 +2009,18 @@ rendering::VisualPtr GameLogicPluginPrivate::VisualAt(
     return target;
   }
   return nullptr;
+}
+
+/////////////////////////////////////////////////
+void GameLogicPluginPrivate::SetPhase(const std::string &_phase)
+{
+  std::lock_guard<std::mutex> lock(this->phaseMutex);
+  this->phase = _phase;
+}
+
+/////////////////////////////////////////////////
+std::string GameLogicPluginPrivate::Phase()
+{
+  std::lock_guard<std::mutex> lock(this->phaseMutex);
+  return this->phase;
 }

--- a/mbzirc_ign/src/GameLogicPlugin.cc
+++ b/mbzirc_ign/src/GameLogicPlugin.cc
@@ -267,6 +267,7 @@ class mbzirc::GameLogicPluginPrivate
   /// \brief Make an entity static
   /// \param[in] _entity Entity to make static
   /// \param[in] _ecm Mutable reference to Entity Component Manager
+  /// \return True if the entity is made static
   public: bool MakeStatic(Entity _entity, EntityComponentManager &_ecm);
 
   /// \brief Callback invoked in the rendering thread after a render update
@@ -845,7 +846,7 @@ void GameLogicPlugin::PostUpdate(
   }
 
   // find the sensor associated with the input stream
-  // used for valdiating target reports
+  // used for validating target reports
   {
     std::lock_guard<std::mutex> lock(this->dataPtr->streamMutex);
     if (!this->dataPtr->targetStreamTopic.empty())
@@ -1009,8 +1010,8 @@ void GameLogicPluginPrivate::CheckRobotsInGeofenceBoundary(
 bool GameLogicPluginPrivate::MakeStatic(Entity _entity,
     EntityComponentManager &_ecm)
 {
-  // make breadcrumb static by spawning a static model and attaching the
-  // breadcrumb to the static model
+  // make entity static by spawning a static model and attaching the
+  // entity to the static model
   // todo(anyone) Add a feature in ign-physics to support making a model
   // static
   if (this->staticModelToSpawn.LinkCount() == 0u)

--- a/mbzirc_ign/test/test_game_logic.cc
+++ b/mbzirc_ign/test/test_game_logic.cc
@@ -492,6 +492,7 @@ TEST_F(MBZIRCTestFixture, GameLogicBoundaryPenalty)
                != std::string::npos &&
              eventsBuffer.str().find("type: exceed_boundary_2")
                == std::string::npos;
+    Step(1);
   }
   EXPECT_TRUE(logged);
 
@@ -526,6 +527,7 @@ TEST_F(MBZIRCTestFixture, GameLogicBoundaryPenalty)
                != std::string::npos &&
              eventsBuffer.str().find("type: exceed_boundary_2")
                == std::string::npos;
+    Step(1);
   }
   EXPECT_TRUE(logged);
 
@@ -559,6 +561,7 @@ TEST_F(MBZIRCTestFixture, GameLogicBoundaryPenalty)
                != std::string::npos &&
              eventsBuffer.str().find("type: exceed_boundary_2")
                != std::string::npos;
+    Step(1);
   }
   EXPECT_TRUE(logged);
 

--- a/mbzirc_ign/worlds/empty_platform.sdf
+++ b/mbzirc_ign/worlds/empty_platform.sdf
@@ -93,5 +93,12 @@
       </link>
     </model>
 
+    <!-- The MBZIRC competition logic plugin -->
+    <plugin filename="libGameLogicPlugin.so"
+            name="mbzirc::GameLogicPlugin">
+      <run_duration_seconds>60</run_duration_seconds>
+      <setup_duration_seconds>30</setup_duration_seconds>
+    </plugin>
+
   </world>
 </sdf>

--- a/mbzirc_ros/CMakeLists.txt
+++ b/mbzirc_ros/CMakeLists.txt
@@ -6,6 +6,7 @@ find_package(ament_cmake REQUIRED)
 
 find_package(geometry_msgs REQUIRED)
 find_package(rclcpp REQUIRED)
+find_package(rosgraph_msgs REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(tf2_msgs REQUIRED)
@@ -34,6 +35,9 @@ install(TARGETS
   optical_frame_publisher
   pose_tf_broadcaster
   DESTINATION lib/${PROJECT_NAME})
+install(DIRECTORY
+  launch
+  DESTINATION share/${PROJECT_NAME})
 
 
 if(BUILD_TESTING)
@@ -48,6 +52,7 @@ if(BUILD_TESTING)
   ament_target_dependencies(test_ros_api
     geometry_msgs
     rclcpp
+    rosgraph_msgs
     sensor_msgs
     std_msgs
     tf2_msgs

--- a/mbzirc_ros/launch/competition.launch.py
+++ b/mbzirc_ros/launch/competition.launch.py
@@ -1,0 +1,70 @@
+# Copyright 2022 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ament_index_python.packages import get_package_share_directory
+
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
+from launch.actions import ExecuteProcess
+from launch.actions import OpaqueFunction
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import LaunchConfiguration
+
+from launch_ros.actions import Node
+
+import os
+
+def launch(context, *args, **kwargs):
+
+    ign_args = LaunchConfiguration('ign_args').perform(context)
+
+    ign_gazebo = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource([os.path.join(
+        get_package_share_directory('ros_ign_gazebo'), 'launch'),
+        '/ign_gazebo.launch.py']),
+        launch_arguments = {'ign_args': ign_args}.items())
+
+    ros2_ign_score_bridge = Node(
+        package='ros_ign_bridge',
+        executable='parameter_bridge',
+        output='screen',
+        arguments=['/mbzirc/score@std_msgs/msg/Float32@ignition.msgs.Float'],
+    )
+
+    ros2_ign_run_clock_bridge = Node(
+        package='ros_ign_bridge',
+        executable='parameter_bridge',
+        output='screen',
+        arguments=['/mbzirc/run_clock@rosgraph_msgs/msg/Clock@ignition.msgs.Clock'],
+    )
+
+    ros2_ign_phase_bridge = Node(
+        package='ros_ign_bridge',
+        executable='parameter_bridge',
+        output='screen',
+        arguments=['/mbzirc/phase@std_msgs/msg/String@ignition.msgs.StringMsg'],
+    )
+
+    return [ign_gazebo,
+            ros2_ign_score_bridge,
+            ros2_ign_run_clock_bridge,
+            ros2_ign_phase_bridge]
+
+def generate_launch_description():
+    return LaunchDescription([
+        DeclareLaunchArgument('ign_args', default_value='',
+            description='Arguments to be passed to Ignition Gazebo'),
+        OpaqueFunction(function = launch)
+        ])
+

--- a/mbzirc_ros/package.xml
+++ b/mbzirc_ros/package.xml
@@ -14,6 +14,7 @@
 
   <depend>geometry_msgs</depend>
   <depend>rclcpp</depend>
+  <depend>rosgraph_msgs</depend>
   <depend>sensor_msgs</depend>
   <depend>tf2</depend>
   <depend>tf2_ros</depend>

--- a/mbzirc_ros/test/launch/test_ros_api.launch.py
+++ b/mbzirc_ros/test/launch/test_ros_api.launch.py
@@ -45,8 +45,8 @@ def generate_test_description():
     gazebo = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
             os.path.join(
-                get_package_share_directory('ros_ign_gazebo'),
-                'launch/ign_gazebo.launch.py')
+                get_package_share_directory('mbzirc_ros'),
+                'launch/competition.launch.py')
         ),
         launch_arguments=arguments.items())
 

--- a/mbzirc_ros/test/ros_api/test_ros_api.cc
+++ b/mbzirc_ros/test/ros_api/test_ros_api.cc
@@ -18,12 +18,15 @@
 #include <gtest/gtest.h>
 
 #include <rclcpp/rclcpp.hpp>
+#include <rosgraph_msgs/msg/clock.hpp>
 #include <sensor_msgs/msg/camera_info.hpp>
 #include <sensor_msgs/msg/fluid_pressure.hpp>
 #include <sensor_msgs/msg/image.hpp>
 #include <sensor_msgs/msg/imu.hpp>
 #include <sensor_msgs/msg/magnetic_field.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
+#include <std_msgs/msg/float32.hpp>
+#include <std_msgs/msg/string.hpp>
 #include <tf2_msgs/msg/tf_message.hpp>
 
 using std::placeholders::_1;
@@ -105,6 +108,24 @@ TEST(RosApiTest, SimTopics)
   waitUntilBoolVarAndSpin(
     node, tfStatic.callbackExecuted, 10ms, 3500);
   EXPECT_TRUE(tfStatic.callbackExecuted);
+
+  // score
+  MyTestClass<std_msgs::msg::Float32> score("/mbzirc/score");
+  waitUntilBoolVarAndSpin(
+    node, score.callbackExecuted, 10ms, 500);
+  EXPECT_TRUE(score.callbackExecuted);
+
+  // phase
+  MyTestClass<std_msgs::msg::String> phase("/mbzirc/phase");
+  waitUntilBoolVarAndSpin(
+    node, phase.callbackExecuted, 10ms, 500);
+  EXPECT_TRUE(phase.callbackExecuted);
+
+  // run_clock
+  MyTestClass<rosgraph_msgs::msg::Clock> runClock("/mbzirc/run_clock");
+  waitUntilBoolVarAndSpin(
+    node, runClock.callbackExecuted, 10ms, 500);
+  EXPECT_TRUE(runClock.callbackExecuted);
 }
 
 /////////////////////////////////////////////////


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

There are 2 geofences for the competition area. If a robot moves outside of the first geofence, a time penalty is given (implemented in https://github.com/osrf/mbzirc/pull/41). 

This PRs adds the 2nd / outer geofence. If a robot moves outside of this geofence, ~a `HaltMotion` component is added to the robot model which will lock its joints and stop its motion - similar to what a 'kill switch' does in the real world.~  the robot is made static. 
* Note: I ran into a crash with ode collision checking error when quadrotor fell from sky and crashing into boundary collisions at high speed, so now just freezing the robot instead of locking its joints with `HaltMotion` component

To test:

1. launch coast world and spawn a quadrotor
    ```sh
    # launch coast world
    ros2 launch ros_ign_gazebo ign_gazebo.launch.py ign_args:="-v 4 -r coast.sdf"
    # spawn quadrotor
    ros2 launch mbzirc_ign spawn.launch.py name:=quadrotor_1 world:=coast model:=mbzirc_quadrotor type:=uav x:=-1500 y:=0 z:=3.6 R:=0 P:=0 Y:=0
    ```

1. Follow the quadrotor by right clicking on the quadrotor model in the 3D window and select `Follow`

1. In a separate terminal, monitor `events.yml` log

    ```
    tail -f /tmp/ign/mbzirc/logs/events.yml
    ```

1. Make the quadrotor take off

    ```
    ros2 topic pub --once /quadrotor_1/cmd_vel geometry_msgs/msg/Twist '{linear: {x: 0,y: 0.0, z: 2.0}, angular: {x: 0.0, y: 0.0, z: 0.0}}'
    ```

1. Move the robot to z = 100 so that it's close to the ceiling of the first geofence

    ```
    ign service -s /world/coast/set_pose --reqtype ignition.msgs.Pose --reptype ignition.msgs.Boolean --timeout 300 --req 'name: "quadrotor_1", position: {x:-1500, y:0, z: 100.0}'
    ```

1. The quadrotor should still be flying upwards and once it's reaches above ~122m, you should see a `exceed_boundary_1` type event logged in `events.yml` file

1. Let the quadrotor continue to fly upwards and once it reaches ~147m where the ceiling of the 2nd geofence is, you should see a `exceed_boundary_outer` type event logged in `events.yml` file. ~The quadrotor's propellers will also stop rotating and it should fall from the sky~ The quadrotor should should freeze in mid air.