### PR TITLE
Add simple arm example

### DIFF
--- a/mbzirc_custom/mbzirc_simple_arm/CMakeLists.txt
+++ b/mbzirc_custom/mbzirc_simple_arm/CMakeLists.txt
@@ -1,0 +1,17 @@
+cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
+
+project(mbzirc_simple_arm)
+
+find_package(ament_cmake REQUIRED)
+
+# Hooks
+ament_environment_hooks("hooks/resource_paths.dsv.in")
+ament_environment_hooks("hooks/resource_paths.sh")
+
+# Uncomment the install call below to install the example simple arm model
+install(DIRECTORY
+  models
+  # launch
+  DESTINATION share/${PROJECT_NAME})
+
+ament_package()

--- a/mbzirc_custom/mbzirc_simple_arm/CMakeLists.txt
+++ b/mbzirc_custom/mbzirc_simple_arm/CMakeLists.txt
@@ -11,7 +11,7 @@ ament_environment_hooks("hooks/resource_paths.sh")
 # Uncomment the install call below to install the example simple arm model
 install(DIRECTORY
   models
-  # launch
+  launch
   DESTINATION share/${PROJECT_NAME})
 
 ament_package()

--- a/mbzirc_custom/mbzirc_simple_arm/CMakeLists.txt
+++ b/mbzirc_custom/mbzirc_simple_arm/CMakeLists.txt
@@ -9,9 +9,9 @@ ament_environment_hooks("hooks/resource_paths.dsv.in")
 ament_environment_hooks("hooks/resource_paths.sh")
 
 # Uncomment the install call below to install the example simple arm model
-install(DIRECTORY
-  models
-  launch
-  DESTINATION share/${PROJECT_NAME})
+# install(DIRECTORY
+#   models
+#   launch
+#   DESTINATION share/${PROJECT_NAME})
 
 ament_package()

--- a/mbzirc_custom/mbzirc_simple_arm/hooks/resource_paths.dsv.in
+++ b/mbzirc_custom/mbzirc_simple_arm/hooks/resource_paths.dsv.in
@@ -1,0 +1,3 @@
+prepend-non-duplicate;IGN_GAZEBO_RESOURCE_PATH;@CMAKE_INSTALL_PREFIX@/share/@PROJECT_NAME@/models
+prepend-non-duplicate;IGN_GAZEBO_SYSTEM_PLUGIN_PATH;@CMAKE_INSTALL_PREFIX@/lib
+prepend-non-duplicate;LD_LIBRARY_PATH;@CMAKE_INSTALL_PREFIX@/lib

--- a/mbzirc_custom/mbzirc_simple_arm/hooks/resource_paths.sh
+++ b/mbzirc_custom/mbzirc_simple_arm/hooks/resource_paths.sh
@@ -1,0 +1,3 @@
+ament_prepend_unique_value IGN_GAZEBO_RESOURCE_PATH "$AMENT_CURRENT_PREFIX/share/@PROJECT_NAME@/models"
+ament_prepend_unique_value IGN_GAZEBO_SYSTEM_PLUGIN_PATH "$AMENT_CURRENT_PREFIX/lib"
+ament_prepend_unique_value LD_LIBRARY_PATH "$AMENT_CURRENT_PREFIX/lib"

--- a/mbzirc_custom/mbzirc_simple_arm/models/mbzirc_simple_arm/model.config
+++ b/mbzirc_custom/mbzirc_simple_arm/models/mbzirc_simple_arm/model.config
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+
+<model>
+  <name>MBZIRC Simple Arm</name>
+  <version>1.0</version>
+  <sdf version="1.9">model.sdf</sdf>
+
+  <description>
+    Simple arm example for MBZIRC
+  </description>
+</model>

--- a/mbzirc_custom/mbzirc_simple_arm/models/mbzirc_simple_arm/model.sdf.erb
+++ b/mbzirc_custom/mbzirc_simple_arm/models/mbzirc_simple_arm/model.sdf.erb
@@ -120,7 +120,7 @@ end
     </link>
 
     <frame name="gripper_mount_point">
-      <pose relative_to='joint_2'>0.01 0 0 0 0 0</pose>
+      <pose relative_to='joint_2'>0.0 0 0 0 0 0</pose>
     </frame>
 
     <include>

--- a/mbzirc_custom/mbzirc_simple_arm/models/mbzirc_simple_arm/model.sdf.erb
+++ b/mbzirc_custom/mbzirc_simple_arm/models/mbzirc_simple_arm/model.sdf.erb
@@ -1,0 +1,217 @@
+<%
+if !defined?(topic_prefix) || topic_prefix == nil || topic_prefix.empty?
+  $topic_prefix = ''
+else
+  $topic_prefix = topic_prefix
+end
+
+if !defined?(gripper) || gripper== nil || gripper.empty?
+  $gripper_model = 'mbzirc_oberon7_gripper'
+else
+  $gripper_model = gripper
+end
+%>
+
+<?xml version="1.0" ?>
+<sdf version='1.9'>
+  <model name="simple_arm">
+    <link name='base_link'>
+      <inertial>
+        <pose>0 0 0.0 0 0 0</pose>
+        <mass>10</mass>
+        <inertia>
+          <ixx>0.03333333</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>0.03333333</iyy>
+          <iyz>0</iyz>
+          <izz>0.05000000</izz>
+        </inertia>
+      </inertial>
+      <collision name="base_link_collision">
+        <pose>0 0 0 0 0 0</pose>
+        <geometry>
+          <cylinder>
+            <length>0.1</length>
+            <radius>0.1</radius>
+          </cylinder>
+        </geometry>
+      </collision>
+      <visual name='base_link_visual'>
+        <pose>0 0 0 0 0 0</pose>
+        <geometry>
+          <cylinder>
+            <length>0.1</length>
+            <radius>0.1</radius>
+          </cylinder>
+        </geometry>
+        <material>
+          <diffuse>0.05 0.05 0.05</diffuse>
+        </material>
+      </visual>
+    </link>
+    <link name='lower_arm_link'>
+      <pose relative_to='base_link'>0.375 0.0 0.0 0 1.570796 0</pose>
+      <inertial>
+        <pose>0.0 0.0 0.0 0 0 0</pose>
+        <mass>10</mass>
+        <inertia>
+          <ixx>0.49375000</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>0.49375000</iyy>
+          <iyz>0</iyz>
+          <izz>0.05</izz>
+        </inertia>
+      </inertial>
+      <collision name='lower_link_collision'>
+        <geometry>
+          <cylinder>
+            <length>0.5</length>
+            <radius>0.1</radius>
+          </cylinder>
+        </geometry>
+      </collision>
+      <visual name='lower_link_visual'>
+        <geometry>
+          <cylinder>
+            <length>0.75</length>
+            <radius>0.1</radius>
+          </cylinder>
+        </geometry>
+        <material>
+          <diffuse>0.05 0.05 0.05</diffuse>
+        </material>
+      </visual>
+    </link>
+    <link name='upper_arm_link'>
+      <pose relative_to='joint_1'>0.375 0.0 0.0 0 1.570796 0</pose>
+      <inertial>
+        <pose>0 0 0 0 0 0</pose>
+        <mass>10</mass>
+        <inertia>
+          <ixx>0.49375000</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>0.49375000</iyy>
+          <iyz>0</iyz>
+          <izz>0.05</izz>
+        </inertia>
+      </inertial>
+      <collision name='upper_link_collision'>
+        <geometry>
+          <cylinder>
+            <length>0.5</length>
+            <radius>0.1</radius>
+          </cylinder>
+        </geometry>
+      </collision>
+      <visual name='upper_link_visual'>
+        <geometry>
+          <cylinder>
+            <length>0.75</length>
+            <radius>0.1</radius>
+          </cylinder>
+        </geometry>
+        <material>
+          <diffuse>0.05 0.05 0.05</diffuse>
+        </material>
+      </visual>
+    </link>
+
+    <frame name="gripper_mount_point">
+      <pose relative_to='joint_2'>0.01 0 0 0 0 0</pose>
+    </frame>
+
+    <include>
+      <name>gripper</name>
+      <uri>model://<%= $gripper_model%></uri>
+      <placement_frame>mount_point</placement_frame>
+      <pose relative_to="gripper_mount_point">0 0 0 0 0 0</pose>
+    </include>
+
+    <joint name='joint_0' type='revolute'>
+      <pose relative_to='base_link'>0.0 0.0 0.0 0 0 0</pose>
+      <parent>base_link</parent>
+      <child>lower_arm_link</child>
+      <axis>
+        <xyz>0 -1 0</xyz>
+        <limit>
+          <lower>-1.570796</lower>
+          <upper>1.5707896</upper>
+          <effort>500</effort>
+          <velocity>0.15</velocity>
+        </limit>
+      </axis>
+    </joint>
+
+    <joint name='joint_1' type='revolute'>
+      <pose relative_to='joint_0'>0.75 0.0 0.0 0 1.570796 0</pose>
+      <parent>lower_arm_link</parent>
+      <child>upper_arm_link</child>
+      <axis>
+        <xyz>0 -1 0</xyz>
+        <limit>
+          <lower>-1.570796</lower>
+          <upper>1.5707896</upper>
+          <effort>500</effort>
+          <velocity>0.15</velocity>
+        </limit>
+      </axis>
+    </joint>
+
+    <joint name='joint_2' type='revolute'>
+      <pose relative_to='joint_1'>0.75 0.0 0.0 0 0 0</pose>
+      <parent>upper_arm_link</parent>
+      <child>gripper::mount_point</child>
+      <axis>
+        <xyz>1 0 0</xyz>
+        <limit>
+          <lower>-6.2831853071795862</lower>
+          <upper>6.2831853071795862</upper>
+          <effort>10</effort>
+          <velocity>0.15</velocity>
+        </limit>
+      </axis>
+      <sensor name="force_torque" type="force_torque">
+        <update_rate>10</update_rate>
+        <topic><%= $topic_prefix %>/arm/joint_2/forcetorque</topic>
+      </sensor>
+    </joint>
+
+    <!-- Controller -->
+    <plugin
+      filename="ignition-gazebo-joint-position-controller-system"
+      name="ignition::gazebo::systems::JointPositionController">
+      <joint_name>joint_0</joint_name>
+      <topic><%= $topic_prefix %>/arm/joint_0</topic>
+      <use_velocity_commands>true</use_velocity_commands>
+      <initial_position>0.5</initial_position>
+    </plugin>
+
+    <plugin
+      filename="ignition-gazebo-joint-position-controller-system"
+      name="ignition::gazebo::systems::JointPositionController">
+      <joint_name>joint_1</joint_name>
+      <topic><%= $topic_prefix %>/arm/joint_1</topic>
+      <use_velocity_commands>true</use_velocity_commands>
+    </plugin>
+
+    <plugin
+      filename="ignition-gazebo-joint-position-controller-system"
+      name="ignition::gazebo::systems::JointPositionController">
+      <joint_name>joint_2</joint_name>
+      <topic><%= $topic_prefix %>/arm/joint_2</topic>
+      <use_velocity_commands>true</use_velocity_commands>
+    </plugin>
+
+    <!-- Joint state publisher -->
+    <plugin filename="libignition-gazebo-joint-state-publisher-system.so" name="ignition::gazebo::systems::JointStatePublisher">
+      <joint_name>joint_0</joint_name>
+      <joint_name>joint_1</joint_name>
+      <joint_name>joint_2</joint_name>
+    </plugin>
+
+    <frame name="arm_mount_point"/>
+  </model>
+</sdf>

--- a/mbzirc_custom/mbzirc_simple_arm/package.xml
+++ b/mbzirc_custom/mbzirc_simple_arm/package.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>mbzirc_simple_arm</name>
+  <version>0.0.0</version>
+  <description>Custom MBZIRC Simple Arm Model</description>
+
+  <maintainer email="ichen@openrobotics.org">Ian Chen</maintainer>
+
+  <license>Apache License 2.0</license>
+
+  <author>Ian Chen</author>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>mbzirc_ign</depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/mbzirc_ign/launch/spawn.launch.py
+++ b/mbzirc_ign/launch/spawn.launch.py
@@ -101,15 +101,12 @@ def spawn(context, model_type, world_name, model_name, position):
 
     bridges = []
     nodes = []
-    custom_launches = []
-    payload_launches = []
     if sim_mode == 'full' or sim_mode == 'bridge':
         [bridges, nodes, custom_launches] = model.bridges(world_name)
 
         [payload_bridges, payload_nodes, payload_launches] = model.payload_bridges(world_name)
         bridges.extend(payload_bridges)
         nodes.extend(payload_nodes)
-        payload_launches.extend(payload_launches)
 
         if model.is_fixed_wing_UAV():
             nodes.append(Node(

--- a/mbzirc_ign/launch/spawn.launch.py
+++ b/mbzirc_ign/launch/spawn.launch.py
@@ -101,9 +101,10 @@ def spawn(context, model_type, world_name, model_name, position):
 
     bridges = []
     nodes = []
+    custom_launches = []
     payload_launches = []
     if sim_mode == 'full' or sim_mode == 'bridge':
-        bridges, nodes = model.bridges(world_name)
+        [bridges, nodes, custom_launches] = model.bridges(world_name)
 
         [payload_bridges, payload_nodes, payload_launches] = model.payload_bridges(world_name)
         bridges.extend(payload_bridges)
@@ -162,6 +163,7 @@ def spawn(context, model_type, world_name, model_name, position):
             launch_processes.append(group_action)
 
         launch_processes.extend(payload_launches)
+        launch_processes.extend(custom_launches)
 
     if sim_mode == 'bridge' and bridge_competition_topics:
         launch_processes.extend(launch_competition_bridges())

--- a/mbzirc_ign/launch/spawn.launch.py
+++ b/mbzirc_ign/launch/spawn.launch.py
@@ -53,7 +53,7 @@ def spawn(context, model_type, world_name, model_name, position):
 
     gripper = LaunchConfiguration('gripper').perform(context)
 
-    if model.isUAV():
+    if model.is_UAV():
         # take flight time in minutes
         flight_time = LaunchConfiguration('flightTime').perform(context)
 
@@ -75,7 +75,7 @@ def spawn(context, model_type, world_name, model_name, position):
         })
 
         model.set_flight_time(flight_time)
-    elif model.isUSV():
+    elif model.is_USV():
         arm = LaunchConfiguration('arm').perform(context)
         arm_slot = LaunchConfiguration('arm_slot').perform(context)
 
@@ -110,7 +110,7 @@ def spawn(context, model_type, world_name, model_name, position):
         nodes.extend(payload_nodes)
         payload_launches.extend(payload_launches)
 
-        if model.isFixedWingUAV():
+        if model.is_fixed_wing_UAV():
             nodes.append(Node(
                 package='mbzirc_ros',
                 executable='fixed_wing_bridge',

--- a/mbzirc_ign/launch/spawn_config.launch.py
+++ b/mbzirc_ign/launch/spawn_config.launch.py
@@ -32,7 +32,7 @@ def spawn(context, config_file, world_name):
     with open(config_file, 'r') as stream:
         models = Model.FromConfig(stream)
 
-    if type(m) != list:
+    if type(models) != list:
         models = [models]
 
     sim_mode = LaunchConfiguration('sim_mode').perform(context)
@@ -57,15 +57,13 @@ def spawn(context, config_file, world_name):
             launch_processes.append(ignition_spawn_entity)
 
         if sim_mode == 'full' or sim_mode == 'bridge':
-            bridges, nodes = model.bridges(world_name)
+            [bridges, nodes, custom_launches] = model.bridges(world_name)
 
-            if model.isUAV():
-                [payload_bridges, payload_nodes, payload_launches] = model.payload_bridges(world_name)
-                bridges.extend(payload_bridges)
-                nodes.extend(payload_nodes)
-                launch_processes.extend(payload_launches)
+            [payload_bridges, payload_nodes, payload_launches] = model.payload_bridges(world_name)
+            bridges.extend(payload_bridges)
+            nodes.extend(payload_nodes)
 
-            if model.isFixedWingUAV():
+            if model.is_fixed_wing_UAV():
                 nodes.append(Node(
                     package='mbzirc_ros',
                     executable='fixed_wing_bridge',
@@ -114,6 +112,10 @@ def spawn(context, config_file, world_name):
                 launch_processes.append(handler)
             elif sim_mode == 'bridge':
                 launch_processes.append(group_action)
+
+            launch_processes.extend(payload_launches)
+            launch_processes.extend(custom_launches)
+
     return launch_processes
 
 

--- a/mbzirc_ign/src/mbzirc_ign/model.py
+++ b/mbzirc_ign/src/mbzirc_ign/model.py
@@ -257,6 +257,8 @@ class Model:
         return [bridges, nodes, payload_launches]
 
     def is_custom_model(self, model):
+        if not model:
+            return False
         try:
             get_package_share_directory(model)
         except PackageNotFoundError:

--- a/mbzirc_ign/src/mbzirc_ign/model.py
+++ b/mbzirc_ign/src/mbzirc_ign/model.py
@@ -67,19 +67,19 @@ class Model:
         self.gripper = ''
         self.arm_slot = '0'
 
-    def isUAV(self):
+    def is_UAV(self):
         return self.model_type in UAVS
 
-    def isFixedWingUAV(self):
+    def is_fixed_wing_UAV(self):
         return self.model_type in FIXED_WING_UAVS
 
-    def isUSV(self):
+    def is_USV(self):
         return self.model_type in USVS
 
-    def hasValidArm(self):
+    def has_valid_arm(self):
         return self.arm in ARMS
 
-    def hasValidGripper(self):
+    def has_valid_gripper(self):
         return self.gripper in GRIPPERS
 
     def bridges(self, world_name):
@@ -96,19 +96,19 @@ class Model:
             # comms rx
             mbzirc_ign.bridges.comms_rx(self.model_name),
         ]
-        if self.isUAV():
+        if self.is_UAV():
             bridges.extend([
                 # Magnetometer
                 mbzirc_ign.bridges.magnetometer(world_name, self.model_name),
                 # Air Pressure
                 mbzirc_ign.bridges.air_pressure(world_name, self.model_name),
             ])
-            if not self.isFixedWingUAV():
+            if not self.is_fixed_wing_UAV():
                 bridges.extend([
                     # twist
                     mbzirc_ign.bridges.cmd_vel(self.model_name)
                 ])
-        elif self.isUSV():
+        elif self.is_USV():
             bridges.extend([
                 # thrust cmd
                 mbzirc_ign.bridges.thrust(self.model_name, 'left'),
@@ -118,7 +118,7 @@ class Model:
                 mbzirc_ign.bridges.thrust_joint_pos(self.model_name, 'right'),
             ])
 
-        if self.hasValidArm():
+        if self.has_valid_arm():
             # arm joint states
             bridges.append(
                 mbzirc_ign.bridges.arm_joint_states(world_name, self.model_name)
@@ -161,8 +161,8 @@ class Model:
                 if not self.gripper:
                     self.gripper = 'mbzirc_oberon7_gripper'
 
-        if self.hasValidGripper():
-            isAttachedToArm = self.isUSV()
+        if self.has_valid_gripper():
+            isAttachedToArm = self.is_USV()
             # gripper joint pos cmd
             if self.gripper == 'mbzirc_oberon7_gripper':
                 # gripper_joint states
@@ -207,7 +207,7 @@ class Model:
                 continue
 
             # check if it is a custom payload
-            if self.is_custom_payload(p['sensor']):
+            if self.is_custom_model(p['sensor']):
                 payload_launch = self.custom_payload_launch(world_name, self.model_name,
                                                             p['sensor'], idx)
                 if payload_launch is not None:
@@ -245,9 +245,9 @@ class Model:
                                     ('output/image', f'slot{idx}/optical/depth')]))
         return [bridges, nodes, payload_launches]
 
-    def is_custom_payload(self, payload):
+    def is_custom_model(self, model):
         try:
-            get_package_share_directory(payload)
+            get_package_share_directory(model)
         except PackageNotFoundError:
             return False
         return True
@@ -314,7 +314,7 @@ class Model:
             if self.battery_capacity == 0:
                 raise RuntimeError('Battery Capacity is zero, was flight_time set?')
             command.append(f'capacity={self.battery_capacity}')
-            if self.hasValidGripper():
+            if self.has_valid_gripper():
                 command.append(f'gripper={self.gripper}')
 
         if self.model_type in USVS or self.model_type == 'static_arm':
@@ -322,14 +322,17 @@ class Model:
 
             # run erb for arm to attach the user specified gripper
             # and also for arm and gripper to generate unique topic names
-            if self.hasValidArm():
+            if self.has_valid_arm() or self.is_custom_model(self.arm):
                 command.append(f'arm={self.arm}')
                 command.append(f'arm_slot={self.arm_slot}')
+                arm_package = 'mbzirc_ign'
+                if self.is_custom_model(self.arm):
+                    arm_package = self.arm
                 arm_model_file = os.path.join(
-                    get_package_share_directory('mbzirc_ign'), 'models',
+                    get_package_share_directory(arm_package), 'models',
                     self.arm, 'model.sdf.erb')
                 arm_model_output_file = os.path.join(
-                    get_package_share_directory('mbzirc_ign'), 'models',
+                    get_package_share_directory(arm_package), 'models',
                     self.arm, 'model.sdf')
                 arm_command = ['erb']
 
@@ -344,7 +347,7 @@ class Model:
                     f.write(str_output)
                 # print(arm_command, str_output)
 
-        if self.hasValidGripper():
+        if self.has_valid_gripper():
             gripper_model_file = os.path.join(
                 get_package_share_directory('mbzirc_ign'), 'models',
                 self.gripper, 'model.sdf.erb')
@@ -353,7 +356,7 @@ class Model:
                 self.gripper, 'model.sdf')
             gripper_command = ['erb']
             topic_prefix = f'{self.model_name}'
-            if (self.isUSV()):
+            if (self.is_USV()):
                 topic_prefix += '/arm'
             gripper_command.append(f'topic_prefix={topic_prefix}')
             gripper_command.append(gripper_model_file)

--- a/mbzirc_ign/src/mbzirc_ign/model.py
+++ b/mbzirc_ign/src/mbzirc_ign/model.py
@@ -163,14 +163,13 @@ class Model:
                     self.gripper = 'mbzirc_oberon7_gripper'
         elif self.is_custom_model(self.arm):
             custom_launch = self.custom_model_launch(world_name, self.model_name,
-                                                self.arm)
+                                                     self.arm)
             if custom_launch is not None:
                 custom_launches.append(custom_launch)
 
             # default to oberon7 gripper if not specified.
             if not self.gripper:
                 self.gripper = 'mbzirc_oberon7_gripper'
-
 
         if self.has_valid_gripper():
             isAttachedToArm = self.is_USV()
@@ -275,7 +274,6 @@ class Model:
                 launch_arguments={'world_name': world_name,
                                   'model_name': model_name}.items())
         return custom_launch
-
 
     def custom_payload_launch(self, world_name, model_name, payload, idx):
         payload_launch = None

--- a/mbzirc_ign/src/mbzirc_ign/test_model.py
+++ b/mbzirc_ign/src/mbzirc_ign/test_model.py
@@ -13,16 +13,17 @@ class TestModel(unittest.TestCase):
                               'config', 'single_uav_config.yaml')
         with open(config, 'r') as stream:
             model = Model.FromConfig(stream)
-        self.assertTrue(model.isUAV())
+        self.assertTrue(model.is_UAV())
 
         model.generate()
 
         args = model.spawn_args()
         self.assertEqual(len(args), 18)
 
-        [bridges, nodes] = model.bridges('test_world_name')
+        [bridges, nodes, launches] = model.bridges('test_world_name')
         self.assertEqual(len(bridges), 8)
         self.assertEqual(len(nodes), 0)
+        self.assertEqual(len(launches), 0)
 
         [payload_bridges, payload_nodes, launch] = model.payload_bridges('test_world_name')
 
@@ -35,32 +36,34 @@ class TestModel(unittest.TestCase):
                               'config', 'single_uav_with_gripper_config.yaml')
         with open(config, 'r') as stream:
             model = Model.FromConfig(stream)
-        self.assertTrue(model.isUAV())
+        self.assertTrue(model.is_UAV())
 
         model.generate()
 
         args = model.spawn_args()
         self.assertEqual(len(args), 18)
 
-        [bridges, nodes] = model.bridges('test_world_name')
+        [bridges, nodes, launches] = model.bridges('test_world_name')
         self.assertEqual(len(bridges), 13)
         self.assertEqual(len(nodes), 0)
+        self.assertEqual(len(launches), 0)
 
     def test_single_fw_uav_config(self):
         config = os.path.join(get_package_share_directory('mbzirc_ign'),
                               'config', 'single_fw_uav_config.yaml')
         with open(config, 'r') as stream:
             model = Model.FromConfig(stream)
-        self.assertTrue(model.isUAV())
+        self.assertTrue(model.is_UAV())
 
         model.generate()
 
         args = model.spawn_args()
         self.assertEqual(len(args), 18)
 
-        [bridges, nodes] = model.bridges('test_world_name')
+        [bridges, nodes, launches] = model.bridges('test_world_name')
         self.assertEqual(len(bridges), 7)
         self.assertEqual(len(nodes), 0)
+        self.assertEqual(len(launches), 0)
 
         [payload_bridges, payload_nodes, launch] = model.payload_bridges('test_world_name')
 
@@ -74,16 +77,17 @@ class TestModel(unittest.TestCase):
         with open(config, 'r') as stream:
             model = Model.FromConfig(stream)
 
-        self.assertTrue(model.isUSV())
+        self.assertTrue(model.is_USV())
 
         model.generate()
 
         args = model.spawn_args()
         self.assertEqual(len(args), 18)
 
-        [bridges, nodes] = model.bridges('test_world_name')
+        [bridges, nodes, launches] = model.bridges('test_world_name')
         self.assertEqual(len(bridges), 9)
         self.assertEqual(len(nodes), 0)
+        self.assertEqual(len(launches), 0)
 
         [payload_bridges, payload_nodes, launch] = model.payload_bridges('test_world_name')
 
@@ -97,16 +101,17 @@ class TestModel(unittest.TestCase):
         with open(config, 'r') as stream:
             model = Model.FromConfig(stream)
 
-        self.assertTrue(model.isUSV())
+        self.assertTrue(model.is_USV())
 
         model.generate()
 
         args = model.spawn_args()
         self.assertEqual(len(args), 18)
 
-        [bridges, nodes] = model.bridges('test_world_name')
+        [bridges, nodes, launches] = model.bridges('test_world_name')
         self.assertEqual(len(bridges), 24)
         self.assertEqual(len(nodes), 1)
+        self.assertEqual(len(launches), 0)
 
     def test_multiple_config(self):
         config = os.path.join(get_package_share_directory('mbzirc_ign'),


### PR DESCRIPTION
Extended the spawn scripts to support loading custom models in the `mbzirc_custom` directory (similar to the way we added support for loading custom sensors in https://github.com/osrf/mbzirc/pull/105)

Added a new `mbzirc_simple_arm` example model that can be attached to the USV. The `install` cmds in the CMakelists.txt is commented out on purpose as this is supported to be an example only.

Here is the accompanying documentation page on the wiki with instructions on testing the simple arm model at the end of the page:
https://github.com/osrf/mbzirc/wiki/Custom-Arm

![mbzirc_simple_arm](https://user-images.githubusercontent.com/4000684/169911630-6afe0f3a-2ce5-4d7e-b64e-5251303f807f.png)

