### PR TITLE
Bridge competition topics

### DIFF
--- a/mbzirc_ign/src/GameLogicPlugin.cc
+++ b/mbzirc_ign/src/GameLogicPlugin.cc
@@ -1479,7 +1479,7 @@ void GameLogicPluginPrivate::ValidateTargetReports()
                 target.largeObjectsReported.insert(largeObj);
                 this->targets[vessel] = target;
                 this->LogEvent("target_reported", "large_object_id_success");
-                this->SetPhase("small_object_id_success");
+                this->SetPhase("large_object_id_success");
                 continue;
               }
               else

--- a/mbzirc_ign/test/test_game_logic.cc
+++ b/mbzirc_ign/test/test_game_logic.cc
@@ -196,19 +196,15 @@ TEST_F(MBZIRCTestFixture, GameLogicPhase)
   ignition::transport::Node node;
 
   // Run clock callback to keep track of current competition state
-  std::mutex runClockMutex;
+  std::mutex phaseMutex;
   std::string phaseData;
-  std::function<void(const ignition::msgs::Clock &_msg)> runClockCb =
-    [&](const ignition::msgs::Clock &_msg)
+  std::function<void(const ignition::msgs::StringMsg &_msg)> phaseCb =
+    [&](const ignition::msgs::StringMsg &_msg)
     {
-      std::lock_guard<std::mutex> lock(runClockMutex);
-      EXPECT_EQ(1, _msg.header().data_size());
-      auto data = _msg.header().data(0);
-      EXPECT_EQ(1, data.value_size());
-      EXPECT_EQ("phase", data.key());
-      phaseData = data.value(0);
+      std::lock_guard<std::mutex> lock(phaseMutex);
+      phaseData = _msg.data();
     };
-  node.Subscribe("/mbzirc/run_clock", runClockCb);
+  node.Subscribe("/mbzirc/phase", phaseCb);
 
   // verify that initial phase is "setup"
   int sleep = 0;
@@ -218,7 +214,7 @@ TEST_F(MBZIRCTestFixture, GameLogicPhase)
   {
     std::this_thread::sleep_for(1000ms);
     Step(10);
-    std::lock_guard<std::mutex> lock(runClockMutex);
+    std::lock_guard<std::mutex> lock(phaseMutex);
     reachedPhase = phaseData == "setup";
   }
   EXPECT_EQ("setup", phaseData);
@@ -236,17 +232,17 @@ TEST_F(MBZIRCTestFixture, GameLogicPhase)
     EXPECT_TRUE(rep.data());
   }
 
-  // check that phase is now "run"
+  // check that phase is now "started"
   sleep = 0;
   reachedPhase = false;
   while(!reachedPhase && sleep++ < maxSleep)
   {
     std::this_thread::sleep_for(1000ms);
     Step(10);
-    std::lock_guard<std::mutex> lock(runClockMutex);
-    reachedPhase = phaseData == "run";
+    std::lock_guard<std::mutex> lock(phaseMutex);
+    reachedPhase = phaseData == "started";
   }
-  EXPECT_EQ("run", phaseData);
+  EXPECT_EQ("started", phaseData);
 
   // publish finish event
   {
@@ -268,7 +264,7 @@ TEST_F(MBZIRCTestFixture, GameLogicPhase)
   {
     std::this_thread::sleep_for(1000ms);
     Step(10);
-    std::lock_guard<std::mutex> lock(runClockMutex);
+    std::lock_guard<std::mutex> lock(phaseMutex);
     reachedPhase = phaseData == "finished";
   }
   EXPECT_EQ("finished", phaseData);
@@ -705,6 +701,20 @@ TEST_F(MBZIRCTestFixture, GameLogicTargetReport)
 
   ASSERT_TRUE(spawnedSuccessfully);
 
+  // create callback for verifying competition phase
+  std::string phase;
+  ignition::transport::Node node;
+  std::mutex phaseMutex;
+  auto cb = [&](const ignition::msgs::StringMsg &_msg) -> void
+  {
+    std::lock_guard<std::mutex> lock(phaseMutex);
+    phase = _msg.data();
+  };
+
+  // Subscribe to a topic by registering a callback.
+  auto cbFunc = std::function<void(const ignition::msgs::StringMsg &)>(cb);
+  EXPECT_TRUE(node.Subscribe("/mbzirc/phase", cbFunc));
+
   std::string logPath = "mbzirc_logs";
   std::string eventsLogPath =
       ignition::common::joinPaths(logPath, "events.yml");
@@ -756,9 +766,20 @@ TEST_F(MBZIRCTestFixture, GameLogicTargetReport)
   }
   EXPECT_TRUE(logged);
 
-  int startTime = simTimeSec;
+  sleep = 0;
+  bool phaseReached = false;
+  while(!phaseReached && sleep++ < maxSleep)
+  {
+    {
+      std::lock_guard<std::mutex> lock(phaseMutex);
+      phaseReached = phase == "started";
+    }
+    Step(1);
+    std::this_thread::sleep_for(1000ms);
+  }
+  EXPECT_TRUE(phaseReached);
 
-  ignition::transport::Node node;
+  int startTime = simTimeSec;
 
   // start stream
   {
@@ -978,6 +999,19 @@ TEST_F(MBZIRCTestFixture, GameLogicTargetReport)
     EXPECT_NEAR(expectedScore, score, 1);
   }
 
+  sleep = 0;
+  phaseReached = false;
+  while(!phaseReached && sleep++ < maxSleep)
+  {
+    {
+      std::lock_guard<std::mutex> lock(phaseMutex);
+      phaseReached = phase == "vessel_id_success";
+    }
+    Step(1);
+    std::this_thread::sleep_for(1000ms);
+  }
+  EXPECT_TRUE(phaseReached);
+
   // advance time
   Step(100);
 
@@ -1141,6 +1175,19 @@ TEST_F(MBZIRCTestFixture, GameLogicTargetReport)
   // advance time
   Step(100);
 
+  sleep = 0;
+  phaseReached = false;
+  while(!phaseReached && sleep++ < maxSleep)
+  {
+    {
+      std::lock_guard<std::mutex> lock(phaseMutex);
+      phaseReached = phase == "small_object_id_success";
+    }
+    Step(1);
+    std::this_thread::sleep_for(1000ms);
+  }
+  EXPECT_TRUE(phaseReached);
+
   moveAboveTargetSmallObjectDone = true;
   moveAboveTargetLargeObject = true;
   Step(20);
@@ -1301,6 +1348,20 @@ TEST_F(MBZIRCTestFixture, GameLogicTargetReport)
   }
 
   moveAboveTargetLargeObjectDone = true;
+
+  sleep = 0;
+  phaseReached = false;
+  while(!phaseReached && sleep++ < maxSleep)
+  {
+    {
+      std::lock_guard<std::mutex> lock(phaseMutex);
+      phaseReached = phase == "large_object_id_success";
+    }
+    Step(1);
+    std::this_thread::sleep_for(1000ms);
+  }
+  EXPECT_TRUE(phaseReached);
+
 
   StopLaunchFile(launchHandle);
   ignition::common::removeAll(logPath);

--- a/mbzirc_ign/worlds/empty_platform.sdf
+++ b/mbzirc_ign/worlds/empty_platform.sdf
@@ -93,5 +93,12 @@
       </link>
     </model>
 
+    <!-- The MBZIRC competition logic plugin -->
+    <plugin filename="libGameLogicPlugin.so"
+            name="mbzirc::GameLogicPlugin">
+      <run_duration_seconds>60</run_duration_seconds>
+      <setup_duration_seconds>30</setup_duration_seconds>
+    </plugin>
+
   </world>
 </sdf>

--- a/mbzirc_ros/CMakeLists.txt
+++ b/mbzirc_ros/CMakeLists.txt
@@ -34,6 +34,9 @@ install(TARGETS
   optical_frame_publisher
   pose_tf_broadcaster
   DESTINATION lib/${PROJECT_NAME})
+install(DIRECTORY
+  launch
+  DESTINATION share/${PROJECT_NAME})
 
 
 if(BUILD_TESTING)

--- a/mbzirc_ros/CMakeLists.txt
+++ b/mbzirc_ros/CMakeLists.txt
@@ -6,6 +6,7 @@ find_package(ament_cmake REQUIRED)
 
 find_package(geometry_msgs REQUIRED)
 find_package(rclcpp REQUIRED)
+find_package(rosgraph_msgs REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(tf2_msgs REQUIRED)
@@ -51,6 +52,7 @@ if(BUILD_TESTING)
   ament_target_dependencies(test_ros_api
     geometry_msgs
     rclcpp
+    rosgraph_msgs
     sensor_msgs
     std_msgs
     tf2_msgs

--- a/mbzirc_ros/launch/competition.launch.py
+++ b/mbzirc_ros/launch/competition.launch.py
@@ -1,0 +1,70 @@
+# Copyright 2022 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ament_index_python.packages import get_package_share_directory
+
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
+from launch.actions import ExecuteProcess
+from launch.actions import OpaqueFunction
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import LaunchConfiguration
+
+from launch_ros.actions import Node
+
+import os
+
+def launch(context, *args, **kwargs):
+
+    ign_args = LaunchConfiguration('ign_args').perform(context)
+
+    ign_gazebo = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource([os.path.join(
+        get_package_share_directory('ros_ign_gazebo'), 'launch'),
+        '/ign_gazebo.launch.py']),
+        launch_arguments = {'ign_args': ign_args}.items())
+
+    ros2_ign_score_bridge = Node(
+        package='ros_ign_bridge',
+        executable='parameter_bridge',
+        output='screen',
+        arguments=['/mbzirc/score@std_msgs/msg/Float32@ignition.msgs.Float'],
+    )
+
+    ros2_ign_run_clock_bridge = Node(
+        package='ros_ign_bridge',
+        executable='parameter_bridge',
+        output='screen',
+        arguments=['/mbzirc/run_clock@rosgraph_msgs/msg/Clock@ignition.msgs.Clock'],
+    )
+
+    ros2_ign_phase_bridge = Node(
+        package='ros_ign_bridge',
+        executable='parameter_bridge',
+        output='screen',
+        arguments=['/mbzirc/phase@std_msgs/msg/String@ignition.msgs.StringMsg'],
+    )
+
+    return [ign_gazebo,
+            ros2_ign_score_bridge,
+            ros2_ign_run_clock_bridge,
+            ros2_ign_phase_bridge]
+
+def generate_launch_description():
+    return LaunchDescription([
+        DeclareLaunchArgument('ign_args', default_value='',
+            description='Arguments to be passed to Ignition Gazebo'),
+        OpaqueFunction(function = launch)
+        ])
+

--- a/mbzirc_ros/package.xml
+++ b/mbzirc_ros/package.xml
@@ -14,6 +14,7 @@
 
   <depend>geometry_msgs</depend>
   <depend>rclcpp</depend>
+  <depend>rosgraph_msgs</depend>
   <depend>sensor_msgs</depend>
   <depend>tf2</depend>
   <depend>tf2_ros</depend>

--- a/mbzirc_ros/test/launch/test_ros_api.launch.py
+++ b/mbzirc_ros/test/launch/test_ros_api.launch.py
@@ -45,8 +45,8 @@ def generate_test_description():
     gazebo = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
             os.path.join(
-                get_package_share_directory('ros_ign_gazebo'),
-                'launch/ign_gazebo.launch.py')
+                get_package_share_directory('mbzirc_ros'),
+                'launch/competition.launch.py')
         ),
         launch_arguments=arguments.items())
 

--- a/mbzirc_ros/test/ros_api/test_ros_api.cc
+++ b/mbzirc_ros/test/ros_api/test_ros_api.cc
@@ -18,12 +18,15 @@
 #include <gtest/gtest.h>
 
 #include <rclcpp/rclcpp.hpp>
+#include <rosgraph_msgs/msg/clock.hpp>
 #include <sensor_msgs/msg/camera_info.hpp>
 #include <sensor_msgs/msg/fluid_pressure.hpp>
 #include <sensor_msgs/msg/image.hpp>
 #include <sensor_msgs/msg/imu.hpp>
 #include <sensor_msgs/msg/magnetic_field.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
+#include <std_msgs/msg/float32.hpp>
+#include <std_msgs/msg/string.hpp>
 #include <tf2_msgs/msg/tf_message.hpp>
 
 using std::placeholders::_1;
@@ -105,6 +108,24 @@ TEST(RosApiTest, SimTopics)
   waitUntilBoolVarAndSpin(
     node, tfStatic.callbackExecuted, 10ms, 3500);
   EXPECT_TRUE(tfStatic.callbackExecuted);
+
+  // score
+  MyTestClass<std_msgs::msg::Float32> score("/mbzirc/score");
+  waitUntilBoolVarAndSpin(
+    node, score.callbackExecuted, 10ms, 500);
+  EXPECT_TRUE(score.callbackExecuted);
+
+  // phase
+  MyTestClass<std_msgs::msg::String> phase("/mbzirc/phase");
+  waitUntilBoolVarAndSpin(
+    node, phase.callbackExecuted, 10ms, 500);
+  EXPECT_TRUE(phase.callbackExecuted);
+
+  // run_clock
+  MyTestClass<rosgraph_msgs::msg::Clock> runClock("/mbzirc/run_clock");
+  waitUntilBoolVarAndSpin(
+    node, runClock.callbackExecuted, 10ms, 500);
+  EXPECT_TRUE(runClock.callbackExecuted);
 }
 
 /////////////////////////////////////////////////


### PR DESCRIPTION
Added a new launch file for bringing up ign-gazebo along with ros2 bridges for competition topics, including:
* `/mbzirc/score` - current score which is sim time + time penalty
* `/mbzirc/phase` - string msg containing info on current phase of the competition: `setup`, `started`, `vessel_id_success`, `small_object_id_success`, `large_object_id_success`
* `/mbzirc/run_clock` - count down of time remaining.

To test, launch simple_demo world using the new launch file and echo the topics using ros2:

```
ros2 launch mbzirc_ros competition.launch.py ign_args:="-v 4 -r simple_demo.sdf"

ros2 topic echo /mbzirc/score

ros2 topic echo /mbzirc/phase

ros2 topic echo /mbzirc/run_clock
```