### PR TITLE
Pause target vessel trajectory following when identified

### DIFF
--- a/mbzirc_ign/src/GameLogicPlugin.cc
+++ b/mbzirc_ign/src/GameLogicPlugin.cc
@@ -278,6 +278,11 @@ class mbzirc::GameLogicPluginPrivate
                                      Entity _entity,
                                      const math::AxisAlignedBox &_boundary);
 
+
+  /// \brief Pause trajectory following for the specified vessel
+  /// \param[in] _vessel Name of vessel
+  public: void PauseVesselTrajectory(const std::string &_vessel);
+
   /// \brief Valid target reports, add time penalties, and update score
   public: void ValidateTargetReports();
 
@@ -1485,6 +1490,18 @@ bool GameLogicPluginPrivate::OnSkipToPhase(
 }
 
 /////////////////////////////////////////////////
+void GameLogicPluginPrivate::PauseVesselTrajectory(const std::string &_vessel)
+{
+  std::string topic = "/model/" + _vessel + "/trajectory_follower/pause";
+  topic = transport::TopicUtils::AsValidTopic(topic);
+  transport::Node::Publisher pub =
+      this->node.Advertise<ignition::msgs::Boolean>(topic);
+  ignition::msgs::Boolean msg;
+  msg.set_data(true);
+  pub.Publish(msg);
+}
+
+/////////////////////////////////////////////////
 void GameLogicPluginPrivate::ValidateTargetReports()
 {
   std::lock_guard<std::mutex> lock(this->reportMutex);
@@ -1518,6 +1535,11 @@ void GameLogicPluginPrivate::ValidateTargetReports()
         this->LogEvent("target_reported", "vessel_id_success");
         this->currentTargetVessel = vessel;
         this->SetPhase("vessel_id_success");
+
+        ignmsg << "Target vessel identified: " << vessel << ". "
+               << "Pausing trajectory following. " << std::endl;
+        this->PauseVesselTrajectory(vessel);
+
         continue;
       }
       // target has already been reported


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

When the target vessel is identified, it should come to a stop (but still affected by waves) so that the teams can proceed with the intervention task. This PR adds a publisher to the game logic plugin to publish a message to pause the trajectory follower system when target vessel is identified.

To test:

1. Start sim paused

    ```
    ros2 launch ros_ign_gazebo ign_gazebo.launch.py ign_args:="-v 4  coast.sdf
    ```

1. Spawn a quadrotor with downward looking camera

    ```
    ros2 launch mbzirc_ign spawn.launch.py name:=quadrotor_1 world:=simple_demo model:=mbzirc_quadrotor type:=uav x:=-1500 y:=0 z:=4.3 R:=0 P:=0 Y:=0 slot3:=mbzirc_hd_camera
    ```

1. Move the quadrotor over Vessel A
    ```
    ign service -s /world/coast/set_pose --reqtype ignition.msgs.Pose --reptype ignition.msgs.Boolean --timeout 300 --req 'name: "quadrotor_1", position: {x: -1400.5, y:20.5, z:0.5}'
    ```

1. Hit Play. It might take some time for the server side to load 

1. Start stream

    ```
    ign service -s /mbzirc/target/stream/start --reqtype ignition.msgs.StringMsg_V --reptype ignition.msgs.Boolean --timeout 300 --req 'data: ["quadrotor_1", "sensor_3"]'
    ```


1. Wait for the vessel to pick up speed and start moving to its next way point. Then report target vessel

     ```
    ign service -s /mbzirc/target/stream/report --reqtype ignition.msgs.StringMsg_V --reptype ignition.msgs.Boolean --timeout 300 --req 'data: ["vessel", "640", "480"]'
     ```

1. You should see the following msg printed and the vessel slowly comes to a stop.

    ````
    [ign gazebo-1] [Msg] Target vessel identified: Vessel A. Pausing trajectory following.
    ````