### PR TITLE
Add sensor payloads to USV

### DIFF
--- a/mbzirc_ign/config/single_usv_config.yaml
+++ b/mbzirc_ign/config/single_usv_config.yaml
@@ -4,4 +4,16 @@ model_type: 'usv'
 position:
   xyz: [15, 0, 0.3]
   rpy: [0, 0, 0]
-
+payload:
+  slot0:
+    sensor: 'mbzirc_vga_camera'
+    rpy: [0, 0, 0]
+  slot1:
+    sensor: 'mbzirc_planar_lidar'
+    rpy: [0, 0, 0]
+  slot2:
+    sensor: 'mbzirc_3d_lidar'
+    rpy: [0, 0, 0]
+  slot3:
+    sensor: 'None'
+    rpy: [0, 0, 0]

--- a/mbzirc_ign/launch/spawn.launch.py
+++ b/mbzirc_ign/launch/spawn.launch.py
@@ -29,43 +29,49 @@ from mbzirc_ign.model import Model
 def spawn(context, model_type, world_name, model_name, position):
     model = Model(model_name, model_type, position)
 
+    slot0_payload = LaunchConfiguration('slot0').perform(context)
+    slot1_payload = LaunchConfiguration('slot1').perform(context)
+    slot2_payload = LaunchConfiguration('slot2').perform(context)
+    slot3_payload = LaunchConfiguration('slot3').perform(context)
+
+    slot0_rpy = LaunchConfiguration('slot0_rpy').perform(context)
+    slot1_rpy = LaunchConfiguration('slot1_rpy').perform(context)
+    slot2_rpy = LaunchConfiguration('slot2_rpy').perform(context)
+    slot3_rpy = LaunchConfiguration('slot3_rpy').perform(context)
+
+    payloads = {
+        'slot0': {'sensor': slot0_payload, 'rpy': slot0_rpy},
+        'slot1': {'sensor': slot1_payload, 'rpy': slot1_rpy},
+        'slot2': {'sensor': slot2_payload, 'rpy': slot2_rpy},
+        'slot3': {'sensor': slot3_payload, 'rpy': slot3_rpy},
+    }
+
     if model.isUAV():
         # take flight time in minutes
         flight_time = LaunchConfiguration('flightTime').perform(context)
 
-        slot0_payload = LaunchConfiguration('slot0').perform(context)
-        slot1_payload = LaunchConfiguration('slot1').perform(context)
-        slot2_payload = LaunchConfiguration('slot2').perform(context)
-        slot3_payload = LaunchConfiguration('slot3').perform(context)
         slot4_payload = LaunchConfiguration('slot4').perform(context)
         slot5_payload = LaunchConfiguration('slot5').perform(context)
         slot6_payload = LaunchConfiguration('slot6').perform(context)
         slot7_payload = LaunchConfiguration('slot7').perform(context)
 
-        slot0_rpy = LaunchConfiguration('slot0_rpy').perform(context)
-        slot1_rpy = LaunchConfiguration('slot1_rpy').perform(context)
-        slot2_rpy = LaunchConfiguration('slot2_rpy').perform(context)
-        slot3_rpy = LaunchConfiguration('slot3_rpy').perform(context)
         slot4_rpy = LaunchConfiguration('slot4_rpy').perform(context)
         slot5_rpy = LaunchConfiguration('slot5_rpy').perform(context)
         slot6_rpy = LaunchConfiguration('slot6_rpy').perform(context)
         slot7_rpy = LaunchConfiguration('slot7_rpy').perform(context)
 
-        payloads = {
-            'slot0': {'sensor': slot0_payload, 'rpy': slot0_rpy},
-            'slot1': {'sensor': slot1_payload, 'rpy': slot1_rpy},
-            'slot2': {'sensor': slot2_payload, 'rpy': slot2_rpy},
-            'slot3': {'sensor': slot3_payload, 'rpy': slot3_rpy},
+        payloads.update({
             'slot4': {'sensor': slot4_payload, 'rpy': slot4_rpy},
             'slot5': {'sensor': slot5_payload, 'rpy': slot5_rpy},
             'slot6': {'sensor': slot6_payload, 'rpy': slot6_rpy},
             'slot7': {'sensor': slot7_payload, 'rpy': slot7_rpy},
-        }
+        })
 
         model.set_flight_time(flight_time)
-        model.set_payload(payloads)
     elif model.isUSV():
         model.set_wavefield(world_name)
+
+    model.set_payload(payloads)
 
     ignition_spawn_entity = Node(
         package='ros_ign_gazebo',
@@ -77,10 +83,9 @@ def spawn(context, model_type, world_name, model_name, position):
     nodes = []
     bridges = model.bridges(world_name)
 
-    if model.isUAV():
-        [payload_bridges, payload_nodes] = model.payload_bridges(world_name)
-        bridges.extend(payload_bridges)
-        nodes.extend(payload_nodes)
+    [payload_bridges, payload_nodes] = model.payload_bridges(world_name)
+    bridges.extend(payload_bridges)
+    nodes.extend(payload_nodes)
 
     nodes.append(Node(
         package='ros_ign_bridge',

--- a/mbzirc_ign/models/mbzirc_usv_base/model.sdf
+++ b/mbzirc_ign/models/mbzirc_usv_base/model.sdf
@@ -597,5 +597,80 @@
     <parent>right_engine_link</parent>
     <child>right_propeller_link</child>
   </joint>
+
+  <!-- Front payload slot -->
+  <frame name="slot_0">
+    <pose>0.738 0 0.68 0 0 0</pose>
+  </frame>
+
+  <!-- Rear payload slot -->
+  <frame name="slot_1">
+    <pose>-0.73 0 0.68 0 0 -3.14159</pose>
+  </frame>
+
+  <!-- Left payload slot -->
+  <frame name="slot_2">
+    <pose>0.0 1.7 0.14 0 0 1.570796</pose>
+  </frame>
+
+  <!-- Right payload slot -->
+  <frame name="slot_3">
+    <pose>0.0 -1.7 0.14 0 0 -1.570796</pose>
+  </frame>
+
+  <!-- uncomment to debug sensor slot frames -->
+  <!--
+  <link name="debug_link">
+    <visual name="sensor_slot0">
+      <pose relative_to="slot_0">0 0 0 0 0 0</pose>
+      <geometry>
+        <box>
+          <size>0.025 0.025 0.025</size>
+        </box>
+      </geometry>
+      <material>
+        <diffuse>0.0 1 0 1</diffuse>
+      </material>
+    </visual>
+    <visual name="sensor_slot1">
+      <pose relative_to="slot_1">0 0 0 0 0 0</pose>
+      <geometry>
+        <box>
+          <size>0.025 0.025 0.025</size>
+        </box>
+      </geometry>
+      <material>
+        <diffuse>0.0 1 0 1</diffuse>
+      </material>
+    </visual>
+    <visual name="sensor_slot2">
+      <pose relative_to="slot_2">0 0 0 0 0 0</pose>
+      <geometry>
+        <box>
+          <size>0.025 0.025 0.025</size>
+        </box>
+      </geometry>
+      <material>
+        <diffuse>0.0 1 0 1</diffuse>
+      </material>
+    </visual>
+    <visual name="sensor_slot3">
+      <pose relative_to="slot_3">0 0 0 0 0 0</pose>
+      <geometry>
+        <box>
+          <size>0.025 0.025 0.025</size>
+        </box>
+      </geometry>
+      <material>
+        <diffuse>0.0 1 0 1</diffuse>
+      </material>
+    </visual>
+  </link>
+  <joint name="debug_link_joint" type="fixed">
+      <child>debug_link</child>
+      <parent>base_link</parent>
+  </joint>
+  -->
+
 </model>
 </sdf>

--- a/mbzirc_ign/models/usv/model.sdf.erb
+++ b/mbzirc_ign/models/usv/model.sdf.erb
@@ -17,6 +17,43 @@ end
   max_velocity_knots = 8 # Maximum velocity in knots. Taken from the USV specification.
   max_velocity_mps = max_velocity_knots * 0.5144 # convert knots to m/s
   max_total_thrust = (x_u + x_uu * max_velocity_mps) * max_velocity_mps
+
+$slot0_payload = nil
+$slot0_rpy = '0 0 0'
+
+$slot1_payload = nil
+$slot1_rpy = '0 0 0'
+
+$slot2_payload = nil
+$slot2_rpy = '0 0 0'
+
+$slot3_payload = nil
+$slot3_rpy = '0 0 0'
+
+if defined?(slot0)
+  $slot0_payload = slot0
+end
+if defined?(slot0_pos)
+  $slot0_rpy = slot0_pos
+end
+if defined?(slot1)
+  $slot1_payload = slot1
+end
+if defined?(slot1_pos)
+  $slot1_rpy = slot1_pos
+end
+if defined?(slot2)
+  $slot2_payload = slot2
+end
+if defined?(slot2_pos)
+  $slot2_rpy = slot2_pos
+end
+if defined?(slot3)
+  $slot3_payload = slot3
+end
+if defined?(slot3_pos)
+  $slot3_rpy = slot3_pos
+end
 %>
 
 <?xml version="1.0"?>
@@ -27,6 +64,87 @@ end
   <include merge="true">
     <uri>model://mbzirc_usv_base</uri>
   </include>
+
+  <% if $slot0_payload != nil%>
+  <!-- Payload slot0 -->
+  <include>
+    <name>sensor_0</name>
+    <uri>model://sensors/<%= $slot0_payload%></uri>
+    <placement_frame>mount_point</placement_frame>
+    <pose relative_to="slot_0" degrees="true">
+      0 0 0 <%= $slot0_rpy%>
+    </pose>
+  </include>
+
+  <joint name="slot_0_joint" type="fixed">
+    <parent>slot_0</parent>
+    <child>sensor_0::mount_point</child>
+  </joint>
+  <% end %>
+  <% if $slot1_payload != nil%>
+  <!-- Payload slot1 -->
+  <include>
+    <name>sensor_1</name>
+    <uri>model://sensors/<%= $slot1_payload%></uri>
+    <placement_frame>mount_point</placement_frame>
+    <pose relative_to="slot_1" degrees="true">
+      0 0 0 <%= $slot1_rpy%>
+    </pose>
+  </include>
+
+  <joint name="slot_1_joint" type="fixed">
+    <parent>slot_1</parent>
+    <child>sensor_1::mount_point</child>
+  </joint>
+  <% end %>
+  <% if $slot2_payload != nil%>
+  <!-- Payload slot2 -->
+  <include>
+    <name>sensor_2</name>
+    <uri>model://sensors/<%= $slot2_payload%></uri>
+    <placement_frame>mount_point</placement_frame>
+    <pose relative_to="slot_2" degrees="true">
+      0 0 0 <%= $slot2_rpy%>
+    </pose>
+  </include>
+
+  <joint name="slot_2_joint" type="fixed">
+    <parent>slot_2</parent>
+    <child>sensor_2::mount_point</child>
+  </joint>
+  <% end %>
+  <% if $slot3_payload != nil%>
+  <!-- Payload slot3 -->
+  <include>
+    <name>sensor_3</name>
+    <uri>model://sensors/<%= $slot3_payload%></uri>
+    <placement_frame>mount_point</placement_frame>
+    <pose relative_to="slot_3" degrees="true">
+      0 0 0 <%= $slot3_rpy%>
+    </pose>
+  </include>
+
+  <joint name="slot_3_joint" type="fixed">
+    <parent>slot_3</parent>
+    <child>sensor_3::mount_point</child>
+  </joint>
+  <% end %>
+  <% if $slot4_payload != nil%>
+  <!-- Payload slot4 -->
+  <include>
+    <name>sensor_4</name>
+    <uri>model://sensors/<%= $slot4_payload%></uri>
+    <placement_frame>mount_point</placement_frame>
+    <pose relative_to="slot_4" degrees="true">
+      0 0 0 <%= $slot4_rpy%>
+    </pose>
+  </include>
+
+  <joint name="slot_4_joint" type="fixed">
+    <parent>slot_4</parent>
+    <child>sensor_4::mount_point</child>
+  </joint>
+  <% end %>
 
   <plugin
     filename="ignition-gazebo-thruster-system"

--- a/mbzirc_ign/src/mbzirc_ign/model.py
+++ b/mbzirc_ign/src/mbzirc_ign/model.py
@@ -169,20 +169,20 @@ class Model:
         command = ['erb']
         command.append(f'name={self.model_name}')
 
+        for (slot, payload) in self.payload.items():
+            if payload['sensor'] and payload['sensor'] != 'None':
+                command.append(f"{slot}={payload['sensor']}")
+            if 'rpy' in payload:
+                if type(payload['rpy']) is str:
+                    r, p, y = payload['rpy'].split(' ')
+                else:
+                    r, p, y = payload['rpy']
+                command.append(f'{slot}_pos={r} {p} {y}')
+
         if self.model_type in UAVS:
             if self.battery_capacity == 0:
                 raise RuntimeError('Battery Capacity is zero, was flight_time set?')
             command.append(f'capacity={self.battery_capacity}')
-
-            for (slot, payload) in self.payload.items():
-                if payload['sensor'] and payload['sensor'] != 'None':
-                    command.append(f"{slot}={payload['sensor']}")
-                if 'rpy' in payload:
-                    if type(payload['rpy']) is str:
-                        r, p, y = payload['rpy'].split(' ')
-                    else:
-                        r, p, y = payload['rpy']
-                    command.append(f'{slot}_pos={r} {p} {y}')
 
         if self.model_type in USVS:
             command.append(f'wavefieldSize={self.wavefield_size}')

--- a/mbzirc_ign/src/mbzirc_ign/test_model.py
+++ b/mbzirc_ign/src/mbzirc_ign/test_model.py
@@ -64,6 +64,11 @@ class TestModel(unittest.TestCase):
         bridges = model.bridges('test_world_name')
         self.assertEqual(len(bridges), 7)
 
+        [payload_bridges, payload_nodes] = model.payload_bridges('test_world_name')
+
+        self.assertEqual(len(payload_bridges), 4)
+        self.assertEqual(len(payload_nodes), 1)
+
     def test_multiple_config(self):
         config = os.path.join(get_package_share_directory('mbzirc_ign'),
                               'config', 'coast_config.yaml')


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>


Added support for USVs to carry 4 sensor payloads. The 4payloads are:

* slot0: front (on top platform)
* slot1: rear (on top platform)
* slot2: left (attached to side of hull)
* slot3: right (attached to side hull)

The green boxes below visualizes the location of the senors on the USV:

![usv_sensor_payloads](https://user-images.githubusercontent.com/4000684/161171294-98e6c3de-2c63-4f1b-a67c-b1c63579093d.png)



As an example for test, the commands below spawns the usv with 4 cameras in the simple demo world. The camera in slot3 (right) is oriented to face forward.

```
ros2 launch ros_ign_gazebo ign_gazebo.launch.py ign_args:="-v 4 -r simple_demo.sdf"

ros2 launch mbzirc_ign spawn.launch.py name:=usv world:=simple_demo model:=usv type:=usv x:=15 y:=0 z:=0.3 R:=0 P:=0 Y:=0 arm:=mbzirc_oberon7_arm gripper:=mbzirc_oberon7_gripper slot0:=mbzirc_hd_camera slot1:=mbzirc_vga_camera slot2:=mbzirc_vga_camera slot3:=mbzirc_vga_camera slot3_rpy:='0 0 90'
```