### PR TITLE
Fix suction gripper test

### DIFF
--- a/mbzirc_ign/CMakeLists.txt
+++ b/mbzirc_ign/CMakeLists.txt
@@ -123,7 +123,7 @@ if(BUILD_TESTING)
     test_game_logic
     test_spawn_usv_maxspeed
     test_fixed_wing
-    # test_gripper
+    test_gripper
     test_spawn_usv_arm
     )
     ament_add_gtest(

--- a/mbzirc_ign/test/test_gripper.cc
+++ b/mbzirc_ign/test/test_gripper.cc
@@ -103,15 +103,17 @@ TEST_F(GripperTestFixture, GripperController)
   }
   // Move arm to pick up object
   ignition::msgs::Double gripperMsg;
-  gripperMsg.set_data(1.57);
+  gripperMsg.set_data(1.56);
   gripper_pub.Publish(gripperMsg);
-  Step(20000);
+  Step(6000);
   //using namespace std::chrono_literals;
   //std::this_thread::sleep_for(2000ms);
   {
     //std::lock_guard<std::mutex> lock(pos_mutex);
-    EXPECT_NEAR(pos.X(), 1, 1e-3);
-    EXPECT_NEAR(pos.Y(), 0, 1e-2);
+    // large tol because the arm moves the cube slightly
+    // when in contact
+    EXPECT_NEAR(pos.X(), 1.01, 1e-2);
+    EXPECT_NEAR(pos.Y(), 0, 1e-1);
     igndbg << pos <<"\n";
   }
 

--- a/mbzirc_ign/worlds/test/suction_gripper.sdf
+++ b/mbzirc_ign/worlds/test/suction_gripper.sdf
@@ -79,7 +79,7 @@
         </visual>
       </link>
       <link name="arm_link">
-        <pose>0 0 0.1 1.57 0 0</pose>
+        <pose>0 0 0.08 1.57 0 0</pose>
         <collision name="arm_collision">
           <geometry>
             <cylinder>
@@ -101,15 +101,178 @@
             <specular>0 0 0.8 1</specular>
           </material>
         </visual>
-        <sensor name='sensor_contact' type='contact'>
+
+        <visual name="arm_contact_visual_11">
+          <pose>0.01 0 0.97 0 1.57 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.001</radius>
+              <length>0.001</length>
+            </cylinder>
+          </geometry>
+          <material>
+            <ambient>0 0.8 0 1</ambient>
+            <diffuse>0 0.8 0 1</diffuse>
+            <specular>0 0.8 0 1</specular>
+          </material>
+        </visual>
+
+        <collision name="arm_contact_collision_11">
+          <pose>0.01 0 0.97 0 1.57 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.001</radius>
+              <length>0.001</length>
+            </cylinder>
+          </geometry>
+        </collision>
+
+        <sensor name='sensor_contact_11' type='contact'>
           <contact>
-            <collision>arm_collision</collision>
-            <topic>/arm_contact</topic>
+            <collision>arm_contact_collision_11</collision>
+            <topic>/arm/contact_sensor_11</topic>
           </contact>
           <always_on>1</always_on>
           <update_rate>100</update_rate>
         </sensor>
-      </link>
+
+        <visual name="arm_contact_visual_01">
+          <pose>0.01 0.003 0.97 0 1.57 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.001</radius>
+              <length>0.001</length>
+            </cylinder>
+          </geometry>
+          <material>
+            <ambient>0 0.8 0 1</ambient>
+            <diffuse>0 0.8 0 1</diffuse>
+            <specular>0 0.8 0 1</specular>
+          </material>
+        </visual>
+
+        <collision name="arm_contact_collision_01">
+          <pose>0.01 0.003 0.97 0 1.57 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.001</radius>
+              <length>0.001</length>
+            </cylinder>
+          </geometry>
+        </collision>
+
+        <sensor name='sensor_contact_01' type='contact'>
+          <contact>
+            <collision>arm_contact_collision_01</collision>
+            <topic>/arm/contact_sensor_01</topic>
+          </contact>
+          <always_on>1</always_on>
+          <update_rate>100</update_rate>
+        </sensor>
+
+        <visual name="arm_contact_visual_21">
+          <pose>0.01 -0.003 0.97 0 1.57 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.001</radius>
+              <length>0.001</length>
+            </cylinder>
+          </geometry>
+          <material>
+            <ambient>0 0.8 0 1</ambient>
+            <diffuse>0 0.8 0 1</diffuse>
+            <specular>0 0.8 0 1</specular>
+          </material>
+        </visual>
+
+        <collision name="arm_contact_collision_21">
+          <pose>0.01 -0.003 0.97 0 1.57 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.001</radius>
+              <length>0.001</length>
+            </cylinder>
+          </geometry>
+        </collision>
+
+        <sensor name='sensor_contact_21' type='contact'>
+          <contact>
+            <collision>arm_contact_collision_21</collision>
+            <topic>/arm/contact_sensor_21</topic>
+          </contact>
+          <always_on>1</always_on>
+          <update_rate>100</update_rate>
+        </sensor>
+
+        <visual name="arm_contact_visual_10">
+          <pose>0.01 0.0 0.967 0 1.57 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.001</radius>
+              <length>0.001</length>
+            </cylinder>
+          </geometry>
+          <material>
+            <ambient>0 0.8 0 1</ambient>
+            <diffuse>0 0.8 0 1</diffuse>
+            <specular>0 0.8 0 1</specular>
+          </material>
+        </visual>
+
+        <collision name="arm_contact_collision_10">
+          <pose>0.01 0.0 0.967 0 1.57 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.001</radius>
+              <length>0.001</length>
+            </cylinder>
+          </geometry>
+        </collision>
+
+        <sensor name='sensor_contact_10' type='contact'>
+          <contact>
+            <collision>arm_contact_collision_10</collision>
+            <topic>/arm/contact_sensor_10</topic>
+          </contact>
+          <always_on>1</always_on>
+          <update_rate>100</update_rate>
+        </sensor>
+
+        <visual name="arm_contact_visual_12">
+          <pose>0.01 0.0 0.973 0 1.57 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.001</radius>
+              <length>0.001</length>
+            </cylinder>
+          </geometry>
+          <material>
+            <ambient>0 0.8 0 1</ambient>
+            <diffuse>0 0.8 0 1</diffuse>
+            <specular>0 0.8 0 1</specular>
+          </material>
+        </visual>
+
+        <collision name="arm_contact_collision_12">
+          <pose>0.01 0.0 0.973 0 1.57 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.001</radius>
+              <length>0.001</length>
+            </cylinder>
+          </geometry>
+        </collision>
+
+        <sensor name='sensor_contact_12' type='contact'>
+          <contact>
+            <collision>arm_contact_collision_12</collision>
+            <topic>/arm/contact_sensor_12</topic>
+          </contact>
+          <always_on>1</always_on>
+          <update_rate>100</update_rate>
+        </sensor>
+
+     </link>
       <joint name="panda_joint_world" type="fixed">
         <parent>world</parent>
         <child>base_link</child>
@@ -122,7 +285,7 @@
           <limit>
             <lower>-1.57</lower>
             <upper>1.57</upper>
-            <effort>0.5</effort>
+            <velocity>0.1</velocity>
           </limit>
         </axis>
       </joint>
@@ -130,20 +293,31 @@
         filename="ignition-gazebo-joint-position-controller-system"
         name="ignition::gazebo::systems::JointPositionController">
         <joint_name>suction_gripper_joint</joint_name>
-        <p_gain>0.1</p_gain>
+        <use_velocity_commands>true</use_velocity_commands>
       </plugin>
       <plugin
         filename="libSuctionGripper.so"
         name="mbzirc::SuctionGripperPlugin">
         <parent_link>arm_link</parent_link>
-        <contact_sensor_topic>arm_contact</contact_sensor_topic>
+        <contact_sensor_topic_prefix>/arm</contact_sensor_topic_prefix>
         <command_topic>gripper/suction_on</command_topic>
       </plugin>
     </model>
 
     <model name="object">
-      <pose>1 0 0.05 0 0 0</pose>
+      <pose>1.01 0 0.05 0 0 0</pose>
       <link name="object_1">
+        <inertial>
+          <mass>100</mass>
+          <inertia>
+            <ixx>0.167</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.167</iyy>
+            <iyz>0</iyz>
+            <izz>0.167</izz>
+          </inertia>
+        </inertial>
         <collision name="object_1_col">
           <geometry>
             <box>


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

Added mini suction gripper to the arm in the test:

![mini_suction_gripper](https://user-images.githubusercontent.com/4000684/168192039-a2369435-d938-4451-a3e7-dacdcf9adc31.png)

It was a bit difficult to have contacts on more than one gripper cylinder collisions so I had to tune a few params around.

