### PR TITLE
Arm custom arm mounting slots

### DIFF
--- a/mbzirc_ign/config/single_usv_with_arm_gripper_config.yaml
+++ b/mbzirc_ign/config/single_usv_with_arm_gripper_config.yaml
@@ -6,3 +6,4 @@ position:
   rpy: [0, 0, 0]
 arm: mbzirc_oberon7_arm
 gripper: mbzirc_oberon7_gripper
+arm_slot: '0'

--- a/mbzirc_ign/launch/spawn.launch.py
+++ b/mbzirc_ign/launch/spawn.launch.py
@@ -77,9 +77,11 @@ def spawn(context, model_type, world_name, model_name, position):
         model.set_flight_time(flight_time)
     elif model.isUSV():
         arm = LaunchConfiguration('arm').perform(context)
+        arm_slot = LaunchConfiguration('arm_slot').perform(context)
 
         model.set_wavefield(world_name)
         model.set_arm(arm)
+        model.set_arm_slot(arm_slot)
 
     model.set_gripper(gripper)
     model.set_payload(payloads)
@@ -246,6 +248,10 @@ def generate_launch_description():
             'gripper',
             default_value='',
             description='gripper model to attach to arm or UAV'),
+        DeclareLaunchArgument(
+            'arm_slot',
+            default_value='0',
+            description='arm slot to attach to usv'),
         DeclareLaunchArgument(
             'slot0',
             default_value='',

--- a/mbzirc_ign/launch/spawn_config.launch.py
+++ b/mbzirc_ign/launch/spawn_config.launch.py
@@ -43,8 +43,7 @@ def spawn(context, config_file, world_name):
         arguments=model.spawn_args()
     )
 
-    nodes = []
-    bridges = model.bridges(world_name)
+    bridges, nodes = model.bridges(world_name)
 
     if model.isUAV():
         [payload_bridges, payload_nodes] = model.payload_bridges(world_name)
@@ -82,7 +81,7 @@ def spawn(context, config_file, world_name):
         package='mbzirc_ros',
         executable='video_target_relay',
         output='screen',
-        parameterss=[{'model_name': model.model_name}]
+        parameters=[{'model_name': model.model_name}]
     ))
 
     group_action = GroupAction([

--- a/mbzirc_ign/models/mbzirc_usv_base/model.sdf
+++ b/mbzirc_ign/models/mbzirc_usv_base/model.sdf
@@ -615,11 +615,6 @@
     <pose>0.0 1.1 0.74 0 0 1.5708</pose>
   </frame>
 
-  <!-- arm slot #1-->
-  <frame name="arm_slot_1">
-    <pose>0.0 -1.1 0.74 0 0 -1.5708</pose>
-  </frame>
-
   <!-- Front payload slot -->
   <frame name="slot_0">
     <pose>0.738 0 0.68 0 0 0</pose>

--- a/mbzirc_ign/models/mbzirc_usv_base/model.sdf
+++ b/mbzirc_ign/models/mbzirc_usv_base/model.sdf
@@ -610,14 +610,14 @@
     <child>right_propeller_link</child>
   </joint>
 
-  <!-- arm slot -->
+  <!-- arm slot #0-->
   <frame name="arm_slot_0">
     <pose>0.0 1.1 0.74 0 0 1.5708</pose>
   </frame>
 
-  <!-- arm slot -->
+  <!-- arm slot #1-->
   <frame name="arm_slot_1">
-    <pose>0.0 -1.1 0.74 0 0 1.5708</pose>
+    <pose>0.0 -1.1 0.74 0 0 -1.5708</pose>
   </frame>
 
   <!-- Front payload slot -->

--- a/mbzirc_ign/models/mbzirc_usv_base/model.sdf
+++ b/mbzirc_ign/models/mbzirc_usv_base/model.sdf
@@ -615,6 +615,11 @@
     <pose>0.0 1.1 0.74 0 0 1.5708</pose>
   </frame>
 
+  <!-- arm slot -->
+  <frame name="arm_slot_1">
+    <pose>0.0 -1.1 0.74 0 0 1.5708</pose>
+  </frame>
+
   <!-- Front payload slot -->
   <frame name="slot_0">
     <pose>0.738 0 0.68 0 0 0</pose>

--- a/mbzirc_ign/models/usv/model.sdf.erb
+++ b/mbzirc_ign/models/usv/model.sdf.erb
@@ -41,6 +41,10 @@ $slot2_rpy = '0 0 0'
 $slot3_payload = nil
 $slot3_rpy = '0 0 0'
 
+$arm_slot_payload = '0'
+if defined?(arm_slot)
+  $arm_slot_payload = arm_slot
+end
 if defined?(slot0)
   $slot0_payload = slot0
 end
@@ -84,10 +88,10 @@ end
     <name>arm</name>
     <uri>model://<%= $arm_name%></uri>
     <placement_frame>arm_mount_point</placement_frame>
-    <pose relative_to="arm_slot_0">0 0 0 0 0 0</pose>
+    <pose relative_to="arm_slot_<%= $arm_slot_payload%>">0 0 0 0 0 0</pose>
   </include>
-  <joint name="arm_slot_0_joint" type="fixed">
-    <parent>arm_slot_0</parent>
+  <joint name="arm_slot_joint" type="fixed">
+    <parent>arm_slot_<%= $arm_slot_payload%></parent>
     <child>arm::arm_mount_point</child>
   </joint>
   <% end %>

--- a/mbzirc_ign/src/mbzirc_ign/model.py
+++ b/mbzirc_ign/src/mbzirc_ign/model.py
@@ -404,6 +404,9 @@ class Model:
         if 'arm' in config:
             model.set_arm(config['arm'])
 
+        if 'arm_slot' in config:
+            model.set_arm_slot(config['arm_slot'])
+
         if 'gripper' in config:
             model.set_gripper(config['gripper'])
 

--- a/mbzirc_ign/src/mbzirc_ign/model.py
+++ b/mbzirc_ign/src/mbzirc_ign/model.py
@@ -62,6 +62,7 @@ class Model:
         self.payload = {}
         self.arm = ''
         self.gripper = ''
+        self.arm_slot = '0'
 
     def isUAV(self):
         return self.model_type in UAVS
@@ -243,6 +244,9 @@ class Model:
     def set_arm(self, arm):
         self.arm = arm
 
+    def set_arm_slot(self, arm_slot):
+        self.arm_slot = arm_slot
+
     def set_gripper(self, gripper):
         self.gripper = gripper
 
@@ -279,6 +283,7 @@ class Model:
             # and also for arm and gripper to generate unique topic names
             if self.hasValidArm():
                 command.append(f'arm={self.arm}')
+                command.append(f'arm_slot={self.arm_slot}')
                 arm_model_file = os.path.join(
                     get_package_share_directory('mbzirc_ign'), 'models',
                     self.arm, 'model.sdf.erb')


### PR DESCRIPTION
Added an extra parameter `arm_slot` that can be used to attach the arm into a custom mounting slot.

Here's the accompanying tutorial:
https://github.com/osrf/mbzirc/wiki/Custom-Arm-Mount

The tutorials shows hot to create a new custom arm slot. Follow the tutorial and you should be able to spawn the arm in the right side of the USV. The default behavior (no `arm_slot` parameter) should still work.