### PR TITLE
Omit waves from lidar returns

### DIFF
--- a/mbzirc_custom/mbzirc_naive_spinning_radar/models/sensors/mbzirc_naive_spinning_radar/model.sdf
+++ b/mbzirc_custom/mbzirc_naive_spinning_radar/models/sensors/mbzirc_naive_spinning_radar/model.sdf
@@ -48,6 +48,7 @@
             <mean>0</mean>
             <stddev>2</stddev>
           </noise>
+          <visibility_mask>55</visibility_mask>
         </lidar>
       </sensor>
     </link>

--- a/mbzirc_custom/mbzirc_point_lidar/models/sensors/mbzirc_point_lidar/model.sdf
+++ b/mbzirc_custom/mbzirc_point_lidar/models/sensors/mbzirc_point_lidar/model.sdf
@@ -34,6 +34,7 @@
             <mean>0</mean>
             <stddev>0.01</stddev>
           </noise>
+          <visibility_mask>55</visibility_mask>
         </lidar>
       </sensor>
     </link>

--- a/mbzirc_ign/models/coast_waves/model.sdf
+++ b/mbzirc_ign/models/coast_waves/model.sdf
@@ -42,6 +42,7 @@
             </wave>
           </wavefield>
         </plugin>
+        <visibility_flags>8</visibility_flags>
       </visual>
     </link>
   </model>

--- a/mbzirc_ign/models/sensors/mbzirc_3d_lidar/model.sdf
+++ b/mbzirc_ign/models/sensors/mbzirc_3d_lidar/model.sdf
@@ -40,6 +40,7 @@
                         <mean>0</mean>
                         <stddev>0.01</stddev>
                     </noise>
+                    <visibility_mask>55</visibility_mask>
                 </lidar>
             </sensor>
         </link>

--- a/mbzirc_ign/models/sensors/mbzirc_planar_lidar/model.sdf
+++ b/mbzirc_ign/models/sensors/mbzirc_planar_lidar/model.sdf
@@ -34,6 +34,7 @@
                         <mean>0</mean>
                         <stddev>0.01</stddev>
                     </noise>
+                    <visibility_mask>55</visibility_mask>
                 </lidar>
             </sensor>
         </link>

--- a/mbzirc_ign/models/waves/model.sdf
+++ b/mbzirc_ign/models/waves/model.sdf
@@ -33,6 +33,7 @@
             </wave>
           </wavefield>
         </plugin>
+        <visibility_flags>8</visibility_flags>
       </visual>
     </link>
   </model>


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

Depends on:
* https://github.com/gazebosim/sdformat/pull/1015
* https://github.com/gazebosim/gz-rendering/pull/625
* https://github.com/gazebosim/gz-sensors/pull/224

Sets visibility mask to lidar and visbility flags to the waves model so that the lidar sensor does not detect waves.

Before - lidar point cloud visualization shows points on the surface of the water plane:
![lidar_water_before](https://user-images.githubusercontent.com/4000684/167957995-0536e291-1dc4-4194-a3cb-c3fdd1a8ed57.png)


After - lidar no longer detects waves:
![lidar_water_after](https://user-images.githubusercontent.com/4000684/167958012-a1931e19-ead5-41d2-96f6-83d33ae9b9e9.png)


