### PR TITLE
Update spawn_config to support spawning robots and bridges separately

### DIFF
--- a/mbzirc_ign/launch/spawn_config.launch.py
+++ b/mbzirc_ign/launch/spawn_config.launch.py
@@ -25,6 +25,8 @@ from launch_ros.actions import PushRosNamespace
 
 from mbzirc_ign.model import Model
 
+import mbzirc_ign.bridges
+
 
 def spawn(context, config_file, world_name):
     with open(config_file, 'r') as stream:
@@ -36,32 +38,99 @@ def spawn(context, config_file, world_name):
     else:
         model = m
 
-    launch_processes = []
-    ignition_spawn_entity = Node(
-        package='ros_ign_gazebo',
-        executable='create',
-        output='screen',
-        arguments=model.spawn_args()
-    )
-    launch_processes.append(ignition_spawn_entity)
+    sim_mode = LaunchConfiguration('sim_mode').perform(context)
+    bridge_competition_topics = LaunchConfiguration('bridge_competition_topics').perform(context)
 
-    bridges, nodes = model.bridges(world_name)
+    launch_processes = []
+
+    if sim_mode == 'full' or sim_mode == 'sim':
+        ignition_spawn_entity = Node(
+            package='ros_ign_gazebo',
+            executable='create',
+            output='screen',
+            arguments=model.spawn_args()
+        )
+        launch_processes.append(ignition_spawn_entity)
+
+    bridges = []
+    nodes = []
     payload_launches = []
 
-    if model.isUAV():
-        [payload_bridges, payload_nodes, payload_launches] = model.payload_bridges(world_name)
-        bridges.extend(payload_bridges)
-        nodes.extend(payload_nodes)
-        payload_launches.extend(payload_launches)
+    if sim_mode == 'full' or sim_mode == 'bridge':
+        bridges, nodes = model.bridges(world_name)
 
-    if model.isFixedWingUAV():
+        if model.isUAV():
+            [payload_bridges, payload_nodes, payload_launches] = model.payload_bridges(world_name)
+            bridges.extend(payload_bridges)
+            nodes.extend(payload_nodes)
+            payload_launches.extend(payload_launches)
+
+        if model.isFixedWingUAV():
+            nodes.append(Node(
+                package='mbzirc_ros',
+                executable='fixed_wing_bridge',
+                output='screen',
+                parameters=[{'model_name': model.model_name}],
+            ))
+
         nodes.append(Node(
-            package='mbzirc_ros',
-            executable='fixed_wing_bridge',
+            package='ros_ign_bridge',
+            executable='parameter_bridge',
             output='screen',
-            parameters=[{'model_name': model.model_name}],
+            arguments=[bridge.argument() for bridge in bridges],
+            remappings=[bridge.remapping() for bridge in bridges],
         ))
 
+        # tf broadcaster
+        nodes.append(Node(
+            package='mbzirc_ros',
+            executable='pose_tf_broadcaster',
+            output='screen',
+            parameters=[
+                {'world_frame': world_name}
+            ]
+        ))
+
+        # video target relay
+        nodes.append(Node(
+            package='mbzirc_ros',
+            executable='video_target_relay',
+            output='screen',
+            parameters=[{'model_name': model.model_name}]
+        ))
+
+        group_action = GroupAction([
+            PushRosNamespace(model.model_name),
+            *nodes
+        ])
+
+        if sim_mode == 'full':
+            handler = RegisterEventHandler(
+                event_handler=OnProcessExit(
+                    target_action=ignition_spawn_entity,
+                    on_exit=[group_action],
+                )
+            )
+            launch_processes.append(handler)
+        elif sim_mode == 'bridge':
+            launch_processes.append(group_action)
+
+        launch_processes.extend(payload_launches)
+
+    if sim_mode == 'bridge' and bridge_competition_topics:
+        launch_processes.extend(launch_competition_bridges())
+    return launch_processes
+
+
+def launch_competition_bridges():
+    bridges = [
+        mbzirc_ign.bridges.score(),
+        mbzirc_ign.bridges.clock(),
+        mbzirc_ign.bridges.run_clock(),
+        mbzirc_ign.bridges.phase(),
+        mbzirc_ign.bridges.stream_status(),
+    ]
+    nodes = []
     nodes.append(Node(
         package='ros_ign_bridge',
         executable='parameter_bridge',
@@ -70,39 +139,7 @@ def spawn(context, config_file, world_name):
         remappings=[bridge.remapping() for bridge in bridges],
     ))
 
-    # tf broadcaster
-    nodes.append(Node(
-        package='mbzirc_ros',
-        executable='pose_tf_broadcaster',
-        output='screen',
-        parameters=[
-            {'world_frame': world_name}
-        ]
-    ))
-
-    # video target relay
-    nodes.append(Node(
-        package='mbzirc_ros',
-        executable='video_target_relay',
-        output='screen',
-        parameters=[{'model_name': model.model_name}]
-    ))
-
-    group_action = GroupAction([
-        PushRosNamespace(model.model_name),
-        *nodes
-    ])
-
-    handler = RegisterEventHandler(
-        event_handler=OnProcessExit(
-            target_action=ignition_spawn_entity,
-            on_exit=[group_action],
-        )
-    )
-    launch_processes.append(handler)
-    launch_processes.extend(payload_launches)
-
-    return launch_processes
+    return nodes
 
 
 def launch(context, *args, **kwargs):
@@ -122,7 +159,17 @@ def generate_launch_description():
         DeclareLaunchArgument(
             'config_file',
             description='YAML configuration file to spawn'),
-
+        DeclareLaunchArgument(
+            'sim_mode',
+            default_value='full',
+            description='Simulation mode: "full", "sim", "bridge".'
+                        'full: spawns robot and launch ros_ign bridges, '
+                        'sim: spawns robot only, '
+                        'bridge: launch ros_ign bridges only.'),
+        DeclareLaunchArgument(
+            'bridge_competition_topics',
+            default_value='True',
+            description='True to bridge competition topics, False to disable bridge.'),
         # launch setup
         OpaqueFunction(function=launch)
     ])


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

Ported changes from https://github.com/osrf/mbzirc/pull/97 to `spawn_config.launch.py`. The changes are mainly for separating the logic for spawning robots models from spawning bridges in preparation for running the simulation on multiple machines

Easier to review without whitespace diff:
https://github.com/osrf/mbzirc/pull/107/files?w=1

To test:

```sh
# launch simulation only with no competition topic bridges
ros2 launch ros_ign_gazebo ign_gazebo.launch.py ign_args:="-v 4 -r simple_demo.sdf"

# spawn a UAV into simulation with no bridges. This is to be run ion the sim container.
ros2 launch mbzirc_ign spawn_config.launch.py world:=simple_demo config_file:=./src/mbzirc/mbzirc_ign/config/single_uav_config.yaml sim_mode:=sim

# launch bridge processes for the UAV. This is to be run on the bridge container
ros2 launch mbzirc_ign spawn_config.launch.py world:=simple_demo config_file:=./src/mbzirc/mbzirc_ign/config/single_uav_config.yaml sim_mode:=bridge
```

To spawn more robots into the simulation locally, you'll need to disable the competition topic bridges:

```sh
# spawn USV with no bridges
ros2 launch mbzirc_ign spawn_config.launch.py world:=simple_demo config_file:=./src/mbzirc/mbzirc_ign/config/single_usv_config.yaml sim_mode:=sim

# spawn USV bridges but disable competition topics since those were already bridged (for local testing only)
ros2 launch mbzirc_ign spawn_config.launch.py world:=simple_demo config_file:=./src/mbzirc/mbzirc_ign/config/single_usv_config.yaml sim_mode:=bridge bridge_competition_topics:=False
```
