### PR TITLE
Support configuring sensor payload on arm

### DIFF
--- a/mbzirc_ign/config/single_usv_with_arm_gripper_config.yaml
+++ b/mbzirc_ign/config/single_usv_with_arm_gripper_config.yaml
@@ -7,3 +7,14 @@ position:
 arm: mbzirc_oberon7_arm
 gripper: mbzirc_oberon7_gripper
 arm_slot: '0'
+payload:
+  slot0:
+    sensor: 'mbzirc_vga_camera'
+    rpy: [0, 0, 0]
+  slot1:
+    sensor: 'mbzirc_hd_camera'
+    rpy: [0, 0, 0]
+arm_payload:
+  slot0:
+    sensor: 'mbzirc_hd_camera'
+    rpy: [0, 0, 0]

--- a/mbzirc_ign/launch/spawn.launch.py
+++ b/mbzirc_ign/launch/spawn.launch.py
@@ -53,6 +53,12 @@ def spawn(context, model_type, world_name, model_name, position):
 
     gripper = LaunchConfiguration('gripper').perform(context)
 
+    arm_slot0_payload = LaunchConfiguration('arm_payload_slot0').perform(context)
+    arm_slot0_rpy = LaunchConfiguration('arm_payload_slot0_rpy').perform(context)
+    arm_payloads = {
+        'slot0': {'sensor': arm_slot0_payload, 'rpy': arm_slot0_rpy},
+    }
+
     if model.isUAV():
         # take flight time in minutes
         flight_time = LaunchConfiguration('flightTime').perform(context)
@@ -88,6 +94,7 @@ def spawn(context, model_type, world_name, model_name, position):
 
     model.set_gripper(gripper)
     model.set_payload(payloads)
+    model.set_arm_payload(arm_payloads)
 
     launch_processes = []
     if sim_mode == 'full' or sim_mode == 'sim':
@@ -323,6 +330,14 @@ def generate_launch_description():
             'slot7_rpy',
             default_value='0 0 0',
             description='Roll, Pitch, Yaw in degrees of payload mount'),
+        DeclareLaunchArgument(
+            'arm_payload_slot0',
+            default_value='',
+            description='Payload mounted to slot 0 on the arm'),
+        DeclareLaunchArgument(
+            'arm_payload_slot0_rpy',
+            default_value='0 0 0',
+            description='Roll, Pitch, Yaw in degrees of payload mount on the arm'),
         DeclareLaunchArgument(
             'sim_mode',
             default_value='full',

--- a/mbzirc_ign/models/mbzirc_oberon7_arm/model.sdf.erb
+++ b/mbzirc_ign/models/mbzirc_oberon7_arm/model.sdf.erb
@@ -12,12 +12,46 @@ else
 end
 
 $camera_sensor_local_pose = "0.19 0.075 0.0 -1.570796326794896 0 0"
+
+$slot0_payload = nil
+$slot0_rpy = '0 0 0'
+
+if defined?(arm_slot0)
+  $arm_slot0_payload = arm_slot0
+end
+if defined?(arm_slot0_pos)
+  $arm_slot0_rpy = arm_slot0_pos
+end
+
 %>
 
 <?xml version="1.0" ?>
 <sdf version='1.9'>
   <model name="oberon7_arm">
-    <link name='base'>
+
+    <!-- arm wrist payload slot -->
+    <frame name="slot_0">
+      <pose relative_to='wrist_link'><%= $camera_sensor_local_pose %></pose>
+    </frame>
+
+    <% if $arm_slot0_payload != nil%>
+    <!-- Payload slot0 -->
+    <include>
+      <name>sensor_0</name>
+      <uri>model://sensors/<%= $arm_slot0_payload%></uri>
+      <placement_frame>mount_point</placement_frame>
+      <pose relative_to="slot_0" degrees="true">
+        0 0 0 <%= $arm_slot0_rpy%>
+      </pose>
+    </include>
+
+    <joint name="slot_0_joint" type="fixed">
+      <parent>wrist_link</parent>
+      <child>sensor_0::mount_point</child>
+    </joint>
+    <% end %>
+
+     <link name='base'>
       <inertial>
         <pose>-0.101581 -0.001371 -0.009781 0 0 0</pose>
         <mass>9.674677170178402</mass>
@@ -397,28 +431,6 @@ $camera_sensor_local_pose = "0.19 0.075 0.0 -1.570796326794896 0 0"
           <diffuse>0.2 0.2 0.2</diffuse>
         </material>
       </visual>
-      <sensor name="camera" type="camera">
-        <pose><%= $camera_sensor_local_pose %></pose>
-        <always_on>1</always_on>
-        <update_rate>30</update_rate>
-        <camera name="camera">
-          <horizontal_fov>1.0472</horizontal_fov>
-          <image>
-            <width>640</width>
-            <height>480</height>
-            <format>R8G8B8</format>
-          </image>
-          <clip>
-            <near>0.01</near>
-            <far>300</far>
-          </clip>
-          <noise>
-            <type>gaussian</type>
-            <mean>0</mean>
-            <stddev>0.007</stddev>
-          </noise>
-        </camera>
-      </sensor>
       <self_collide>false</self_collide>
     </link>
 

--- a/mbzirc_ign/models/usv/model.sdf.erb
+++ b/mbzirc_ign/models/usv/model.sdf.erb
@@ -13,7 +13,7 @@ end
 if !defined?(gripper) || gripper== nil || gripper.empty?
   $gripper_name = 'mbzirc_oberon7_gripper'
 else
-  $model_name = gripper
+  $gripper_name = gripper
 end
 
 if !defined?(wavefieldSize) || wavefieldSize == nil || wavefieldSize.empty?

--- a/mbzirc_ign/src/mbzirc_ign/bridges.py
+++ b/mbzirc_ign/src/mbzirc_ign/bridges.py
@@ -171,28 +171,6 @@ def gripper_joint_force_torque(model_name, joint_name, isAttachedToArm):
         direction=BridgeDirection.IGN_TO_ROS)
 
 
-def arm_image(world_name, model_name, link_name):
-    prefix = f'/world/{world_name}/model/{model_name}/model/arm/link/{link_name}/sensor'
-    link = link_name.rstrip('_link')
-    return Bridge(
-        ign_topic=f'{prefix}/camera/image',
-        ros_topic=f'arm/{link}/image_raw',
-        ign_type='ignition.msgs.Image',
-        ros_type='sensor_msgs/msg/Image',
-        direction=BridgeDirection.IGN_TO_ROS)
-
-
-def arm_camera_info(world_name, model_name, link_name):
-    prefix = f'/world/{world_name}/model/{model_name}/model/arm/link/{link_name}/sensor'
-    link = link_name.rstrip('_link')
-    return Bridge(
-        ign_topic=f'{prefix}/camera/camera_info',
-        ros_topic=f'arm/{link}/camera_info',
-        ign_type='ignition.msgs.CameraInfo',
-        ros_type='sensor_msgs/msg/CameraInfo',
-        direction=BridgeDirection.IGN_TO_ROS)
-
-
 def gripper_suction_contacts(model_name, isAttachedToArm):
     prefix = 'gripper'
     if isAttachedToArm:

--- a/mbzirc_ign/src/mbzirc_ign/model.py
+++ b/mbzirc_ign/src/mbzirc_ign/model.py
@@ -133,31 +133,9 @@ class Model:
                         mbzirc_ign.bridges.arm_joint_pos(self.model_name, joint)
                     )
 
-                # camera_link = 'wrist_link'
-                # camera_link_no_suffix = camera_link.rstrip('_link')
-                # bridges.append(
-                #     mbzirc_ign.bridges.arm_image(world_name, self.model_name, camera_link)
-                # )
-                # bridges.append(
-                #     mbzirc_ign.bridges.arm_camera_info(
-                #         world_name, self.model_name, camera_link
-                #     )
-                # )
                 bridges.append(
                     mbzirc_ign.bridges.wrist_joint_force_torque(self.model_name),
                 )
-                # nodes.append(Node(
-                #     package='mbzirc_ros',
-                #     executable='optical_frame_publisher',
-                #     arguments=['1'],
-                #     remappings=[('input/image', f'arm/{camera_link_no_suffix}/image_raw'),
-                #                 ('output/image',
-                #                 f'arm/{camera_link_no_suffix}/optical/image_raw'),
-                #                 ('input/camera_info',
-                #                 f'arm/{camera_link_no_suffix}/camera_info'),
-                #                 ('output/camera_info',
-                #                     f'arm/{camera_link_no_suffix}/optical/camera_info')]))
-
                 # default to oberon7 gripper if not specified.
                 if not self.gripper:
                     self.gripper = 'mbzirc_oberon7_gripper'

--- a/mbzirc_ign/src/mbzirc_ign/payload_bridges.py
+++ b/mbzirc_ign/src/mbzirc_ign/payload_bridges.py
@@ -19,88 +19,105 @@ def lidar_models():
     return models
 
 
-def slot_prefix(world_name, model_name, slot_idx):
-    s = f'/world/{world_name}/model/{model_name}/model/sensor_{slot_idx}/link/sensor_link/sensor'
+def slot_prefix(world_name, model_name, slot_idx, model_prefix=''):
+    s = f'/world/{world_name}/model/{model_name}/model/'
+    if model_prefix != '':
+        s += f'{model_prefix}/model/'
+    s += f'sensor_{slot_idx}/link/sensor_link/sensor'
     return s
 
 
-def image(world_name, model_name, slot_idx):
-    prefix = slot_prefix(world_name, model_name, slot_idx)
+def ros_slot_prefix(slot_idx, model_prefix=''):
+    s = ''
+    if model_prefix != '':
+        s = f'{model_prefix}/'
+    s += f'slot{slot_idx}'
+    return s
+
+
+def image(world_name, model_name, slot_idx, model_prefix=''):
+    prefix = slot_prefix(world_name, model_name, slot_idx, model_prefix)
+    ros_prefix = ros_slot_prefix(slot_idx, model_prefix)
     return Bridge(
         ign_topic=f'{prefix}/camera/image',
-        ros_topic=f'slot{slot_idx}/image_raw',
+        ros_topic=f'{ros_prefix}/image_raw',
         ign_type='ignition.msgs.Image',
         ros_type='sensor_msgs/msg/Image',
         direction=BridgeDirection.IGN_TO_ROS)
 
 
-def depth_image(world_name, model_name, slot_idx):
-    prefix = slot_prefix(world_name, model_name, slot_idx)
+def depth_image(world_name, model_name, slot_idx, model_prefix=''):
+    prefix = slot_prefix(world_name, model_name, slot_idx, model_prefix)
+    ros_prefix = ros_slot_prefix(slot_idx, model_prefix)
     return Bridge(
         ign_topic=f'{prefix}/camera/depth_image',
-        ros_topic=f'slot{slot_idx}/depth',
+        ros_topic=f'{ros_prefix}/depth',
         ign_type='ignition.msgs.Image',
         ros_type='sensor_msgs/msg/Image',
         direction=BridgeDirection.IGN_TO_ROS)
 
 
-def camera_info(world_name, model_name, slot_idx):
-    prefix = slot_prefix(world_name, model_name, slot_idx)
+def camera_info(world_name, model_name, slot_idx, model_prefix=''):
+    prefix = slot_prefix(world_name, model_name, slot_idx, model_prefix)
+    ros_prefix = ros_slot_prefix(slot_idx, model_prefix)
     return Bridge(
         ign_topic=f'{prefix}/camera/camera_info',
-        ros_topic=f'slot{slot_idx}/camera_info',
+        ros_topic=f'{ros_prefix}/camera_info',
         ign_type='ignition.msgs.CameraInfo',
         ros_type='sensor_msgs/msg/CameraInfo',
         direction=BridgeDirection.IGN_TO_ROS)
 
 
-def lidar_scan(world_name, model_name, slot_idx):
-    prefix = slot_prefix(world_name, model_name, slot_idx)
+def lidar_scan(world_name, model_name, slot_idx, model_prefix=''):
+    prefix = slot_prefix(world_name, model_name, slot_idx, model_prefix)
+    ros_prefix = ros_slot_prefix(slot_idx, model_prefix)
     return Bridge(
         ign_topic=f'{prefix}/lidar/scan',
-        ros_topic=f'slot{slot_idx}/scan',
+        ros_topic=f'{ros_prefix}/scan',
         ign_type='ignition.msgs.LaserScan',
         ros_type='sensor_msgs/msg/LaserScan',
         direction=BridgeDirection.IGN_TO_ROS)
 
 
-def lidar_points(world_name, model_name, slot_idx):
-    prefix = slot_prefix(world_name, model_name, slot_idx)
+def lidar_points(world_name, model_name, slot_idx, model_prefix=''):
+    prefix = slot_prefix(world_name, model_name, slot_idx, model_prefix)
+    ros_prefix = ros_slot_prefix(slot_idx, model_prefix)
     return Bridge(
         ign_topic=f'{prefix}/lidar/scan/points',
-        ros_topic=f'slot{slot_idx}/points',
+        ros_topic=f'{ros_prefix}/points',
         ign_type='ignition.msgs.PointCloudPacked',
         ros_type='sensor_msgs/msg/PointCloud2',
         direction=BridgeDirection.IGN_TO_ROS)
 
 
-def camera_points(world_name, model_name, slot_idx):
-    prefix = slot_prefix(world_name, model_name, slot_idx)
+def camera_points(world_name, model_name, slot_idx, model_prefix=''):
+    prefix = slot_prefix(world_name, model_name, slot_idx, model_prefix)
+    ros_prefix = ros_slot_prefix(slot_idx, model_prefix)
     return Bridge(
         ign_topic=f'{prefix}/camera/points',
-        ros_topic=f'slot{slot_idx}/points',
+        ros_topic=f'{ros_prefix}/points',
         ign_type='ignition.msgs.PointCloudPacked',
         ros_type='sensor_msgs/msg/PointCloud2',
         direction=BridgeDirection.IGN_TO_ROS)
 
 
-def payload_bridges(world_name, model_name, payload, idx):
+def payload_bridges(world_name, model_name, payload, idx, model_prefix=''):
     bridges = []
     if payload in camera_models():
         bridges = [
-            image(world_name, model_name, idx),
-            camera_info(world_name, model_name, idx)
+            image(world_name, model_name, idx, model_prefix),
+            camera_info(world_name, model_name, idx, model_prefix)
         ]
     elif payload in lidar_models():
         bridges = [
-            lidar_scan(world_name, model_name, idx),
-            lidar_points(world_name, model_name, idx)
+            lidar_scan(world_name, model_name, idx, model_prefix),
+            lidar_points(world_name, model_name, idx, model_prefix)
         ]
     elif payload in rgbd_models():
         bridges = [
-            image(world_name, model_name, idx),
-            camera_info(world_name, model_name, idx),
-            depth_image(world_name, model_name, idx),
-            camera_points(world_name, model_name, idx),
+            image(world_name, model_name, idx, model_prefix),
+            camera_info(world_name, model_name, idx, model_prefix),
+            depth_image(world_name, model_name, idx, model_prefix),
+            camera_points(world_name, model_name, idx, model_prefix),
         ]
     return bridges

--- a/mbzirc_ign/src/mbzirc_ign/test_bridges.py
+++ b/mbzirc_ign/src/mbzirc_ign/test_bridges.py
@@ -92,17 +92,6 @@ class TestBridges(unittest.TestCase):
                          f'/{self.model_name}/arm/elbow'
                          '@std_msgs/msg/Float64]ignition.msgs.Double')
 
-        camera_link = 'wrist_link'
-        prefix = (f'/world/{self.world_name}/model/{self.model_name}/'
-                  f'model/arm/link/{camera_link}/sensor')
-        bridge = bridges.arm_image(self.world_name, self.model_name, camera_link)
-        self.assertEqual(bridge.argument(),
-                         f'{prefix}/camera/image'
-                         '@sensor_msgs/msg/Image[ignition.msgs.Image')
-        bridge = bridges.arm_camera_info(self.world_name, self.model_name, 'wrist_link')
-        self.assertEqual(bridge.argument(),
-                         f'{prefix}/camera/camera_info'
-                         '@sensor_msgs/msg/CameraInfo[ignition.msgs.CameraInfo')
         bridge = bridges.wrist_joint_force_torque(self.model_name)
         self.assertEqual(bridge.argument(),
                          f'/{self.model_name}/arm/wrist/forcetorque'
@@ -206,11 +195,16 @@ class TestPayloadBridges(unittest.TestCase):
     world_name = 'foo'
     model_name = 'bar'
     link_name = 'baz'
+    arm_name = 'arm'
     idx = 0
 
-    def prefix(self):
-        return (f'/world/{self.world_name}/model/{self.model_name}'
-                f'/model/sensor_{self.idx}/link/sensor_link/sensor')
+    def prefix(self, model_prefix=''):
+        if model_prefix:
+            return (f'/world/{self.world_name}/model/{self.model_name}/model/{model_prefix}'
+                    f'/model/sensor_{self.idx}/link/sensor_link/sensor')
+        else:
+            return (f'/world/{self.world_name}/model/{self.model_name}'
+                    f'/model/sensor_{self.idx}/link/sensor_link/sensor')
 
     def test_image(self):
         bridge = payload_bridges.image(self.world_name, self.model_name, self.idx)
@@ -223,10 +217,27 @@ class TestPayloadBridges(unittest.TestCase):
                          f'{self.prefix()}/camera/depth_image'
                          '@sensor_msgs/msg/Image[ignition.msgs.Image')
 
+        bridge = payload_bridges.image(self.world_name, self.model_name, self.idx, self.arm_name)
+        self.assertEqual(bridge.argument(),
+                         f'{self.prefix(self.arm_name)}/camera/image'
+                         '@sensor_msgs/msg/Image[ignition.msgs.Image')
+
+        bridge = payload_bridges.depth_image(self.world_name, self.model_name, self.idx,
+                                             self.arm_name)
+        self.assertEqual(bridge.argument(),
+                         f'{self.prefix(self.arm_name)}/camera/depth_image'
+                         '@sensor_msgs/msg/Image[ignition.msgs.Image')
+
     def test_camera_info(self):
         bridge = payload_bridges.camera_info(self.world_name, self.model_name, self.idx)
         self.assertEqual(bridge.argument(),
                          f'{self.prefix()}/camera/camera_info'
+                         '@sensor_msgs/msg/CameraInfo[ignition.msgs.CameraInfo')
+
+        bridge = payload_bridges.camera_info(self.world_name, self.model_name, self.idx,
+                                             self.arm_name)
+        self.assertEqual(bridge.argument(),
+                         f'{self.prefix(self.arm_name)}/camera/camera_info'
                          '@sensor_msgs/msg/CameraInfo[ignition.msgs.CameraInfo')
 
     def test_points(self):
@@ -238,6 +249,18 @@ class TestPayloadBridges(unittest.TestCase):
         bridge = payload_bridges.camera_points(self.world_name, self.model_name, self.idx)
         self.assertEqual(bridge.argument(),
                          f'{self.prefix()}/camera/points'
+                         '@sensor_msgs/msg/PointCloud2[ignition.msgs.PointCloudPacked')
+
+        bridge = payload_bridges.lidar_points(self.world_name, self.model_name, self.idx,
+                                              self.arm_name)
+        self.assertEqual(bridge.argument(),
+                         f'{self.prefix(self.arm_name)}/lidar/scan/points'
+                         '@sensor_msgs/msg/PointCloud2[ignition.msgs.PointCloudPacked')
+
+        bridge = payload_bridges.camera_points(self.world_name, self.model_name, self.idx,
+                                               self.arm_name)
+        self.assertEqual(bridge.argument(),
+                         f'{self.prefix(self.arm_name)}/camera/points'
                          '@sensor_msgs/msg/PointCloud2[ignition.msgs.PointCloudPacked')
 
     def test_payload_bridges(self):

--- a/mbzirc_ign/src/mbzirc_ign/test_model.py
+++ b/mbzirc_ign/src/mbzirc_ign/test_model.py
@@ -105,8 +105,14 @@ class TestModel(unittest.TestCase):
         self.assertEqual(len(args), 18)
 
         [bridges, nodes] = model.bridges('test_world_name')
-        self.assertEqual(len(bridges), 24)
-        self.assertEqual(len(nodes), 1)
+        self.assertEqual(len(bridges), 22)
+        self.assertEqual(len(nodes), 0)
+
+        [payload_bridges, payload_nodes, launch] = model.payload_bridges('test_world_name')
+
+        self.assertEqual(len(payload_bridges), 6)
+        self.assertEqual(len(payload_nodes), 3)
+        self.assertEqual(len(launch), 0)
 
     def test_coast(self):
         config = os.path.join(get_package_share_directory('mbzirc_ign'),

--- a/mbzirc_ros/CMakeLists.txt
+++ b/mbzirc_ros/CMakeLists.txt
@@ -102,7 +102,7 @@ if(BUILD_TESTING)
   )
 
   add_launch_test(test/launch/test_ros_api.launch.py
-    TIMEOUT 280
+    TIMEOUT 300
   )
 endif()
 

--- a/mbzirc_ros/test/launch/test_ros_api.launch.py
+++ b/mbzirc_ros/test/launch/test_ros_api.launch.py
@@ -160,7 +160,7 @@ def generate_test_description():
 class RosApiTest(unittest.TestCase):
 
     def test_termination(self, process_under_test, proc_info):
-        proc_info.assertWaitForShutdown(process=process_under_test, timeout=280)
+        proc_info.assertWaitForShutdown(process=process_under_test, timeout=300)
 
 @launch_testing.post_shutdown_test()
 class RosApiTestAfterShutdown(unittest.TestCase):

--- a/mbzirc_ros/test/launch/test_ros_api.launch.py
+++ b/mbzirc_ros/test/launch/test_ros_api.launch.py
@@ -114,7 +114,8 @@ def generate_test_description():
                'z'      : '0.08',
                'arm'    : 'mbzirc_oberon7_arm',
                'gripper': 'mbzirc_oberon7_gripper',}
-
+    # add hd camera to arm
+    arguments['arm_payload_slot0'] = 'mbzirc_hd_camera'
     spawn_usv = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
             os.path.join(

--- a/mbzirc_ros/test/ros_api/test_ros_api.cc
+++ b/mbzirc_ros/test/ros_api/test_ros_api.cc
@@ -296,28 +296,28 @@ TEST(RosApiTest, ArmTopics)
 
   // image_raw
   MyTestClass<sensor_msgs::msg::Image> image(
-      "/usv/arm/wrist/image_raw");
+      "/usv/arm/slot0/image_raw");
   waitUntilBoolVarAndSpin(
     node, image.callbackExecuted, 10ms, 500);
   EXPECT_TRUE(image.callbackExecuted);
 
   // camera_info
   MyTestClass<sensor_msgs::msg::CameraInfo> cameraInfo(
-      "/usv/arm/wrist/camera_info");
+      "/usv/arm/slot0/camera_info");
   waitUntilBoolVarAndSpin(
     node, cameraInfo.callbackExecuted, 10ms, 500);
   EXPECT_TRUE(cameraInfo.callbackExecuted);
 
   // optical image
   MyTestClass<sensor_msgs::msg::Image> imageOptical(
-      "/usv/arm/wrist/optical/image_raw");
+      "/usv/arm/slot0/optical/image_raw");
   waitUntilBoolVarAndSpin(
     node, imageOptical.callbackExecuted, 10ms, 500);
   EXPECT_TRUE(imageOptical.callbackExecuted);
 
   // optical camera_info
   MyTestClass<sensor_msgs::msg::CameraInfo> cameraInfoOptical(
-      "/usv/arm/wrist/optical/camera_info");
+      "/usv/arm/slot0/optical/camera_info");
   waitUntilBoolVarAndSpin(
     node, cameraInfoOptical.callbackExecuted, 10ms, 500);
   EXPECT_TRUE(cameraInfoOptical.callbackExecuted);

--- a/mbzirc_ros/test/ros_api/test_ros_api.cc
+++ b/mbzirc_ros/test/ros_api/test_ros_api.cc
@@ -127,7 +127,7 @@ TEST(RosApiTest, SimTopics)
   // run_clock
   MyTestClass<rosgraph_msgs::msg::Clock> runClock("/mbzirc/run_clock");
   waitUntilBoolVarAndSpin(
-    node, runClock.callbackExecuted, 10ms, 500);
+    node, runClock.callbackExecuted, 10ms, 3500);
   EXPECT_TRUE(runClock.callbackExecuted);
 }
 


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

This PR adds support for configuring the sensor payload on the wrist of the robot arm. This removes the hardcorded VGA camera and lets user specify the sensor to use from the list of available sensor models in mbzirc. Only 1 sensor payload is allowed.

The two new args are:
* `arm_payload_slot0`
* `arm_payload_slot0_rpy`

here is an example of spawning a USV with lidar:

```sh
# launch simple demo world
ros2 launch mbzirc_ros competition_local.launch.py ign_args:="-v 4 -r simple_demo.sdf"

# spawns USV with arm and 1) a lidar on the wrist of arm, and 2) a camera on the top platform of the USV
ros2 launch mbzirc_ign spawn.launch.py name:=usv world:=simple_demo model:=usv x:=15 y:=0 z:=0.3 R:=0 P:=0 Y:=0 arm:=mbzirc_oberon7_arm arm_payload_slot0:=mbzirc_planar_lidar arm_payload_slot0_rpy:='0 -10 0' slot0:=mbzirc_hd_camera
```

![mbzirc_arm_lidar](https://user-images.githubusercontent.com/4000684/170622604-dc5498c3-91c8-4957-ad6b-275fb508c4de.png)

