### PR TITLE
Bump tx power

### DIFF
--- a/mbzirc_ign/worlds/coast.sdf
+++ b/mbzirc_ign/worlds/coast.sdf
@@ -322,7 +322,7 @@
       </range_config>
       <radio_config>
         <capacity>1000000</capacity>
-        <tx_power>20</tx_power>
+        <tx_power>25</tx_power>
         <noise_floor>-90</noise_floor>
         <modulation>QPSK</modulation>
       </radio_config>

--- a/mbzirc_ign/worlds/simple_demo.sdf
+++ b/mbzirc_ign/worlds/simple_demo.sdf
@@ -65,7 +65,7 @@
       </range_config>
       <radio_config>
         <capacity>1000000</capacity>
-        <tx_power>20</tx_power>
+        <tx_power>25</tx_power>
         <noise_floor>-90</noise_floor>
         <modulation>QPSK</modulation>
       </radio_config>


### PR DESCRIPTION
I just bumped the tx power used in the comms from 20 to 25 dBm to increase the communication range a bit.

Signed-off-by: Carlos Agüero <caguero@openrobotics.org>