### PR TITLE
Fix vessel rocking

### DIFF
--- a/mbzirc_ign/worlds/coast.sdf
+++ b/mbzirc_ign/worlds/coast.sdf
@@ -457,14 +457,14 @@
         <yDotV>0.0</yDotV>
         <nDotR>0.0</nDotR>
         <!-- Linear and quadratic drag -->
-        <xU>51.3</xU>
-        <xUU>72.4</xUU>
-        <yV>40.0</yV>
+        <xU>510.3</xU>
+        <xUU>720.4</xUU>
+        <yV>400.0</yV>
         <yVV>0.0</yVV>
-        <zW>500.0</zW>
-        <kP>50.0</kP>
-        <mQ>50.0</mQ>
-        <nR>400.0</nR>
+        <zW>5000.0</zW>
+        <kP>500.0</kP>
+        <mQ>500.0</mQ>
+        <nR>15000.0</nR>
         <nRR>0.0</nRR>
       </plugin>
 
@@ -481,11 +481,10 @@
         <!-- max_velocity_knots = 1 # Maximum velocity in knots -->
         <!-- max_velocity_mps = max_velocity_knots * 0.5144 # Knots to m/s -->
         <!-- (x_u + x_uu * max_velocity_mps) * max_velocity_mps -->
-        <force>45.55</force>
-        <torque>45.55</torque>
+        <force>453</force>
+        <torque>200</torque>
         <range_tolerance>5</range_tolerance>
         <bearing_tolerance>5</bearing_tolerance>
-        <zero_vel_on_bearing_reached>true</zero_vel_on_bearing_reached>
       </plugin>
     </include>
 
@@ -530,14 +529,14 @@
         <yDotV>0.0</yDotV>
         <nDotR>0.0</nDotR>
         <!-- Linear and quadratic drag -->
-        <xU>102</xU>
-        <xUU>145</xUU>
-        <yV>40.0</yV>
+        <xU>1020</xU>
+        <xUU>1450</xUU>
+        <yV>400.0</yV>
         <yVV>0.0</yVV>
-        <zW>500.0</zW>
-        <kP>50.0</kP>
-        <mQ>50.0</mQ>
-        <nR>400.0</nR>
+        <zW>5000.0</zW>
+        <kP>500.0</kP>
+        <mQ>500.0</mQ>
+        <nR>15000.0</nR>
         <nRR>0.0</nRR>
       </plugin>
 
@@ -554,11 +553,10 @@
         <!-- max_velocity_knots = 1 # Maximum velocity in knots -->
         <!-- max_velocity_mps = max_velocity_knots * 0.5144 # Knots to m/s -->
         <!-- (x_u + x_uu * max_velocity_mps) * max_velocity_mps -->
-        <force>90.8</force>
-        <torque>90.8</torque>
+        <force>908</force>
+        <torque>200</torque>
         <range_tolerance>5</range_tolerance>
         <bearing_tolerance>5</bearing_tolerance>
-        <zero_vel_on_bearing_reached>true</zero_vel_on_bearing_reached>
       </plugin>
     </include>
 
@@ -603,14 +601,14 @@
         <yDotV>0.0</yDotV>
         <nDotR>0.0</nDotR>
         <!-- Linear and quadratic drag -->
-        <xU>102</xU>
-        <xUU>145</xUU>
-        <yV>40.0</yV>
+        <xU>1020</xU>
+        <xUU>1450</xUU>
+        <yV>400.0</yV>
         <yVV>0.0</yVV>
-        <zW>500.0</zW>
-        <kP>50.0</kP>
-        <mQ>50.0</mQ>
-        <nR>400.0</nR>
+        <zW>5000.0</zW>
+        <kP>500.0</kP>
+        <mQ>500.0</mQ>
+        <nR>15000.0</nR>
         <nRR>0.0</nRR>
       </plugin>
 
@@ -627,11 +625,10 @@
         <!-- max_velocity_knots = 1 # Maximum velocity in knots -->
         <!-- max_velocity_mps = max_velocity_knots * 0.5144 # Knots to m/s -->
         <!-- (x_u + x_uu * max_velocity_mps) * max_velocity_mps -->
-        <force>90.8</force>
-        <torque>90.8</torque>
+        <force>908</force>
+        <torque>200</torque>
         <range_tolerance>5</range_tolerance>
         <bearing_tolerance>5</bearing_tolerance>
-        <zero_vel_on_bearing_reached>true</zero_vel_on_bearing_reached>
       </plugin>
     </include>
 
@@ -676,14 +673,14 @@
         <yDotV>0.0</yDotV>
         <nDotR>0.0</nDotR>
         <!-- Linear and quadratic drag -->
-        <xU>102</xU>
-        <xUU>145</xUU>
-        <yV>40.0</yV>
+        <xU>1020</xU>
+        <xUU>1450</xUU>
+        <yV>400.0</yV>
         <yVV>0.0</yVV>
-        <zW>500.0</zW>
-        <kP>50.0</kP>
-        <mQ>50.0</mQ>
-        <nR>400.0</nR>
+        <zW>5000.0</zW>
+        <kP>500.0</kP>
+        <mQ>500.0</mQ>
+        <nR>15000.0</nR>
         <nRR>0.0</nRR>
       </plugin>
 
@@ -700,11 +697,10 @@
         <!-- max_velocity_knots = 1 # Maximum velocity in knots -->
         <!-- max_velocity_mps = max_velocity_knots * 0.5144 # Knots to m/s -->
         <!-- (x_u + x_uu * max_velocity_mps) * max_velocity_mps -->
-        <force>90.8</force>
-        <torque>90.8</torque>
+        <force>908</force>
+        <torque>200</torque>
         <range_tolerance>5</range_tolerance>
         <bearing_tolerance>5</bearing_tolerance>
-        <zero_vel_on_bearing_reached>true</zero_vel_on_bearing_reached>
       </plugin>
     </include>
 
@@ -750,14 +746,14 @@
         <yDotV>0.0</yDotV>
         <nDotR>0.0</nDotR>
         <!-- Linear and quadratic drag -->
-        <xU>77</xU>
-        <xUU>108.6</xUU>
-        <yV>40.0</yV>
+        <xU>770</xU>
+        <xUU>1086</xUU>
+        <yV>400.0</yV>
         <yVV>0.0</yVV>
-        <zW>500.0</zW>
-        <kP>50.0</kP>
-        <mQ>50.0</mQ>
-        <nR>400.0</nR>
+        <zW>5000.0</zW>
+        <kP>500.0</kP>
+        <mQ>500.0</mQ>
+        <nR>15000.0</nR>
         <nRR>0.0</nRR>
       </plugin>
 
@@ -774,11 +770,10 @@
         <!-- max_velocity_knots = 1 # Maximum velocity in knots -->
         <!-- max_velocity_mps = max_velocity_knots * 0.5144 # Knots to m/s -->
         <!-- (x_u + x_uu * max_velocity_mps) * max_velocity_mps -->
-        <force>100</force>
-        <torque>100</torque>
+        <force>1000</force>
+        <torque>200</torque>
         <bearing_tolerance>5</bearing_tolerance>
         <range_tolerance>5</range_tolerance>
-        <zero_vel_on_bearing_reached>true</zero_vel_on_bearing_reached>
       </plugin>
     </include>
 
@@ -823,14 +818,14 @@
         <yDotV>0.0</yDotV>
         <nDotR>0.0</nDotR>
         <!-- Linear and quadratic drag -->
-        <xU>77</xU>
-        <xUU>108.6</xUU>
-        <yV>40.0</yV>
+        <xU>770</xU>
+        <xUU>1086</xUU>
+        <yV>400.0</yV>
         <yVV>0.0</yVV>
-        <zW>500.0</zW>
-        <kP>50.0</kP>
-        <mQ>50.0</mQ>
-        <nR>400.0</nR>
+        <zW>5000.0</zW>
+        <kP>500.0</kP>
+        <mQ>500.0</mQ>
+        <nR>15000.0</nR>
         <nRR>0.0</nRR>
       </plugin>
 
@@ -847,11 +842,10 @@
         <!-- max_velocity_knots = 1 # Maximum velocity in knots -->
         <!-- max_velocity_mps = max_velocity_knots * 0.5144 # Knots to m/s -->
         <!-- (x_u + x_uu * max_velocity_mps) * max_velocity_mps -->
-        <force>100</force>
-        <torque>100</torque>
+        <force>1000</force>
+        <torque>200</torque>
         <bearing_tolerance>5</bearing_tolerance>
         <range_tolerance>5</range_tolerance>
-        <zero_vel_on_bearing_reached>true</zero_vel_on_bearing_reached>
       </plugin>
     </include>
 
@@ -896,14 +890,14 @@
         <yDotV>0.0</yDotV>
         <nDotR>0.0</nDotR>
         <!-- Linear and quadratic drag -->
-        <xU>102</xU>
-        <xUU>145</xUU>
-        <yV>40.0</yV>
+        <xU>1020</xU>
+        <xUU>1450</xUU>
+        <yV>400.0</yV>
         <yVV>0.0</yVV>
-        <zW>500.0</zW>
-        <kP>50.0</kP>
-        <mQ>50.0</mQ>
-        <nR>400.0</nR>
+        <zW>5000.0</zW>
+        <kP>500.0</kP>
+        <mQ>500.0</mQ>
+        <nR>15000.0</nR>
         <nRR>0.0</nRR>
       </plugin>
 
@@ -920,11 +914,10 @@
         <!-- max_velocity_knots = 1 # Maximum velocity in knots -->
         <!-- max_velocity_mps = max_velocity_knots * 0.5144 # Knots to m/s -->
         <!-- (x_u + x_uu * max_velocity_mps) * max_velocity_mps -->
-        <force>90.8</force>
-        <torque>90.8</torque>
+        <force>908</force>
+        <torque>200</torque>
         <range_tolerance>5</range_tolerance>
         <bearing_tolerance>5</bearing_tolerance>
-        <zero_vel_on_bearing_reached>true</zero_vel_on_bearing_reached>
       </plugin>
     </include>
 

--- a/mbzirc_ign/worlds/faster_than_realtime.sdf
+++ b/mbzirc_ign/worlds/faster_than_realtime.sdf
@@ -173,14 +173,14 @@
         <yDotV>0.0</yDotV>
         <nDotR>0.0</nDotR>
         <!-- Linear and quadratic drag -->
-        <xU>51.3</xU>
-        <xUU>72.4</xUU>
-        <yV>40.0</yV>
+        <xU>510.3</xU>
+        <xUU>720.4</xUU>
+        <yV>400.0</yV>
         <yVV>0.0</yVV>
-        <zW>500.0</zW>
-        <kP>50.0</kP>
-        <mQ>50.0</mQ>
-        <nR>400.0</nR>
+        <zW>5000.0</zW>
+        <kP>500.0</kP>
+        <mQ>500.0</mQ>
+        <nR>15000.0</nR>
         <nRR>0.0</nRR>
       </plugin>
     </include>

--- a/mbzirc_ign/worlds/simple_demo.sdf
+++ b/mbzirc_ign/worlds/simple_demo.sdf
@@ -249,14 +249,14 @@
         <yDotV>0.0</yDotV>
         <nDotR>0.0</nDotR>
         <!-- Linear and quadratic drag -->
-        <xU>51.3</xU>
-        <xUU>72.4</xUU>
-        <yV>40.0</yV>
+        <xU>510.3</xU>
+        <xUU>720.4</xUU>
+        <yV>400.0</yV>
         <yVV>0.0</yVV>
-        <zW>500.0</zW>
-        <kP>50.0</kP>
-        <mQ>50.0</mQ>
-        <nR>400.0</nR>
+        <zW>5000.0</zW>
+        <kP>500.0</kP>
+        <mQ>500.0</mQ>
+        <nR>15000.0</nR>
         <nRR>0.0</nRR>
       </plugin>
     </include>


### PR DESCRIPTION
This pull request removes the rocking that some of the vessels where experiencing in the ocean.

**How to test it?**

* Run the coast environment:

```
ros2 launch mbzirc_ros competition_local.launch.py ign_args:="-v 4 -r coast.sdf"
```

Look at vessel A. Before this PR, the boat starts rocking around 1min 20s sim time. It shouldn't happen now. Let it run for some time and verify that the vessel never has a rocking behavior and it starts moving to the waypoints. Additionally watch other vessels and confirm that they also move eventually.

**Here's the long explanation about the rocking:**

The rocking was introduced when the `TrajectoryFollower` plugin was using the `<zero_vel_on_bearing_reached>` option. The problem is the following: The vessel starts rotating to be aligned with the next waypoint. When is fully aligned the `TrajectoryFollower` plugin was setting the angular velocity to zero. Then, it starts moving and approaching the next waypoint. If at some point the vessel becomes misaligned, we remove the `AngularVelocityCmd` command from the `ecm` and let the `TrajectoryFollower` to rotate the vessel again. Here's where the rocking starts. This behavior is kind of expected as we were artificially locking the vessel in roll, pitch yaw and at this point we unlock it. Then, it produces some oscillations until the drag stops it or we lock the vessel again. The solution is not to use `<zero_vel_on_bearing_reached>`.

Now, the original reason for using that option was to avoid the overshooting happening when the vessel is rotating to be aligned with the next waypoint. In order to not overshoot, this pull request makes two changes: (1) it Increases most of the hydrodynamics parameters and specially `<nR>`. The old values were configured for the WAM-V which is approximately an order of magnitude lighter than the vessels. Increasing the parameters will add extra drag to reduce the velocity of the vessel when there's no force/torque applied to it. (2) Increasing the drag also requires to increase the value of `<torque>` and `<force>` in the `TrajectoryFollower` plugin. The new `<torque>` value makes the vessel rotation slower to avoid overshooting.

Note: Additionally, it's possible to make the vessels to rotate faster if we modify `TrajectoryFollower` internally to use a PID. With the changes in this pull request and the PID, the vessel can rotate faster and the overshooting won't happen. I decided not to modify `TrajectoryFollower` for not changing existing behavior but if the new angular velocity of the vessels is too slow we can apply this extra change to `TrajectoryFollower`.