### PR TITLE
Update thruster joint rotation to match spec

### DIFF
--- a/mbzirc_ign/models/mbzirc_usv_base/model.sdf
+++ b/mbzirc_ign/models/mbzirc_usv_base/model.sdf
@@ -546,10 +546,10 @@
     <axis>
       <xyz>0 0 1</xyz>
       <limit>
-        <lower>-1.57079</lower>
-        <upper>1.57079</upper>
+        <lower>0</lower>
+        <upper>3.14159</upper>
         <effort>10</effort>
-        <velocity>10</velocity>
+        <velocity>0.2618</velocity>
       </limit>
     </axis>
     <parent>base_link</parent>
@@ -576,10 +576,10 @@
     <axis>
       <xyz>0 0 1</xyz>
       <limit>
-        <lower>-1.57079</lower>
-        <upper>1.57079</upper>
+        <lower>0</lower>
+        <upper>3.14159</upper>
         <effort>10</effort>
-        <velocity>10</velocity>
+        <velocity>0.2618</velocity>
       </limit>
     </axis>
     <parent>base_link</parent>


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

Fixes https://github.com/osrf/mbzirc/issues/117

Updated joint limits to match the rotation angle in the USV spec (at bottom of page): https://www.mbzirc.com/grand-challenge#loop-10

I also brought back the changes for the rotation speed from https://github.com/osrf/mbzirc/pull/33 which were probably lost during the last refactor.


