### PR TITLE
Extend GameLogicPlugin to support scoring manipulation task

### DIFF
--- a/mbzirc_ign/CMakeLists.txt
+++ b/mbzirc_ign/CMakeLists.txt
@@ -51,6 +51,7 @@ install(
 # Plugins
 list(APPEND MBZIRC_IGN_PLUGINS
   GameLogicPlugin
+  RegionDetector
   SimpleHydrodynamics
   Surface
   WaveVisual

--- a/mbzirc_ign/CMakeLists.txt
+++ b/mbzirc_ign/CMakeLists.txt
@@ -51,7 +51,7 @@ install(
 # Plugins
 list(APPEND MBZIRC_IGN_PLUGINS
   GameLogicPlugin
-  RegionDetector
+  EntityDetector
   SimpleHydrodynamics
   Surface
   WaveVisual

--- a/mbzirc_ign/models/usv/model.sdf.erb
+++ b/mbzirc_ign/models/usv/model.sdf.erb
@@ -158,13 +158,27 @@ end
 
   <!-- uncomment the following to visualize valid region for placement
       of target objects -->
-  <!--
   <link name='target_placement_region'>
     <visual name="v1">
+      <pose>0 0 0.22 0 0 0</pose>
       <transparency>0.5</transparency>
       <geometry>
         <box>
-          <size>5 5 5</size>
+          <size>4 3.3 0.25</size>
+        </box>
+      </geometry>
+      <material>
+        <ambient>0.0 1.0 0.0 0.5</ambient>
+        <diffuse>0.0 1.0 0.0 0.5</diffuse>
+        <specular>0.5 0.5 0.5 0.5</specular>
+      </material>
+    </visual>
+    <visual name="v2">
+      <pose>0 0 0.8 0 0 0</pose>
+      <transparency>0.5</transparency>
+      <geometry>
+        <box>
+          <size>1.5 2.2 0.25</size>
         </box>
       </geometry>
       <material>
@@ -179,21 +193,30 @@ end
     <parent>target_placement_region</parent>
     <child>base_link</child>
   </joint>
-  -->
-
   <!-- This plugin detects when target objects are placed at the
        the defined region. A message is published on the <topic> when these
        events occur -->
-  <plugin filename="libRegionDetector.so"
-          name="mbzirc::RegionDetector">
-    <topic>/target_object_detector</topic>
-    <pose>0 0 0 0 0 0</pose>
+  <plugin filename="libEntityDetector.so"
+          name="mbzirc::EntityDetector">
+    <topic>/mbzirc/target_object_detector/placed</topic>
+    <pose>0 0 0.22 0 0 0</pose>
     <geometry>
       <box>
-        <size>5 5 5</size>
+        <size>4 3.3 0.25</size>
       </box>
     </geometry>
   </plugin>
+  <plugin filename="libEntityDetector.so"
+          name="mbzirc::EntityDetector">
+    <topic>/mbzirc/target_object_detector/placed</topic>
+    <pose>0 0 0.8 0 0 0</pose>
+    <geometry>
+      <box>
+        <size>1.5 2.2 0.25</size>
+      </box>
+    </geometry>
+  </plugin>
+
 
 </model>
 </sdf>

--- a/mbzirc_ign/models/usv/model.sdf.erb
+++ b/mbzirc_ign/models/usv/model.sdf.erb
@@ -154,5 +154,46 @@ end
     <static_publisher>true</static_publisher>
     <static_update_frequency>1</static_update_frequency>
   </plugin>
+
+
+  <!-- uncomment the following to visualize valid region for placement
+      of target objects -->
+  <!--
+  <link name='target_placement_region'>
+    <visual name="v1">
+      <transparency>0.5</transparency>
+      <geometry>
+        <box>
+          <size>5 5 5</size>
+        </box>
+      </geometry>
+      <material>
+        <ambient>0.0 1.0 0.0 0.5</ambient>
+        <diffuse>0.0 1.0 0.0 0.5</diffuse>
+        <specular>0.5 0.5 0.5 0.5</specular>
+      </material>
+    </visual>
+    <cast_shadows>false</cast_shadows>
+  </link>
+  <joint name="target_placement_joint" type="fixed">
+    <parent>target_placement_region</parent>
+    <child>base_link</child>
+  </joint>
+  -->
+
+  <!-- This plugin detects when target objects are placed at the
+       the defined region. A message is published on the <topic> when these
+       events occur -->
+  <plugin filename="libRegionDetector.so"
+          name="mbzirc::RegionDetector">
+    <topic>/target_object_detector</topic>
+    <pose>0 0 0 0 0 0</pose>
+    <geometry>
+      <box>
+        <size>5 5 5</size>
+      </box>
+    </geometry>
+  </plugin>
+
 </model>
 </sdf>

--- a/mbzirc_ign/models/usv/model.sdf.erb
+++ b/mbzirc_ign/models/usv/model.sdf.erb
@@ -273,45 +273,7 @@ end
     <static_update_frequency>1</static_update_frequency>
   </plugin>
 
-
-  <!-- uncomment the following to visualize valid region for placement
-      of target objects -->
-  <link name='target_placement_region'>
-    <visual name="v1">
-      <pose>0 0 0.22 0 0 0</pose>
-      <transparency>0.5</transparency>
-      <geometry>
-        <box>
-          <size>4 3.3 0.25</size>
-        </box>
-      </geometry>
-      <material>
-        <ambient>0.0 1.0 0.0 0.5</ambient>
-        <diffuse>0.0 1.0 0.0 0.5</diffuse>
-        <specular>0.5 0.5 0.5 0.5</specular>
-      </material>
-    </visual>
-    <visual name="v2">
-      <pose>0 0 0.8 0 0 0</pose>
-      <transparency>0.5</transparency>
-      <geometry>
-        <box>
-          <size>1.5 2.2 0.25</size>
-        </box>
-      </geometry>
-      <material>
-        <ambient>0.0 1.0 0.0 0.5</ambient>
-        <diffuse>0.0 1.0 0.0 0.5</diffuse>
-        <specular>0.5 0.5 0.5 0.5</specular>
-      </material>
-    </visual>
-    <cast_shadows>false</cast_shadows>
-  </link>
-  <joint name="target_placement_joint" type="fixed">
-    <parent>target_placement_region</parent>
-    <child>base_link</child>
-  </joint>
-  <!-- This plugin detects when target objects are placed at the
+  <!-- These plugins detect when target objects are placed at the
        the defined region. A message is published on the <topic> when these
        events occur -->
   <plugin filename="libEntityDetector.so"
@@ -334,7 +296,94 @@ end
       </box>
     </geometry>
   </plugin>
+  <plugin filename="libEntityDetector.so"
+          name="mbzirc::EntityDetector">
+    <topic>/mbzirc/target_object_detector/placed</topic>
+    <pose>0 -1.35 0.22 0 0 0</pose>
+    <geometry>
+      <box>
+        <size>5.8 0.58 0.25</size>
+      </box>
+    </geometry>
+  </plugin>
+  <plugin filename="libEntityDetector.so"
+          name="mbzirc::EntityDetector">
+    <topic>/mbzirc/target_object_detector/placed</topic>
+    <pose>0 1.35 0.22 0 0 0</pose>
+    <geometry>
+      <box>
+        <size>5.8 0.58 0.25</size>
+      </box>
+    </geometry>
+  </plugin>
 
+  <!-- uncomment the following to visualize valid region for placement
+      of target objects -->
+  <!--
+  <link name='target_placement_region'>
+    <visual name="bottom_platform">
+      <pose>0 0 0.22 0 0 0</pose>
+      <transparency>0.5</transparency>
+      <geometry>
+        <box>
+          <size>4 3.3 0.25</size>
+        </box>
+      </geometry>
+      <material>
+        <ambient>0.0 1.0 0.0 0.5</ambient>
+        <diffuse>0.0 1.0 0.0 0.5</diffuse>
+        <specular>0.5 0.5 0.5 0.5</specular>
+      </material>
+    </visual>
+    <visual name="top_platform">
+      <pose>0 0 0.8 0 0 0</pose>
+      <transparency>0.5</transparency>
+      <geometry>
+        <box>
+          <size>1.5 2.2 0.25</size>
+        </box>
+      </geometry>
+      <material>
+        <ambient>0.0 1.0 0.0 0.5</ambient>
+        <diffuse>0.0 1.0 0.0 0.5</diffuse>
+        <specular>0.5 0.5 0.5 0.5</specular>
+      </material>
+    </visual>
+    <visual name="left_hull">
+      <pose>0 -1.35 0.22 0 0 0</pose>
+      <transparency>0.5</transparency>
+      <geometry>
+        <box>
+          <size>5.8 0.58 0.25</size>
+        </box>
+      </geometry>
+      <material>
+        <ambient>0.0 1.0 0.0 0.5</ambient>
+        <diffuse>0.0 1.0 0.0 0.5</diffuse>
+        <specular>0.5 0.5 0.5 0.5</specular>
+      </material>
+    </visual>
+    <visual name="right_hull">
+      <pose>0 1.35 0.22 0 0 0</pose>
+      <transparency>0.5</transparency>
+      <geometry>
+        <box>
+          <size>5.8 0.58 0.25</size>
+        </box>
+      </geometry>
+      <material>
+        <ambient>0.0 1.0 0.0 0.5</ambient>
+        <diffuse>0.0 1.0 0.0 0.5</diffuse>
+        <specular>0.5 0.5 0.5 0.5</specular>
+      </material>
+    </visual>
+    <cast_shadows>false</cast_shadows>
+  </link>
+  <joint name="target_placement_joint" type="fixed">
+    <parent>target_placement_region</parent>
+    <child>base_link</child>
+  </joint>
+  -->
 
 </model>
 </sdf>

--- a/mbzirc_ign/src/EntityDetector.cc
+++ b/mbzirc_ign/src/EntityDetector.cc
@@ -1,0 +1,325 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include <ignition/msgs/pose.pb.h>
+
+#include <ignition/common/Profiler.hh>
+#include <ignition/math/AxisAlignedBox.hh>
+#include <ignition/math/Vector3.hh>
+#include <ignition/plugin/Register.hh>
+#include <ignition/transport/Node.hh>
+#include <sdf/Box.hh>
+#include <sdf/Element.hh>
+//#include <sdf/Geometry.hh>
+
+#include "ignition/gazebo/Model.hh"
+#include "ignition/gazebo/Util.hh"
+#include "ignition/gazebo/components/Model.hh"
+#include "ignition/gazebo/components/Name.hh"
+#include "ignition/gazebo/components/ParentEntity.hh"
+#include "ignition/gazebo/components/Pose.hh"
+
+#include "EntityDetector.hh"
+
+using namespace ignition;
+using namespace gazebo;
+using namespace systems;
+using namespace mbzirc;
+
+/////////////////////////////////////////////////
+void EntityDetector::Configure(const Entity &_entity,
+               const std::shared_ptr<const sdf::Element> &_sdf,
+               EntityComponentManager &_ecm,
+               EventManager &/*_eventMgr*/)
+{
+  this->model = Model(_entity);
+  if (!this->model.Valid(_ecm))
+  {
+    ignerr << "EntityDetector should be attached to a model entity. "
+           << "Failed to initialize." << std::endl;
+    return;
+  }
+
+  this->detectorName = this->model.Name(_ecm);
+
+  auto sdfClone = _sdf->Clone();
+  bool hasGeometry{false};
+  if (sdfClone->HasElement("geometry"))
+  {
+    auto geom = sdfClone->GetElement("geometry");
+    if (geom->HasElement("box"))
+    {
+      auto box = geom->GetElement("box");
+      auto boxSize = box->Get<math::Vector3d>("size");
+      this->detectorGeometry = math::AxisAlignedBox(-boxSize / 2, boxSize / 2);
+      hasGeometry = true;
+    }
+  }
+
+  if (!hasGeometry)
+  {
+    ignerr << "'<geometry><box>' is a required parameter for "
+              "EntityDetector. Failed to initialize.\n";
+    return;
+  }
+
+  if (sdfClone->HasElement("pose"))
+  {
+    this->poseOffset = sdfClone->Get<math::Pose3d>("pose");
+  }
+
+ /* if (sdfClone->HasElement("entities"))
+  {
+    auto entities = sdfClone->GetElement("entities");
+    auto entNameElem = entities->GetElement("name");
+    while (entNameElem)
+    {
+      std::string entName = entNameElem->Get<std::string>();
+      if (!entName.empty())
+        this->entityNames.push_back(entName);
+      entNameElem = entNameElem->GetNextElement("name");
+    }
+  }
+  else
+  {
+    ignwarn << "No entities to detect in Region Detector" << std::endl;
+  }
+*/
+
+
+  std::string defaultTopic{"/model/" + this->model.Name(_ecm) +
+                             "/entity_detector/status"};
+  auto topic = _sdf->Get<std::string>("topic", defaultTopic).first;
+
+  ignmsg << "EntityDetector publishing messages on "
+         << "[" << topic << "]" << std::endl;
+
+  transport::Node node;
+  this->pub = node.Advertise<msgs::Pose>(topic);
+  this->initialized = true;
+  std::cerr << "region detector loaded !!!!!! " << std::endl;
+}
+
+//////////////////////////////////////////////////
+void EntityDetector::PreUpdate(
+  const ignition::gazebo::UpdateInfo &_info,
+  ignition::gazebo::EntityComponentManager &_ecm)
+{
+  if (!this->worldPoseEnabled)
+  {
+    enableComponent<components::WorldPose>(_ecm, this->model.Entity(), true);
+    this->worldPoseEnabled = true;
+  }
+}
+
+
+//////////////////////////////////////////////////
+void EntityDetector::PostUpdate(
+  const ignition::gazebo::UpdateInfo &_info,
+  const ignition::gazebo::EntityComponentManager &_ecm)
+{
+  IGN_PROFILE("EntityDetector::PostUpdate");
+
+  if (this->initialized && !this->model.Valid(_ecm))
+  {
+    // Deactivate this system if the parent model has been removed
+    this->initialized = false;
+    return;
+  }
+
+  if (_info.paused)
+    return;
+
+  if (!this->initialized)
+  {
+    return;
+  }
+
+  /*// find entity ids associated with input entity names
+  if (!this->entityNames.empty())
+  {
+    for (const auto entName : this->entityNames)
+    {
+      auto ent = _ecm.EntityByComponents(
+          components::Name(entName), components::Model());
+      if (ent != kNullEntity)
+      {
+        this->entitiesToDetect.insert(ent);
+        std::cerr << "found " << entName << std::endl;
+      }
+    }
+    this->entityNames.clear();
+    return;
+  }
+*/
+
+  auto poseComp = _ecm.Component<components::Pose>(this->model.Entity());
+  if (!poseComp)
+    return;
+  auto modelPose = poseComp->Data();
+
+  // Double negative because AxisAlignedBox does not currently have operator+
+  // that takes a position
+  auto region = this->detectorGeometry -
+    (-(modelPose.Pos() + modelPose.Rot() * this->poseOffset.Pos()));
+
+  _ecm.Each<components::Model, components::Name, components::Pose>(
+      [&](const Entity &_entity, const components::Model *,
+          const components::Name *_name,
+          const components::Pose *_pose) -> bool
+      {
+        auto name = _name->Data();
+        auto pose = _pose->Data();
+        bool alreadyDetected = this->IsAlreadyDetected(_entity);
+
+        if (region.Contains(pose.Pos()))
+        {
+          if (!alreadyDetected)
+          {
+            const math::Pose3d relPose = modelPose.Inverse() * pose;
+            this->AddToDetected(_entity);
+            this->Publish(_entity, name, true, relPose, _info.simTime);
+          }
+        }
+        else if (alreadyDetected)
+        {
+          const math::Pose3d relPose = modelPose.Inverse() * pose;
+          this->RemoveFromDetected(_entity);
+          this->Publish(_entity, name, false, relPose, _info.simTime);
+        }
+        return true;
+      });
+
+  /*
+  for (const auto &ent : this->entitiesToDetect)
+  {
+    auto poseComp = _ecm.Component<components::WorldPose>(ent);
+    math::Pose3d pose = poseComp->Data();
+    bool alreadyDetected = this->IsAlreadyDetected(ent);
+    if (region.Contains(pose.Pos()))
+    {
+      if (!alreadyDetected)
+      {
+        this->AddToDetected(ent);
+        this->Publish(ent, name, true, relPose, _info.simTime);
+      }
+    }
+    else if (alreadyDetected)
+    {
+      this->RemoveFromDetected(ent);
+      this->Publish(ent, name, false, relPose, _info.simTime);
+    }
+  }
+
+  _ecm.Each<components::Performer, components::Geometry,
+            components::ParentEntity>(
+      [&](const Entity &_entity, const components::Performer *,
+          const components::Geometry *_geometry,
+          const components::ParentEntity *_parent) -> bool
+      {
+        auto pose = _ecm.Component<components::Pose>(_parent->Data())->Data();
+        auto name = _ecm.Component<components::Name>(_parent->Data())->Data();
+        const math::Pose3d relPose = modelPose.Inverse() * pose;
+
+        // We assume the geometry contains a box.
+        auto perfBox = _geometry->Data().BoxShape();
+        if (nullptr == perfBox)
+        {
+          ignerr << "Internal error: geometry of performer [" << _entity
+                 << "] missing box." << std::endl;
+          return true;
+        }
+
+        math::AxisAlignedBox performerVolume{pose.Pos() - perfBox->Size() / 2,
+                                             pose.Pos() + perfBox->Size() / 2};
+
+        bool alreadyDetected = this->IsAlreadyDetected(_entity);
+        if (region.Intersects(performerVolume))
+        {
+          if (!alreadyDetected)
+          {
+            this->AddToDetected(_entity);
+            this->Publish(_entity, name, true, relPose, _info.simTime);
+          }
+        }
+        else if (alreadyDetected)
+        {
+          this->RemoveFromDetected(_entity);
+          this->Publish(_entity, name, false, relPose, _info.simTime);
+        }
+
+        return true;
+      });
+  */
+}
+
+//////////////////////////////////////////////////
+bool EntityDetector::IsAlreadyDetected(const Entity &_entity) const
+{
+  return this->detectedEntities.find(_entity) != this->detectedEntities.end();
+}
+
+//////////////////////////////////////////////////
+void EntityDetector::AddToDetected(const Entity &_entity)
+{
+  this->detectedEntities.insert(_entity);
+}
+
+//////////////////////////////////////////////////
+void EntityDetector::RemoveFromDetected(const Entity &_entity)
+{
+  this->detectedEntities.erase(_entity);
+}
+
+//////////////////////////////////////////////////
+void EntityDetector::Publish(
+    const Entity &_entity, const std::string &_name, bool _state,
+    const math::Pose3d &_pose,
+    const std::chrono::steady_clock::duration &_stamp)
+{
+  msgs::Pose msg = msgs::Convert(_pose);
+  msg.set_name(_name);
+  msg.set_id(_entity);
+
+  auto stamp = math::durationToSecNsec(_stamp);
+  msg.mutable_header()->mutable_stamp()->set_sec(stamp.first);
+  msg.mutable_header()->mutable_stamp()->set_nsec(stamp.second);
+
+  {
+    auto *headerData = msg.mutable_header()->add_data();
+    headerData->set_key("frame_id");
+    headerData->add_value(this->detectorName);
+  }
+  {
+    auto *headerData = msg.mutable_header()->add_data();
+    headerData->set_key("state");
+    headerData->add_value(std::to_string(_state));
+  }
+  {
+    auto *headerData = msg.mutable_header()->add_data();
+    headerData->set_key("count");
+    headerData->add_value(std::to_string(this->detectedEntities.size()));
+  }
+
+  this->pub.Publish(msg);
+}
+
+IGNITION_ADD_PLUGIN(mbzirc::EntityDetector,
+                    ignition::gazebo::System,
+                    ignition::gazebo::ISystemConfigure,
+                    ignition::gazebo::ISystemPreUpdate,
+                    ignition::gazebo::ISystemPostUpdate)

--- a/mbzirc_ign/src/EntityDetector.hh
+++ b/mbzirc_ign/src/EntityDetector.hh
@@ -120,12 +120,6 @@ namespace mbzirc
     /// \brief Keeps a set of detected entities
     private: std::unordered_set<ignition::gazebo::Entity> detectedEntities;
 
-    /// \brief Ids of entities to detect
-//    private: std::unordered_set<std::string> entitiesToDetect;
-
-    /// \brief Names of entities to detect
-//    private: std::unordered_set<std::string> entityNames;
-
     /// \brief The model associated with this system.
     private: ignition::gazebo::Model model;
 

--- a/mbzirc_ign/src/EntityDetector.hh
+++ b/mbzirc_ign/src/EntityDetector.hh
@@ -1,0 +1,152 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef MBZIRC_IGN_ENTITYDETECTOR_HH_
+#define MBZIRC_IGN_ENTITYDETECTOR_HH_
+
+#include <map>
+#include <memory>
+#include <string>
+#include <unordered_set>
+
+#include <ignition/transport/Node.hh>
+
+#include "ignition/gazebo/Model.hh"
+#include "ignition/gazebo/System.hh"
+
+namespace mbzirc
+{
+  /// \brief A system system that publishes on a topic when an entity enters
+  /// or leaves a specified region.
+  ///
+  /// An entity is detected when an entity's position enters the
+  /// EntityDetector's region, which is represented by an
+  /// ignition::math::AxisAlignedBox. When an entity is detected, the system
+  /// publishes an ignition.msgs.Pose message with the pose of the detected
+  /// entity with respect to the model containing the EntityDetector. The
+  /// name and id fields of the Pose message will be set to the name and the
+  /// entity of the detected entity respectively. The header of the Pose
+  /// message contains the time stamp of detection. The `data` field of the
+  /// header will contain the key "frame_id" with a value set to the name of
+  /// the model containing the EntityDetector system and the key "state" with
+  /// a value set to "1" if the entity is entering the detector's region and
+  /// "0" if the entity is leaving the region. The `data` field of the
+  /// header will also contain the key "count" with a value set to the
+  /// number of entities currently in the region.
+  ///
+  /// The EntityDetector has to be attached to a `<model>` and it's region
+  /// is centered on the containing model's origin.
+  ///
+  /// ## System parameters
+  ///
+  /// `<topic>`: Custom topic to be used for publishing when an entity is
+  /// detected. If not set, the default topic with the following pattern would
+  /// be used "/model/<model_name>/entity_detector/status". The topic type
+  /// is ignition.msgs.Pose
+  /// `<geometry>`: Detection region. Currently, only the `<box>` geometry is
+  /// supported. The position of the geometry is derived from the pose of the
+  /// containing model.
+  /// `<pose>`: Additional pose offset relative to the parent model's pose.
+  /// This pose is added to the parent model pose when computing the
+  /// detection region. Only the position component of the `<pose>` is used.
+  /// `<entities>`
+  ///     `<name>`: Name of entity to detector
+
+  class EntityDetector
+      : public ignition::gazebo::System,
+        public ignition::gazebo::ISystemConfigure,
+        public ignition::gazebo::ISystemPreUpdate,
+        public ignition::gazebo::ISystemPostUpdate
+  {
+    /// Documentation inherited
+    public: EntityDetector() = default;
+
+    /// Documentation inherited
+    public: void Configure(const ignition::gazebo::Entity &_entity,
+                           const std::shared_ptr<const sdf::Element> &_sdf,
+                           ignition::gazebo::EntityComponentManager &_ecm,
+                           ignition::gazebo::EventManager &_eventMgr) final;
+
+    /// Documentation inherited
+    public: void PreUpdate(
+                const ignition::gazebo::UpdateInfo &_info,
+                ignition::gazebo::EntityComponentManager &_ecm) final;
+
+    /// Documentation inherited
+    public: void PostUpdate(
+                const ignition::gazebo::UpdateInfo &_info,
+                const ignition::gazebo::EntityComponentManager &_ecm) final;
+
+    /// \brief Check if the entity has already been detected
+    /// \param [in] _entity The entity to test
+    /// \returns True if the entity has already been detected
+    private: bool IsAlreadyDetected(const ignition::gazebo::Entity &_entity)
+        const;
+
+    /// \brief Add the entity to the list of detected entities
+    /// \param [in] _entity The entity to add
+    private: void AddToDetected(const ignition::gazebo::Entity &_entity);
+
+    /// \brief Remove the entity from the list of detected entities
+    /// \param [in] _entity The entity to remove
+    private: void RemoveFromDetected(const ignition::gazebo::Entity &_entity);
+
+    /// \brief Publish the event that the entity is detected or no longer
+    /// detected.
+    /// \param [in] _entity The entity to report
+    /// \param [in] _name The name of the entity that triggered the event
+    /// \param [in] _state The new state of the detector
+    /// \param [in] _pose The pose of the entity that triggered the event
+    /// \param [in] _stamp Time stamp of the event
+    private: void Publish(const ignition::gazebo::Entity &_entity,
+                          const std::string &_name,
+                          bool _state, const ignition::math::Pose3d &_pose,
+                          const std::chrono::steady_clock::duration &_stamp);
+
+    /// \brief Keeps a set of detected entities
+    private: std::unordered_set<ignition::gazebo::Entity> detectedEntities;
+
+    /// \brief Ids of entities to detect
+//    private: std::unordered_set<std::string> entitiesToDetect;
+
+    /// \brief Names of entities to detect
+//    private: std::unordered_set<std::string> entityNames;
+
+    /// \brief The model associated with this system.
+    private: ignition::gazebo::Model model;
+
+    /// \brief Name of the detector used as the frame_id in published messages.
+    private: std::string detectorName;
+
+    /// \brief Detector region. Only a box geometry is supported
+    private: ignition::math::AxisAlignedBox detectorGeometry;
+
+    /// \brief Ignition communication publisher.
+    private: ignition::transport::Node::Publisher pub;
+
+    /// \brief Whether the system has been initialized
+    private: bool initialized{false};
+
+    /// \brief Additional pose offset for the plugin.
+    private: ignition::math::Pose3d poseOffset;
+
+    /// \brief if world pose component has been enabled or not
+    private: bool worldPoseEnabled{false};
+  };
+}
+
+#endif

--- a/mbzirc_ign/src/GameLogicPlugin.cc
+++ b/mbzirc_ign/src/GameLogicPlugin.cc
@@ -22,6 +22,8 @@
 
 #include <chrono>
 #include <mutex>
+#include <unordered_map>
+#include <unordered_set>
 
 #include <ignition/math/AxisAlignedBox.hh>
 
@@ -78,25 +80,25 @@ class mbzirc::GameLogicPluginPrivate
     public: std::string vessel;
 
     /// \brief List of small target objects
-    public: std::set<std::string> smallObjects;
+    public: std::unordered_set<std::string> smallObjects;
 
     /// \brief List of large target objects
-    public: std::set<std::string> largeObjects;
+    public: std::unordered_set<std::string> largeObjects;
 
     /// \brief Indicates if vessel has been reported
     public: bool vesselReported = false;
 
     /// \brief Set of small objects that have been reported.
-    public: std::set<std::string> smallObjectsReported;
+    public: std::unordered_set<std::string> smallObjectsReported;
 
     /// \brief Set of large objects that have been reported.
-    public: std::set<std::string> largeObjectsReported;
+    public: std::unordered_set<std::string> largeObjectsReported;
 
     /// \brief Set of small objects that have been retrieved.
-    public: std::set<std::string> smallObjectsRetrieved;
+    public: std::unordered_set<std::string> smallObjectsRetrieved;
 
     /// \brief Set of large objects that have been retrieved.
-    public: std::set<std::string> largeObjectsRetrieved;
+    public: std::unordered_set<std::string> largeObjectsRetrieved;
   };
 
   /// \brief Information of target in stream
@@ -143,7 +145,7 @@ class mbzirc::GameLogicPluginPrivate
           };
 
   /// \brief A map of penalty type and time penalties.
-  public: const std::map<PenaltyType, int> kTimePenalties = {
+  public: const std::unordered_map<PenaltyType, int> kTimePenalties = {
           {TARGET_VESSEL_ID_1, 180},
           {TARGET_VESSEL_ID_2, 240},
           {TARGET_VESSEL_ID_3, IGN_INT32_MAX},
@@ -399,7 +401,7 @@ class mbzirc::GameLogicPluginPrivate
   public: std::vector<ignition::msgs::Pose> objectsDropped;
 
   /// \brief Objects that need to be disabled
-  public: std::set<std::string> objectsToDisable;
+  public: std::unordered_set<std::string> objectsToDisable;
 
   /// \brief Ignition transport competition clock publisher.
   public: transport::Node::Publisher competitionClockPub;
@@ -411,10 +413,10 @@ class mbzirc::GameLogicPluginPrivate
   public: std::string logPath{"/dev/null"};
 
   /// \brief Names of the spawned robots.
-  public: std::map<Entity, std::string> robotNames;
+  public: std::unordered_map<Entity, std::string> robotNames;
 
   /// \brief Initial pose of robots
-  public: std::map<Entity, math::Vector3d> robotInitialPos;
+  public: std::unordered_map<Entity, math::Vector3d> robotInitialPos;
 
  /// \brief Current state.
   public: std::string state = "init";
@@ -429,7 +431,7 @@ class mbzirc::GameLogicPluginPrivate
   public: EventManager *eventManager{nullptr};
 
   /// \brief Models with dead batteries.
-  public: std::set<std::string> deadBatteries;
+  public: std::unordered_set<std::string> deadBatteries;
 
   /// \brief Amount of allowed setup time in seconds.
   public: int setupTimeSec = 600;
@@ -463,7 +465,7 @@ class mbzirc::GameLogicPluginPrivate
 
   /// \brief Map of robot entity id and bool var to indicate if they are inside
   ///  the competition boundary
-  public: std::map<Entity, bool> robotsInBoundary;
+  public: std::unordered_map<Entity, bool> robotsInBoundary;
 
   /// \brief SDF DOM of a static model with empty link
   public: sdf::Model staticModelToSpawn;
@@ -475,7 +477,7 @@ class mbzirc::GameLogicPluginPrivate
   public: Entity worldEntity{kNullEntity};
 
   /// \brief A list of robots that have been disabled
-  public: std::set<Entity> disabledRobots;
+  public: std::unordered_set<Entity> disabledRobots;
 
   /// \brief Number of times robot moved beyond competition boundary
   public: unsigned int geofenceBoundaryPenaltyCount = 0u;
@@ -485,23 +487,23 @@ class mbzirc::GameLogicPluginPrivate
 
   /// \brief Map of vessel to number of times small object is incorrectly
   /// identified
-  public: std::map<std::string, unsigned int> smallObjectIdPenaltyCount;
+  public: std::unordered_map<std::string, unsigned int> smallObjectIdPenaltyCount;
 
   /// \brief Map of vessel to number times large object is incorrectly
   /// identified
-  public: std::map<std::string, unsigned int> largeObjectIdPenaltyCount;
+  public: std::unordered_map<std::string, unsigned int> largeObjectIdPenaltyCount;
 
   /// \brief Map of vessel to number of times small object retrieval failed
-  public: std::map<std::string, unsigned int> smallObjectRetrievePenaltyCount;
+  public: std::unordered_map<std::string, unsigned int> smallObjectRetrievePenaltyCount;
 
   /// \brief Map of vessel to number of times small object retrieval failed
-  public: std::map<std::string, unsigned int> largeObjectRetrievePenaltyCount;
+  public: std::unordered_map<std::string, unsigned int> largeObjectRetrievePenaltyCount;
 
   /// \brief Total time penalty in seconds;
   public: int timePenalty = 0;
 
   /// \brief A map of target vessel name and targets.
-  public: std::map<std::string, Target> targets;
+  public: std::unordered_map<std::string, Target> targets;
 
   /// \brief Sensor entity on vehicle currently streaming video of target
   public: Entity targetStreamSensorEntity;
@@ -510,7 +512,7 @@ class mbzirc::GameLogicPluginPrivate
   public: std::string targetStreamTopic;
 
   /// \brief Sensor entity on vehicle currently streaming video of target
-  public: std::set<Entity> cameraSensors;
+  public: std::unordered_set<Entity> cameraSensors;
 
   /// \brief Connection to the post-render event.
   public: ignition::common::ConnectionPtr postRenderConn;
@@ -530,16 +532,16 @@ class mbzirc::GameLogicPluginPrivate
   public: std::string currentTargetVessel;
 
   /// \brief A set of target vessel visuals
-  public: std::set<rendering::VisualPtr> targetVesselVisuals;
+  public: std::unordered_set<rendering::VisualPtr> targetVesselVisuals;
 
   /// \brief A map of target vessel name and the small target object visuals
   /// on the vessel
-  public: std::map<std::string, std::set<rendering::VisualPtr>>
+  public: std::unordered_map<std::string, std::unordered_set<rendering::VisualPtr>>
       targetSmallObjectVisuals;
 
   /// \brief A map of target vessel name and the large target object visuals
   /// on the vessel
-  public: std::map<std::string, std::set<rendering::VisualPtr>>
+  public: std::unordered_map<std::string, std::unordered_set<rendering::VisualPtr>>
       targetLargeObjectVisuals;
 
   /// \brief Max allowed error (%) for reported target vessel image position

--- a/mbzirc_ign/src/GameLogicPlugin.cc
+++ b/mbzirc_ign/src/GameLogicPlugin.cc
@@ -821,8 +821,8 @@ void GameLogicPlugin::PostUpdate(
     const ignition::gazebo::UpdateInfo &_info,
     const ignition::gazebo::EntityComponentManager &_ecm)
 {
-  if (_info.paused)
-    return;
+//  if (_info.paused)
+//    return;
 
   // Store sim time
   int64_t s, ns;
@@ -925,7 +925,6 @@ void GameLogicPlugin::PostUpdate(
         }
       }
     }
-    return;
   }
 
   // find the sensor associated with the input stream
@@ -964,10 +963,6 @@ void GameLogicPlugin::PostUpdate(
   {
     this->dataPtr->ValidateTargetObjectRetrieval();
   }
-
-  // check task completion
-  // update score files and pause sim if tasks are done
-  this->dataPtr->CheckTaskCompletion();
 
   // Get the start sim time in nanoseconds.
   auto startSimTime = std::chrono::nanoseconds(
@@ -1479,7 +1474,6 @@ bool GameLogicPluginPrivate::OnSkipToPhase(
   }
   this->SetPhase(p);
   ignmsg << "Skipping to phase: " << p << std::endl;
-  std::cerr << "skipping to phase " << std::endl;
 
   _res.set_data(true);
   return true;
@@ -1808,7 +1802,6 @@ void GameLogicPluginPrivate::ValidateTargetObjectRetrieval()
               target.smallObjectsRetrieved.find(objName) ==
               target.smallObjectsRetrieved.end())
           {
-            std::cerr << "small object placed! " << std::endl;
             this->LogEvent("target_retrieval", "small_object_retrieve_success");
             this->SetPhase("small_object_retrieve_success");
             target.smallObjectsRetrieved.insert(objName);
@@ -1830,7 +1823,7 @@ void GameLogicPluginPrivate::ValidateTargetObjectRetrieval()
               target.largeObjectsRetrieved.find(objName) ==
               target.largeObjectsRetrieved.end())
           {
-            target.largeObjectsRetrieved.insert(largeObj);
+            target.largeObjectsRetrieved.insert(objName);
             this->LogEvent("target_retrieval", "large_object_retrieve_success");
             this->SetPhase("large_object_retrieve_success");
             this->CheckTaskCompletion();
@@ -2329,7 +2322,6 @@ void GameLogicPluginPrivate::SetPhase(const std::string &_phase)
 {
   std::lock_guard<std::mutex> lock(this->phaseMutex);
   this->phase = _phase;
-  std::cerr << "setting phase " << _phase << std::endl;
 }
 
 /////////////////////////////////////////////////

--- a/mbzirc_ign/worlds/coast.sdf
+++ b/mbzirc_ign/worlds/coast.sdf
@@ -1074,5 +1074,23 @@
       </link>
     </model>
     -->
+
+    <model name="ocean_entity_detector">
+      <static>true</static>
+      <!-- This plugin detects when target objects are dropped into the ocean
+           at the defined region. A message is published on the <topic> when
+           these events occur -->
+      <plugin filename="libEntityDetector.so"
+              name="mbzirc::EntityDetector">
+        <topic>/mbzirc/target_object_detector/dropped</topic>
+        <pose>0 0 -100 0 0 0</pose>
+        <geometry>
+          <box>
+            <size>3162.28 3162.28 10</size>
+          </box>
+        </geometry>
+      </plugin>
+    </model>
+
   </world>
 </sdf>

--- a/mbzirc_ign/worlds/coast.sdf
+++ b/mbzirc_ign/worlds/coast.sdf
@@ -866,7 +866,7 @@
     </include>
 
     <model name="small_box_a">
-      <pose>-1400 20 0.5 0 0.0 -1.0</pose>
+      <pose relative_to="Vessel A">-0.14 0.04 0.2 0 0 1.2</pose>
       <link name="link">
         <inertial>
           <mass>1</mass>
@@ -899,39 +899,56 @@
       </link>
     </model>
 
-    <model name="large_box_a">
-      <pose>-1400.5 20 0.65 0 0.0 -1.0</pose>
+    <model name="small_box_a_duplicate">
+      <pose relative_to="Vessel A">-1.28 0.23 0.2 0 0 1</pose>
       <link name="link">
         <inertial>
-          <mass>10</mass>
+          <mass>1</mass>
           <inertia>
-          <ixx>0.26667</ixx>
+          <ixx>0.0066667</ixx>
           <ixy>0.0</ixy>
           <ixz>0.0</ixz>
-          <iyy>0.26667</iyy>
+          <iyy>0.0066667</iyy>
           <iyz>0.0</iyz>
-          <izz>0.26667</izz>
+          <izz>0.0066667</izz>
           </inertia>
         </inertial>
         <visual name="visual">
           <geometry>
             <box>
-              <size>0.4 0.4 0.4</size>
+              <size>0.2 0.2 0.2</size>
             </box>
           </geometry>
           <material>
-            <diffuse>0 1 0</diffuse>
+            <diffuse>0 0 1</diffuse>
           </material>
         </visual>
         <collision name="collision">
           <geometry>
             <box>
-              <size>0.4 0.4 0.4</size>
+              <size>0.2 0.2 0.2</size>
             </box>
           </geometry>
         </collision>
       </link>
     </model>
+
+
+    <include>
+      <name>large_dry_box_a</name>
+      <pose relative_to="Vessel A">0.08 -0.59 0.2 0 0 -0.3</pose>
+      <uri>
+        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Large Dry Box
+      </uri>
+    </include>
+
+    <include>
+      <name>large_dry_box_a_duplicate</name>
+      <pose relative_to="Vessel A">0.7 0.23 0.2 0 0 0.2</pose>
+      <uri>
+        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Large Dry Box
+      </uri>
+    </include>
 
     <model name="max_bounds">
       <static>true</static>
@@ -1050,7 +1067,9 @@
       <target>
         <vessel>Vessel A</vessel>
         <small_object>small_box_a</small_object>
-        <large_object>large_box_a</large_object>
+        <small_object>small_box_a_duplicate</small_object>
+        <large_object>large_dry_box_a</large_object>
+        <large_object>large_dry_box_a_duplicate</large_object>
       </target>
     </plugin>
 

--- a/mbzirc_ign/worlds/faster_than_realtime.sdf
+++ b/mbzirc_ign/worlds/faster_than_realtime.sdf
@@ -215,6 +215,41 @@
       </link>
     </model>
 
+    <model name="small_box_a_duplicate">
+      <pose>24.2 26.5 0.5 0 0 0</pose>
+      <link name="link">
+        <inertial>
+          <mass>1</mass>
+          <inertia>
+          <ixx>0.0066667</ixx>
+          <ixy>0.0</ixy>
+          <ixz>0.0</ixz>
+          <iyy>0.0066667</iyy>
+          <iyz>0.0</iyz>
+          <izz>0.0066667</izz>
+          </inertia>
+        </inertial>
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>0.2 0.2 0.2</size>
+            </box>
+          </geometry>
+          <material>
+            <diffuse>0 0 1</diffuse>
+          </material>
+        </visual>
+        <collision name="collision">
+          <geometry>
+            <box>
+              <size>0.2 0.2 0.2</size>
+            </box>
+          </geometry>
+        </collision>
+      </link>
+    </model>
+
+
     <model name="large_box_a">
       <pose>24.9 24.85 0.65 0 0 0</pose>
       <link name="link">
@@ -249,6 +284,41 @@
       </link>
     </model>
 
+    <model name="large_box_a_duplicate">
+      <pose>24.9 25.0 0.65 0 0 0</pose>
+      <link name="link">
+        <inertial>
+          <mass>10</mass>
+          <inertia>
+          <ixx>0.26667</ixx>
+          <ixy>0.0</ixy>
+          <ixz>0.0</ixz>
+          <iyy>0.26667</iyy>
+          <iyz>0.0</iyz>
+          <izz>0.26667</izz>
+          </inertia>
+        </inertial>
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>0.4 0.4 0.4</size>
+            </box>
+          </geometry>
+          <material>
+            <diffuse>0 1 0</diffuse>
+          </material>
+        </visual>
+        <collision name="collision">
+          <geometry>
+            <box>
+              <size>0.4 0.4 0.4</size>
+            </box>
+          </geometry>
+        </collision>
+      </link>
+    </model>
+
+
     <!-- The MBZIRC competition logic plugin -->
     <plugin filename="libGameLogicPlugin.so"
             name="mbzirc::GameLogicPlugin">
@@ -264,9 +334,28 @@
       <target>
         <vessel>Vessel A</vessel>
         <small_object>small_box_a</small_object>
+        <small_object>small_box_a_duplicate</small_object>
         <large_object>large_box_a</large_object>
+        <large_object>large_box_a_duplicate</large_object>
       </target>
     </plugin>
+
+    <model name="ocean_entity_detector">
+      <static>true</static>
+      <!-- This plugin detects when target objects are dropped into the ocean
+           at the defined region. A message is published on the <topic> when
+           these events occur -->
+      <plugin filename="libEntityDetector.so"
+              name="mbzirc::EntityDetector">
+        <topic>/mbzirc/target_object_detector/dropped</topic>
+        <pose>0 0 -20 0 0 0</pose>
+        <geometry>
+          <box>
+            <size>140 140 5</size>
+          </box>
+        </geometry>
+      </plugin>
+    </model>
 
   </world>
 </sdf>

--- a/mbzirc_ign/worlds/simple_demo.sdf
+++ b/mbzirc_ign/worlds/simple_demo.sdf
@@ -255,9 +255,9 @@
 
     <include>
       <name>large_grey_box</name>
-      <pose relative_to="Vessel A">0.08 -0.64 0.2 0 0 -0.3</pose>
+      <pose relative_to="Vessel A">0.08 -0.6 0.2 0 0 -0.3</pose>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Large Grey Box
+        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Large Dry Box
       </uri>
     </include>
 
@@ -265,7 +265,7 @@
       <name>large_grey_box_a</name>
       <pose relative_to="Vessel A">0.7 0.23 0.2 0 0 0.2</pose>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Large Grey Box
+        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Large Dry Box
       </uri>
     </include>
     -->
@@ -402,8 +402,8 @@
         <!--
         <small_object>small_blue_box</small_object>
         <small_object>small_blue_box_a</small_object>
-        <large_object>large_grey_box</large_object>
-        <large_object>large_grey_box_a</large_object>
+        <large_object>large_dry_box</large_object>
+        <large_object>large_dry_box_a</large_object>
         -->
         <small_object>small_box_a</small_object>
         <large_object>large_box_a</large_object>

--- a/mbzirc_ign/worlds/simple_demo.sdf
+++ b/mbzirc_ign/worlds/simple_demo.sdf
@@ -236,7 +236,7 @@
       </plugin>
     </include>
 
-    <!--
+    <!-- uncomment when small blue box switches to simple colliders
     <include>
       <name>small_blue_box</name>
       <pose relative_to="Vessel A">-0.14 0.04 0.2 0 0 1.2</pose>
@@ -252,26 +252,26 @@
         https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Small Blue Box
       </uri>
     </include>
+    -->
 
     <include>
-      <name>large_grey_box</name>
-      <pose relative_to="Vessel A">0.08 -0.6 0.2 0 0 -0.3</pose>
+      <name>large_dry_box_a</name>
+      <pose relative_to="Vessel A">0.08 -0.59 0.2 0 0 -0.3</pose>
       <uri>
         https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Large Dry Box
       </uri>
     </include>
 
     <include>
-      <name>large_grey_box_a</name>
+      <name>large_dry_box_a_duplicate</name>
       <pose relative_to="Vessel A">0.7 0.23 0.2 0 0 0.2</pose>
       <uri>
         https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Large Dry Box
       </uri>
     </include>
-    -->
 
     <model name="small_box_a">
-      <pose>24 26.5 0.5 0 0 0</pose>
+      <pose relative_to="Vessel A">-0.14 0.04 0.2 0 0 1.2</pose>
       <link name="link">
         <inertial>
           <mass>1</mass>
@@ -304,6 +304,41 @@
       </link>
     </model>
 
+    <model name="small_box_a_duplicate">
+      <pose relative_to="Vessel A">-1.28 0.23 0.2 0 0 1</pose>
+      <link name="link">
+        <inertial>
+          <mass>1</mass>
+          <inertia>
+          <ixx>0.0066667</ixx>
+          <ixy>0.0</ixy>
+          <ixz>0.0</ixz>
+          <iyy>0.0066667</iyy>
+          <iyz>0.0</iyz>
+          <izz>0.0066667</izz>
+          </inertia>
+        </inertial>
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>0.2 0.2 0.2</size>
+            </box>
+          </geometry>
+          <material>
+            <diffuse>0 0 1</diffuse>
+          </material>
+        </visual>
+        <collision name="collision">
+          <geometry>
+            <box>
+              <size>0.2 0.2 0.2</size>
+            </box>
+          </geometry>
+        </collision>
+      </link>
+    </model>
+
+<!--
     <model name="large_box_a">
       <pose>24.9 24.85 0.65 0 0 0</pose>
       <link name="link">
@@ -337,6 +372,7 @@
         </collision>
       </link>
     </model>
+-->
 
     <wind>
       <linear_velocity>0.3 0 0</linear_velocity>
@@ -402,11 +438,12 @@
         <!--
         <small_object>small_blue_box</small_object>
         <small_object>small_blue_box_a</small_object>
-        <large_object>large_dry_box</large_object>
-        <large_object>large_dry_box_a</large_object>
         -->
         <small_object>small_box_a</small_object>
-        <large_object>large_box_a</large_object>
+        <small_object>small_box_a_duplicate</small_object>
+
+        <large_object>large_dry_box_a</large_object>
+        <large_object>large_dry_box_a_duplicate</large_object>
       </target>
     </plugin>
 

--- a/mbzirc_ign/worlds/simple_demo.sdf
+++ b/mbzirc_ign/worlds/simple_demo.sdf
@@ -435,13 +435,8 @@
       </geofence>
       <target>
         <vessel>Vessel A</vessel>
-        <!--
-        <small_object>small_blue_box</small_object>
-        <small_object>small_blue_box_a</small_object>
-        -->
         <small_object>small_box_a</small_object>
         <small_object>small_box_a_duplicate</small_object>
-
         <large_object>large_dry_box_a</large_object>
         <large_object>large_dry_box_a_duplicate</large_object>
       </target>

--- a/mbzirc_ign/worlds/simple_demo.sdf
+++ b/mbzirc_ign/worlds/simple_demo.sdf
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 
-<sdf version="1.6">
+<sdf version="1.9">
   <world name="simple_demo">
 
     <physics name="4ms" type="dart">
@@ -236,6 +236,40 @@
       </plugin>
     </include>
 
+    <!--
+    <include>
+      <name>small_blue_box</name>
+      <pose relative_to="Vessel A">-0.14 0.04 0.2 0 0 1.2</pose>
+      <uri>
+        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Small Blue Box
+      </uri>
+    </include>
+
+    <include>
+      <name>small_blue_box_a</name>
+      <pose relative_to="Vessel A">-1.28 0.23 0.2 0 0 1</pose>
+      <uri>
+        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Small Blue Box
+      </uri>
+    </include>
+
+    <include>
+      <name>large_grey_box</name>
+      <pose relative_to="Vessel A">0.08 -0.64 0.2 0 0 -0.3</pose>
+      <uri>
+        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Large Grey Box
+      </uri>
+    </include>
+
+    <include>
+      <name>large_grey_box_a</name>
+      <pose relative_to="Vessel A">0.7 0.23 0.2 0 0 0.2</pose>
+      <uri>
+        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Large Grey Box
+      </uri>
+    </include>
+    -->
+
     <model name="small_box_a">
       <pose>24 26.5 0.5 0 0 0</pose>
       <link name="link">
@@ -365,6 +399,12 @@
       </geofence>
       <target>
         <vessel>Vessel A</vessel>
+        <!--
+        <small_object>small_blue_box</small_object>
+        <small_object>small_blue_box_a</small_object>
+        <large_object>large_grey_box</large_object>
+        <large_object>large_grey_box_a</large_object>
+        -->
         <small_object>small_box_a</small_object>
         <large_object>large_box_a</large_object>
       </target>
@@ -390,5 +430,23 @@
       </link>
     </model>
     -->
+
+    <model name="ocean_entity_detector">
+      <static>true</static>
+      <!-- This plugin detects when target objects are dropped into the ocean
+           at the defined region. A message is published on the <topic> when
+           these events occur -->
+      <plugin filename="libEntityDetector.so"
+              name="mbzirc::EntityDetector">
+        <topic>/mbzirc/target_object_detector/dropped</topic>
+        <pose>0 0 -20 0 0 0</pose>
+        <geometry>
+          <box>
+            <size>140 140 5</size>
+          </box>
+        </geometry>
+      </plugin>
+    </model>
+
   </world>
 </sdf>


### PR DESCRIPTION
New logic added in GameLogicPlugin:
* checks for if any target objects are placed inside the specified regions over the USV
    *  Done using a new `EntityDetector` plugin - code is adapted from [PerfromerDetector](https://github.com/ignitionrobotics/ign-gazebo/tree/ign-gazebo6/src/systems/performer_detector)  but works for all entities.
* user gets 2 tries (hence there are now 2 small and 2 large objects on the target vessel). They only need to place one of each on the USV.
*  objects retrieval must be done in the correct order: small object -> large object
* if object drops into ocean, user gets a time penalty

The target object region placement region is currently quite generous. Green boxes below visualizes the valid region of placement:

![mbzirc_object_placement_region](https://user-images.githubusercontent.com/4000684/161661553-22637a1e-caef-4ff6-8105-900b1292c08c.png)


To test:

1. launch coast world:

    ```
    ros2 launch mbzirc_ros competition.launch.py ign_args:="-v 4 -r coast.sdf"
    ```

1. spawn the USV

    ```
    ros2 launch mbzirc_ign spawn.launch.py name:=usv world:=coast model:=usv type:=usv x:=-1462 y:=-16.5 z:=0.3 R:=0 P:=0 Y:=0
    ```

1. skip the target identification and go straight to the end of identification phase:

    ```
    ign service -s /mbzirc/skip_to_phase --reqtype ignition.msgs.StringMsg --reptype ignition.msgs.Boolean --timeout 300 --req 'data: "large_object_id_success"'
    ```

    You can confirm this by checking the current phase using `ros2 topic echo /mbzirc/phase`

1. Open separate terminals and monitor `events.yml` and `score.yml` logs

    ```
    tail -f  /tmp/ign/mbzirc/logs/events.yml
    ```

    ```
    watch -n 1 -d cat /tmp/ign/mbzirc/logs/score.yml
    ```

1. Test unsuccessful small object retrieval. Drop `small_box_a` into ocean:

    ```
    ign service -s /world/coast/set_pose --reqtype ignition.msgs.Pose --reptype ignition.msgs.Boolean --timeout 300 --req 'name: "small_box_a", position: {x:-1462, y:-10, z: 2.0}'
    ```

    Wait a few secs and you should see a `small_object_retrieve_failure_1` event logged in `events.yml` and the score in `score.yml` jumps by 120s

1. Test successful small object retrieval. Drop `small_box_a_duplicate` onto USV:

    ```
    ign service -s /world/coast/set_pose --reqtype ignition.msgs.Pose --reptype ignition.msgs.Boolean --timeout 300 --req 'name: "small_box_a_duplicate", position: {x:-1462, y:-17.85, z: 2.0}'
    ```

    You should see a `small_object_retrieve_success` event logged in `events.yml` and the score continues to increment by 1s at a time.


1. Test unsuccessful large object retrieval. Drop `large_dry_box_a` into ocean:

    ```
    ign service -s /world/coast/set_pose --reqtype ignition.msgs.Pose --reptype ignition.msgs.Boolean --timeout 300 --req 'name: "large_dry_box_a", position: {x:-1461, y:-10, z: 2.0}'
    ```

    Wait a few secs and you should see a `large_object_retrieve_failure_1` event logged in `events.yml` and the score in `score.yml` jumps by 120s

1. Test successful large object retrieval. Drop `large_dry_box_a_duplicate` onto USV:

    ```
    ign service -s /world/coast/set_pose --reqtype ignition.msgs.Pose --reptype ignition.msgs.Boolean --timeout 300 --req 'name: "large_dry_box_a_duplicate", position: {x:-1462, y:-16.5, z: 2.0}'
    ```

    You should see a `large_object_retrieve_success` event and a `finished` event logged in `events.yml`. Simulation should now be paused to indicate the end of the run.






