### PR TITLE
Adds support for takeoff

### DIFF
--- a/mbzirc_ign/CMakeLists.txt
+++ b/mbzirc_ign/CMakeLists.txt
@@ -21,7 +21,6 @@ find_package(ignition-rendering6 REQUIRED)
 set(IGN_RENDERING_VER ${ignition-rendering6_VERSION_MAJOR})
 find_package(sdformat12 REQUIRED)
 
-find_package(rclcpp REQUIRED)
 find_package(std_msgs REQUIRED)
 
 #============================================================================
@@ -117,7 +116,7 @@ if(BUILD_TESTING)
     )
     target_include_directories(${TEST_TARGET}
       PRIVATE ${CMAKE_BINARY_DIR} ${CMAKE_BINARY_DIR}/proto)
-    target_link_libraries(${TEST_TARGET} ignition-gazebo${IGN_GAZEBO_VER}::ignition-gazebo${IGN_GAZEBO_VER} rclcpp::rclcpp)
+    target_link_libraries(${TEST_TARGET} ignition-gazebo${IGN_GAZEBO_VER}::ignition-gazebo${IGN_GAZEBO_VER})
     set_tests_properties(${TEST_TARGET} PROPERTIES TIMEOUT 120)
   endforeach()
 

--- a/mbzirc_ign/CMakeLists.txt
+++ b/mbzirc_ign/CMakeLists.txt
@@ -23,7 +23,6 @@ find_package(sdformat12 REQUIRED)
 
 find_package(rclcpp REQUIRED)
 find_package(std_msgs REQUIRED)
-find_package(mavros_msgs REQUIRED)
 
 #============================================================================
 # Hooks
@@ -67,8 +66,6 @@ foreach(PLUGIN ${MBZIRC_IGN_PLUGINS})
     Waves
   )
 endforeach()
-
-ament_target_dependencies(FixedWingController PUBLIC rclcpp mavros_msgs)
 
 install(
   TARGETS ${MBZIRC_IGN_PLUGINS}
@@ -119,8 +116,8 @@ if(BUILD_TESTING)
       test/${TEST_TARGET}.cc
     )
     target_include_directories(${TEST_TARGET}
-      PRIVATE ${CMAKE_BINARY_DIR} ${CMAKE_BINARY_DIR}/proto mavros_msgs)
-    target_link_libraries(${TEST_TARGET} ignition-gazebo${IGN_GAZEBO_VER}::ignition-gazebo${IGN_GAZEBO_VER} rclcpp::rclcpp ${mavros_msgs_LIBRARIES})
+      PRIVATE ${CMAKE_BINARY_DIR} ${CMAKE_BINARY_DIR}/proto)
+    target_link_libraries(${TEST_TARGET} ignition-gazebo${IGN_GAZEBO_VER}::ignition-gazebo${IGN_GAZEBO_VER} rclcpp::rclcpp)
     set_tests_properties(${TEST_TARGET} PROPERTIES TIMEOUT 120)
   endforeach()
 

--- a/mbzirc_ign/models/mbzirc_fixed_wing/model.sdf.erb
+++ b/mbzirc_ign/models/mbzirc_fixed_wing/model.sdf.erb
@@ -241,7 +241,7 @@ end
       <roll_p>0.1</roll_p>
       <roll_i>0.01</roll_i>
       <roll_d>0.01</roll_d>
-      <pitch_axis>1 0 0</pitch_axis>
+      <pitch_axis>-1 0 0</pitch_axis>
       <pitch_p>1</pitch_p>
       <pitch_i>0.2</pitch_i>
       <pitch_d>0.1</pitch_d>

--- a/mbzirc_ign/models/mbzirc_fixed_wing_base/model.sdf
+++ b/mbzirc_ign/models/mbzirc_fixed_wing_base/model.sdf
@@ -170,10 +170,42 @@
       </collision>
     </link>
 
-    <!-- This skid is added for launch purposes it makes sure the vehicle is
-    facing slightly upwards-->
-    <link name="skid">
-      <pose>0 -0.3 -0.1 0 0 0</pose>
+    <!-- This skid is added for launch purposes it makes sure the vehicle can 
+      slide-->
+    <link name="front_skid">
+      <pose>0 -0.3 0 0 0 0</pose>
+      <inertial>
+        <pose>0 0 0 0 0 0</pose>
+        <mass>0.1</mass>
+        <inertia>
+          <ixx>0.00016667</ixx>
+          <ixy>0</ixy>
+          <iyy>0.00016667</iyy>
+          <ixz>0</ixz>
+          <iyz>0</iyz>
+          <izz>0.00016667</izz>
+        </inertia>
+      </inertial>
+      <!--
+      <visual name="visual">
+        <geometry>
+          <sphere>
+            <radius>0.3</radius>
+          </sphere>
+        </geometry>
+      </visual>
+      -->
+      <collision name="collision">
+        <geometry>
+          <sphere>
+            <radius>0.31</radius>
+          </sphere>
+        </geometry>
+      </collision>
+    </link>
+
+    <link name="left_skid">
+      <pose>-0.6 0 0 0 0 0</pose>
       <inertial>
         <pose>0 0 0 0 0 0</pose>
         <mass>0.1</mass>
@@ -204,10 +236,73 @@
       </collision>
     </link>
 
-    <joint name="skid_joint" type="fixed">
+    <link name="right_skid">
+      <pose>0.6 0 0 0 0 0</pose>
+      <inertial>
+        <pose>0 0 0 0 0 0</pose>
+        <mass>0.1</mass>
+        <inertia>
+          <ixx>0.00016667</ixx>
+          <ixy>0</ixy>
+          <iyy>0.00016667</iyy>
+          <ixz>0</ixz>
+          <iyz>0</iyz>
+          <izz>0.00016667</izz>
+        </inertia>
+      </inertial>
+      <!--
+      <visual name="visual">
+        <geometry>
+          <sphere>
+            <radius>0.3</radius>
+          </sphere>
+        </geometry>
+      </visual>
+      -->
+      <collision name="collision">
+        <geometry>
+          <sphere>
+            <radius>0.3</radius>
+          </sphere>
+        </geometry>
+      </collision>
+    </link>
+
+
+    <joint name="front_skid_joint" type="revolute">
       <parent>wing</parent>
-      <child>skid</child>
+      <child>front_skid</child>
       <pose>0 0 0 0 0 0</pose>
+      <axis>
+        <xyz>1 0 0</xyz>
+        <dynamics>
+          <damping>0.002</damping>
+        </dynamics>
+      </axis>
+    </joint>
+
+    <joint name="left_skid_joint" type="revolute">
+      <parent>wing</parent>
+      <child>left_skid</child>
+      <pose>0 0 0 0 0 0</pose>
+      <axis>
+        <xyz>1 0 0</xyz>
+        <dynamics>
+          <damping>0.002</damping>
+        </dynamics>
+      </axis>
+    </joint>
+
+    <joint name="right_skid_joint" type="revolute">
+      <parent>wing</parent>
+      <child>right_skid</child>
+      <pose>0 0 0 0 0 0</pose>
+      <axis>
+        <xyz>1 0 0</xyz>
+        <dynamics>
+          <damping>0.002</damping>
+        </dynamics>
+      </axis>
     </joint>
 
     <joint name="propeller_joint" type="revolute">

--- a/mbzirc_ign/package.xml
+++ b/mbzirc_ign/package.xml
@@ -13,14 +13,12 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <build_depend>ament_cmake_python</build_depend>
-  <build_depend>rclcpp</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>mbzirc_ros</build_depend>
 
   <exec_depend>ament_index_python</exec_depend>
   <exec_depend>launch</exec_depend>
   <exec_depend>launch_ros</exec_depend>
-  <exec_depend>rclcpp</exec_depend>
   <exec_depend>ros_ign_gazebo</exec_depend>
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>xacro</exec_depend>

--- a/mbzirc_ign/package.xml
+++ b/mbzirc_ign/package.xml
@@ -16,7 +16,6 @@
   <build_depend>rclcpp</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>mbzirc_ros</build_depend>
-  <build_depend>mavros_msgs</build_depend>
 
   <exec_depend>ament_index_python</exec_depend>
   <exec_depend>launch</exec_depend>

--- a/mbzirc_ign/src/FixedWingController.cc
+++ b/mbzirc_ign/src/FixedWingController.cc
@@ -123,8 +123,7 @@ class mbzirc::FixedWingControllerPrivate
 
   /// \brief Setup the ros node
   /// \param[in] _name Ros node name
-  /// \param[in] _topic Topic to listen on
-  public: void SetupROS(std::string _name, std::string _topic)
+  public: void SetupSubscribers(std::string _name)
   {
     node.Subscribe(_name+"/cmd/target_attitude",
       &FixedWingControllerPrivate::OnAttitudeTarget, this);
@@ -171,9 +170,6 @@ class mbzirc::FixedWingControllerPrivate
     this->takeOffAltitude = takeoff_params.data(1);
     this->mode = Mode::TAKE_OFF;
     _result.set_data(true);
-
-    //std::unique_lock lk(takeOffMutex);
-    //takeOffCv.wait(lk, [this]{return takeOffFlag;});
     return true;
   }
 
@@ -273,8 +269,8 @@ void FixedWingControllerPlugin::Configure(
   }
 
   /// Uncomment for logging
-  igndbg << "initiallized log file" << std::endl;
-  this->dataPtr->logFile.open("zephyr_take_off_controller.csv");
+  //igndbg << "initiallized log file" << std::endl;
+  //this->dataPtr->logFile.open("zephyr_take_off_controller.csv");
 
   /// Setup Roll PID
   if (_sdf->HasElement("roll_p"))
@@ -327,9 +323,7 @@ void FixedWingControllerPlugin::Configure(
   }
 
   /// Start listening to attitude target messages
-  this->dataPtr->SetupROS(
-    _sdf->Get<std::string>("model_name"),
-    _sdf->Get<std::string>("cmd_topic"));
+  this->dataPtr->SetupSubscribers(_sdf->Get<std::string>("model_name"));
 }
 
 /////////////////////////////////////////////////////////////////////
@@ -375,11 +369,6 @@ void FixedWingControllerPlugin::PreUpdate(
       if (pose->Data().Z() >= this->dataPtr->takeOffAltitude) {
         this->dataPtr->mode = FixedWingControllerPrivate::Mode::ATTITUDE_CONTROL;
         this->dataPtr->targetPitch = 0;
-        //{
-        //  std::lock_guard<std::mutex> lock(this->dataPtr->takeOffMutex);
-        //  this->dataPtr->takeOffFlag = true;
-        //  this->dataPtr->takeOffCv.notify_one();
-        //}
       }
     }
     else
@@ -405,8 +394,8 @@ void FixedWingControllerPlugin::PreUpdate(
   }
 
 
-  this->dataPtr->logFile << currPitch << "," << linVel << ", " << cmd << "\n";
-  this->dataPtr->logFile.flush();
+  //this->dataPtr->logFile << currPitch << "," << linVel << ", " << cmd << "\n";
+  //this->dataPtr->logFile.flush();
 
 }
 

--- a/mbzirc_ign/src/FixedWingController.cc
+++ b/mbzirc_ign/src/FixedWingController.cc
@@ -50,8 +50,10 @@ class mbzirc::FixedWingControllerPrivate
   public: enum class Mode
   {
     /// \brief Take off mode
-    TAKE_OFF,
-    /// \brief Auto mode
+    TAKE_OFF_START,
+    /// \brief Enter into a climb
+    TAKE_OFF_CLIMB,
+    /// \brief Just use to maintain attitude
     ATTITUDE_CONTROL
   };
 
@@ -132,6 +134,8 @@ class mbzirc::FixedWingControllerPrivate
       &FixedWingControllerPrivate::TakeOffService, this);
   }
 
+
+
   /// \brief Callback for attitude target messages
   /// \param[in] _msg Attitude target message
   public: void OnAttitudeTarget(const msgs::Float_V& _msg)
@@ -151,6 +155,9 @@ class mbzirc::FixedWingControllerPrivate
     targetRoll = euler.X();
     targetPitch = euler.Y();
     targetVelocity = _msg.data(4);
+
+    this->pitchControl.Reset();
+    this->rollControl.Reset();
   }
 
   /// \brief Take off service
@@ -170,8 +177,11 @@ class mbzirc::FixedWingControllerPrivate
     }
     this->takeOffMinPitch = _takeoffParams.data(0);
     this->takeOffAltitude = _takeoffParams.data(1);
-    this->mode = Mode::TAKE_OFF;
+    this->mode = Mode::TAKE_OFF_START;
     _result.set_data(true);
+
+    this->pitchControl.Reset();
+    this->rollControl.Reset();
     return true;
   }
 
@@ -353,7 +363,8 @@ void FixedWingControllerPlugin::PreUpdate(
 
   auto cmd = 0.0;
 
-  if (this->dataPtr->mode == FixedWingControllerPrivate::Mode::TAKE_OFF) {
+  /// State machine for flight controller
+  if (this->dataPtr->mode == FixedWingControllerPrivate::Mode::TAKE_OFF_START) {
     /// Goal of takeoff controller is to increase altitude as much as possible.
     /// Once a basic airspeed is achieved we adjust the angle of attack.
     /// Fix Thruster power-
@@ -361,37 +372,48 @@ void FixedWingControllerPlugin::PreUpdate(
     thrusterPower.set_data(this->dataPtr->takeOffPower);
     this->dataPtr->thruster.Publish(thrusterPower);
 
+    /// Keep the Aircraft on the runway till ready to take off
+    auto pitchError = rotation.Dot(this->dataPtr->pitchAxis);
+    auto offset = this->dataPtr->pitchControl.Update(pitchError, _info.dt);
+
+    /// Control aerelions
+    msgs::Double leftFlap;
+    leftFlap.set_data(offset);
+    this->dataPtr->leftFlap.Publish(leftFlap);
+
+    msgs::Double rightFlap;
+    rightFlap.set_data(offset);
+    this->dataPtr->rightFlap.Publish(rightFlap);
+    cmd = offset;
+
     /// Detect if sufficient lift is achieved
     if (linVel > this->dataPtr->takeOffSpeed) {
+      /// Transition into climb
+      this->dataPtr->mode = FixedWingControllerPrivate::Mode::TAKE_OFF_CLIMB;
       this->dataPtr->targetVelocity = this->dataPtr->takeOffPower;
       this->dataPtr->targetPitch = std::max(0.1, this->dataPtr->takeOffMinPitch);
-      this->dataPtr->ExecuteAttitudeControlLoop(rotation, _info);
-
-      /// Once target altitude is reached level out.
-      if (pose->Data().Z() >= this->dataPtr->takeOffAltitude) {
-        this->dataPtr->mode = FixedWingControllerPrivate::Mode::ATTITUDE_CONTROL;
-        this->dataPtr->targetPitch = 0;
-      }
-    }
-    else
-    {
-      /// Keep the Aircraft on the runway till ready to take off
-      auto pitchError = rotation.Dot(this->dataPtr->pitchAxis);
-      auto offset = this->dataPtr->pitchControl.Update(pitchError, _info.dt);
-
-      /// Control aerelions
-      msgs::Double leftFlap;
-      leftFlap.set_data(offset);
-      this->dataPtr->leftFlap.Publish(leftFlap);
-
-      msgs::Double rightFlap;
-      rightFlap.set_data(offset);
-      this->dataPtr->rightFlap.Publish(rightFlap);
-      cmd = offset;
-
+      this->dataPtr->rollControl.Reset();
+      this->dataPtr->pitchControl.Reset();
     }
   }
-  else if (this->dataPtr->mode == FixedWingControllerPrivate::Mode::ATTITUDE_CONTROL){
+  else if (
+    this->dataPtr->mode == FixedWingControllerPrivate::Mode::TAKE_OFF_CLIMB)
+  {
+    /// Maintain a fixed climb rate
+    this->dataPtr->targetVelocity = this->dataPtr->takeOffPower;
+    this->dataPtr->targetPitch = std::max(0.1, this->dataPtr->takeOffMinPitch);
+    this->dataPtr->ExecuteAttitudeControlLoop(rotation, _info);
+    /// Once target altitude is reached level out.
+    if (pose->Data().Z() >= this->dataPtr->takeOffAltitude) {
+      this->dataPtr->mode = FixedWingControllerPrivate::Mode::ATTITUDE_CONTROL;
+      this->dataPtr->targetPitch = 0;
+      this->dataPtr->rollControl.Reset();
+      this->dataPtr->pitchControl.Reset();
+    }
+  }
+  else if (
+    this->dataPtr->mode == FixedWingControllerPrivate::Mode::ATTITUDE_CONTROL)
+  {
     this->dataPtr->ExecuteAttitudeControlLoop(rotation, _info);
   }
 

--- a/mbzirc_ign/src/FixedWingController.cc
+++ b/mbzirc_ign/src/FixedWingController.cc
@@ -121,6 +121,9 @@ class mbzirc::FixedWingControllerPrivate
   {
     node.Subscribe(_name+"/cmd/target_attitude",
       &FixedWingControllerPrivate::OnAttitudeTarget, this);
+
+    node.Advertise(_name+"/cmd/takeoff",
+      &FixedWingControllerPrivate::TakeOffService, this);
   }
 
   /// \brief Callback for attitude target messages
@@ -142,6 +145,27 @@ class mbzirc::FixedWingControllerPrivate
     targetRoll = euler.X();
     targetPitch = euler.Y();
     targetVelocity = _msg.data(4);
+  }
+
+  /// \brief Take off service
+  /// \param[in] 
+  public: bool TakeOffService(
+    const msgs::Float_V& takeoff_params,
+    msgs::Boolean &_result)
+  {
+    std::lock_guard<std::mutex> lock(this->mutex);
+    if (takeoff_params.data_size() != 3)
+    {
+      ignerr << "Malformed takeoff parameters" << std::endl;
+      _result.set_data(false);
+      return false;
+    }
+    this->takeOffPower = takeoff_params.data(0);
+    this->takeOffMinPitch = takeoff_params.data(1);
+    this->takeOffAltitude = takeoff_params.data(2);
+    this->mode = Mode::TAKE_OFF;
+    _result.set_data(true);
+    return true;
   }
 
   /// \brief Execute the control loop

--- a/mbzirc_ign/src/FixedWingController.cc
+++ b/mbzirc_ign/src/FixedWingController.cc
@@ -161,15 +161,14 @@ class mbzirc::FixedWingControllerPrivate
     msgs::Boolean &_result)
   {
     std::lock_guard<std::mutex> lock(this->mutex);
-    if (takeoff_params.data_size() != 3)
+    if (takeoff_params.data_size() != 2)
     {
       ignerr << "Malformed takeoff parameters" << std::endl;
       _result.set_data(false);
       return false;
     }
-    this->takeOffPower = takeoff_params.data(0);
-    this->takeOffMinPitch = takeoff_params.data(1);
-    this->takeOffAltitude = takeoff_params.data(2);
+    this->takeOffMinPitch = takeoff_params.data(0);
+    this->takeOffAltitude = takeoff_params.data(1);
     this->mode = Mode::TAKE_OFF;
     _result.set_data(true);
 

--- a/mbzirc_ign/src/FixedWingController.cc
+++ b/mbzirc_ign/src/FixedWingController.cc
@@ -154,20 +154,22 @@ class mbzirc::FixedWingControllerPrivate
   }
 
   /// \brief Take off service
-  /// \param[in] 
+  /// \param[in] takeOffParams - Take off parameters. A float array of 2 
+  /// elements. First being pitch, second being target altitude.
+  /// \param[out] _result - Result of the service call.
   public: bool TakeOffService(
-    const msgs::Float_V& takeoff_params,
+    const msgs::Float_V& _takeoffParams,
     msgs::Boolean &_result)
   {
     std::lock_guard<std::mutex> lock(this->mutex);
-    if (takeoff_params.data_size() != 2)
+    if (_takeoffParams.data_size() != 2)
     {
       ignerr << "Malformed takeoff parameters" << std::endl;
       _result.set_data(false);
       return false;
     }
-    this->takeOffMinPitch = takeoff_params.data(0);
-    this->takeOffAltitude = takeoff_params.data(1);
+    this->takeOffMinPitch = _takeoffParams.data(0);
+    this->takeOffAltitude = _takeoffParams.data(1);
     this->mode = Mode::TAKE_OFF;
     _result.set_data(true);
     return true;

--- a/mbzirc_ign/src/FixedWingController.cc
+++ b/mbzirc_ign/src/FixedWingController.cc
@@ -293,7 +293,7 @@ void FixedWingControllerPlugin::PreUpdate(
     this->dataPtr->thruster.Publish(thrusterPower);
 
     /// Detect if sufficient lift is achieved
-    if(linVel > 20) {
+    if(linVel > this->dataPtr->takeOffSpeed) {
       this->dataPtr->targetVelocity = this->dataPtr->takeOffPower;
       this->dataPtr->targetPitch = 0.1;
       this->dataPtr->mode = FixedWingControllerPrivate::Mode::ATTITUDE_CONTROL;

--- a/mbzirc_ign/src/FixedWingController.cc
+++ b/mbzirc_ign/src/FixedWingController.cc
@@ -116,7 +116,7 @@ class mbzirc::FixedWingControllerPrivate
   public: bool takeOffFlag{false};
 
   /// Uncomment to enable logging for PID tuning
-  public: std::ofstream logFile;
+  ///public: std::ofstream logFile;
 
   /// \brief Mutex for setpoints
   public: std::mutex mutex;

--- a/mbzirc_ign/test/test_fixed_wing.cc
+++ b/mbzirc_ign/test/test_fixed_wing.cc
@@ -55,7 +55,7 @@ TEST_F(MBZIRCTestFixture, FixedWingController)
   LoadWorld("empty_platform.sdf");
 
   std::atomic<bool> keepRunning {true};
-  auto rosThread = std::thread([&](){
+  auto cmdThread = std::thread([&](){
       while(keepRunning)
       {
         ignition::msgs::Float_V msg;
@@ -168,8 +168,8 @@ TEST_F(MBZIRCTestFixture, FixedWingController)
   StopLaunchFile(launchHandle);
 
   keepRunning = false;
-  if (rosThread.joinable())
-    rosThread.join();
+  if (cmdThread.joinable())
+    cmdThread.join();
 
 
   ASSERT_TRUE(spawnedSuccessfully) << "Fixed Wing not spawned";

--- a/mbzirc_ign/test/test_fixed_wing.cc
+++ b/mbzirc_ign/test/test_fixed_wing.cc
@@ -27,38 +27,15 @@
 #include <ignition/gazebo/components.hh>
 #include <ignition/transport/Node.hh>
 
-#include <rclcpp/rclcpp.hpp>
-
-#include <mavros_msgs/msg/attitude_target.hpp>
-
 #include "helper/TestFixture.hh"
 
 using namespace std::chrono_literals;
 
 TEST_F(MBZIRCTestFixture, FixedWingController)
 {
-  // Create a ROS Node to commandeer the fixed wing
-  char const** argv = NULL;
-  if (!rclcpp::ok())
-    rclcpp::init(0, argv);
-  auto rosNode = std::make_shared<rclcpp::Node>("TestFixedWing");
-  auto publisher =
-    rosNode->create_publisher<mavros_msgs::msg::AttitudeTarget>("/zephyr/cmd/attitude", 10);
-  auto timer_ = rosNode->create_wall_timer(100ms, [&]() {
-    mavros_msgs::msg::AttitudeTarget msg;
-    msg.type_mask = mavros_msgs::msg::AttitudeTarget::IGNORE_ROLL_RATE
-      | mavros_msgs::msg::AttitudeTarget::IGNORE_PITCH_RATE
-      | mavros_msgs::msg::AttitudeTarget::IGNORE_ROLL_RATE;
-    msg.orientation.x = 0;
-    msg.orientation.y = 0;
-    msg.orientation.z = 0;
-    msg.orientation.w = 1;
-    msg.thrust = 1000;
-    publisher->publish(msg);
-
-    igndbg << "Publishing attitude target" << std::endl;
-  });
-
+  ignition::transport::Node node;
+  auto pub =
+    node.Advertise<ignition::msgs::Float_V>("/zephyr/cmd/target_attitude");
 
   std::vector<std::pair<std::string,std::string>> params{
     {"name", "zephyr"},
@@ -77,12 +54,18 @@ TEST_F(MBZIRCTestFixture, FixedWingController)
    // Create a Gazebo world
   LoadWorld("empty_platform.sdf");
 
-  std::atomic<bool> keepRosRunning {true};
+  std::atomic<bool> keepRunning {true};
   auto rosThread = std::thread([&](){
-      while(keepRosRunning && rclcpp::ok())
+      while(keepRunning)
       {
-        rclcpp::spin_some(rosNode);
-        std::this_thread::sleep_for(std::chrono::milliseconds(25));
+        ignition::msgs::Float_V msg;
+        msg.add_data(1);
+        msg.add_data(0);
+        msg.add_data(0);
+        msg.add_data(0);
+        msg.add_data(1000);
+        pub.Publish(msg);
+        std::this_thread::sleep_for(100ms);
       }
   });
 
@@ -184,7 +167,7 @@ TEST_F(MBZIRCTestFixture, FixedWingController)
 
   StopLaunchFile(launchHandle);
 
-  keepRosRunning = false;
+  keepRunning = false;
   if (rosThread.joinable())
     rosThread.join();
 

--- a/mbzirc_ign/test/test_gripper.cc
+++ b/mbzirc_ign/test/test_gripper.cc
@@ -30,8 +30,6 @@
 #include <chrono>
 #include <thread>
 
-#include <rclcpp/rclcpp.hpp>
-
 #include "helper/TestFixture.hh"
 
 class GripperTestFixture: public MBZIRCTestFixture

--- a/mbzirc_ign/worlds/coast.sdf
+++ b/mbzirc_ign/worlds/coast.sdf
@@ -347,6 +347,31 @@
       <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Dock</uri>
     </include>
 
+    <model name="fixed_wing_chock">
+      <static>true</static>
+      <pose>-1497.55 0 4.133 0 0 0</pose>
+      <link name="link">
+        <collision name="collision">
+          <geometry>
+            <box>
+              <size>0.1 50 0.1</size>
+            </box>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>0.1 50 0.1</size>
+            </box>
+          </geometry>
+          <material>
+            <diffuse>0.05 0.05 0.05 1.0</diffuse>
+          </material>
+          <cast_shadows>0</cast_shadows>
+        </visual>
+      </link>
+    </model>
+
     <include>
       <name>Beach</name>
       <pose>-1500 0 0 0 0 -1.570796</pose>

--- a/mbzirc_ign/worlds/coast.sdf
+++ b/mbzirc_ign/worlds/coast.sdf
@@ -5,7 +5,7 @@
 
     <physics name="4ms" type="dart">
       <max_step_size>0.004</max_step_size>
-      <real_time_factor>1.0</real_time_factor>
+      <real_time_factor>0.5</real_time_factor>
     </physics>
 
     <gui fullscreen="0">

--- a/mbzirc_ign/worlds/coast.sdf
+++ b/mbzirc_ign/worlds/coast.sdf
@@ -5,7 +5,7 @@
 
     <physics name="4ms" type="dart">
       <max_step_size>0.004</max_step_size>
-      <real_time_factor>0.5</real_time_factor>
+      <real_time_factor>1.0</real_time_factor>
     </physics>
 
     <gui fullscreen="0">

--- a/mbzirc_ros/package.xml
+++ b/mbzirc_ros/package.xml
@@ -15,7 +15,6 @@
   <depend>geometry_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rosgraph_msgs</depend>
-  <depend>mavros_msgs</depend>
   <depend>sensor_msgs</depend>
   <depend>tf2</depend>
   <depend>tf2_ros</depend>

--- a/mbzirc_ros/package.xml
+++ b/mbzirc_ros/package.xml
@@ -15,6 +15,7 @@
   <depend>geometry_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rosgraph_msgs</depend>
+  <depend>mavros_msgs</depend>
   <depend>sensor_msgs</depend>
   <depend>tf2</depend>
   <depend>tf2_ros</depend>


### PR DESCRIPTION
This commit adds support for takeoff behaviour in the flight controller. I also discovered that the pitch axis was flipped. This PR fixes it as well. It also removes the dependency on ros within the ignition plugin. A separate ros bridge was added in #81. The aim is to move that to another bridge node.

![takeoff](https://user-images.githubusercontent.com/542272/161703171-f810d34b-2bea-4dfc-a392-ab7dc410bb4f.gif)

## To test
You will need 3 terminals. In one terminal start gazebo.
```
ign gazebo coast.sdf
```
In another spawn the plane:
```
# Spawns on runway.
ros2 launch mbzirc_ign spawn.launch.py name:=zephyr world:=coast model:=mbzirc_fixed_wing type:=uav x:=-1500 y:=0 z:=5
```
Finally command the plane to take off:
```
ign service -s /zephyr/cmd/takeoff  --reqtype ignition.msgs.Float_V --reptype ignition.msgs.Boolean -r "data: [0.2, 40]" --timeout 10000000
```
The plane should start flying. The format of the last service is [intended pitch, target altitude]
## Todo
- [x] updates tests
- [x] update mavros command interface (see #81)
- [ ] write docs

Signed-off-by: Arjo Chakravarty <arjo@openrobotics.org>