### PR TITLE
Don't bridge low level controls for fixed wings

### DIFF
--- a/mbzirc_ign/src/mbzirc_ign/model.py
+++ b/mbzirc_ign/src/mbzirc_ign/model.py
@@ -77,16 +77,7 @@ class Model:
                 # Air Pressure
                 mbzirc_ign.bridges.air_pressure(world_name, self.model_name),
             ])
-            if self.isFixedWingUAV():
-                bridges.extend([
-                    # Left Flap
-                    mbzirc_ign.bridges.fixed_wing_flap(self.model_name, 'left'),
-                    # Right Flap
-                    mbzirc_ign.bridges.fixed_wing_flap(self.model_name, 'right'),
-                    # Propeller
-                    mbzirc_ign.bridges.fixed_wing_prop(self.model_name),
-                ])
-            else:
+            if not self.isFixedWingUAV():
                 bridges.extend([
                     # twist
                     mbzirc_ign.bridges.cmd_vel(self.model_name)


### PR DESCRIPTION
Since we have an attitude controller, it does not make sense to bridge low level controls to teams for fixed wings as the commands will be over written by the attitude controller. Instead they should publish messages to attitude controllers.

An alternative to this PR would be to have an enable/disable flag for the ttitude controller and bridge that over.

Signed-off-by: Arjo Chakravarty <arjo@openrobotics.org>