### PR TITLE
Disable sensors on drained battery

### DIFF
--- a/mbzirc_ign/worlds/coast.sdf
+++ b/mbzirc_ign/worlds/coast.sdf
@@ -279,6 +279,7 @@
       filename="ignition-gazebo-sensors-system"
       name="ignition::gazebo::systems::Sensors">
       <render_engine>ogre2</render_engine>
+      <disable_on_drained_battery>true</disable_on_drained_battery>
     </plugin>
     <plugin
       filename="ignition-gazebo-air-pressure-system"

--- a/mbzirc_ign/worlds/simple_demo.sdf
+++ b/mbzirc_ign/worlds/simple_demo.sdf
@@ -20,6 +20,7 @@
       filename="ignition-gazebo-sensors-system"
       name="ignition::gazebo::systems::Sensors">
       <render_engine>ogre2</render_engine>
+      <disable_on_drained_battery>true</disable_on_drained_battery>
     </plugin>
     <plugin
       filename="ignition-gazebo-air-pressure-system"


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

Adds the `<disable_on_drained_battery>` parameter in sensors system introduced in https://github.com/gazebosim/gz-sim/pull/1385

This sets the sensors active state of `false` to prevent them from publishing data once the battery is completely drained.