### PR TITLE
Add single entry point competition launch

### DIFF
--- a/mbzirc_ign/launch/competition.launch.py
+++ b/mbzirc_ign/launch/competition.launch.py
@@ -1,0 +1,171 @@
+# Copyright 2021 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ament_index_python.packages import get_package_share_directory
+
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
+from launch.actions import GroupAction
+from launch.actions import OpaqueFunction
+from launch.actions import RegisterEventHandler
+from launch.event_handlers import OnProcessExit
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import LaunchConfiguration
+
+from launch_ros.actions import Node
+from launch_ros.actions import PushRosNamespace
+
+from mbzirc_ign.model import Model
+
+import mbzirc_ign.bridges
+
+import os
+
+
+def spawn(context, config_file, world_name):
+    with open(config_file, 'r') as stream:
+        models = Model.FromConfig(stream)
+
+    if type(models) != list:
+        # In the case that a single model is parsed, pack it in a list
+        models = [models]
+
+    launch_processes = []
+    bridges = []
+    nodes = []
+
+    # Only one instance of compeititon topics required
+    launch_processes.extend(launch_competition_bridges())
+
+    for model in models:
+        ignition_spawn_entity = Node(
+            package='ros_ign_gazebo',
+            executable='create',
+            output='screen',
+            arguments=model.spawn_args()
+        )
+        launch_processes.append(ignition_spawn_entity)
+
+        bridges, nodes = model.bridges(world_name)
+
+        if model.isUAV():
+            payload = model.payload_bridges(world_name)
+            payload_bridges = payload[0]
+            payload_nodes = payload[1]
+            payload_launches = payload[2]
+            bridges.extend(payload_bridges)
+            nodes.extend(payload_nodes)
+            launch_processes.extend(payload_launches)
+
+        if model.isFixedWingUAV():
+            nodes.append(Node(
+                package='mbzirc_ros',
+                executable='fixed_wing_bridge',
+                output='screen',
+                parameters=[{'model_name': model.model_name}],
+            ))
+
+        nodes.append(Node(
+            package='ros_ign_bridge',
+            executable='parameter_bridge',
+            output='screen',
+            arguments=[bridge.argument() for bridge in bridges],
+            remappings=[bridge.remapping() for bridge in bridges],
+        ))
+
+        # tf broadcaster
+        nodes.append(Node(
+            package='mbzirc_ros',
+            executable='pose_tf_broadcaster',
+            output='screen',
+            parameters=[
+                {'world_frame': world_name}
+            ]
+        ))
+
+        # video target relay
+        nodes.append(Node(
+            package='mbzirc_ros',
+            executable='video_target_relay',
+            output='screen',
+            parameters=[{'model_name': model.model_name}]
+        ))
+
+        group_action = GroupAction([
+            PushRosNamespace(model.model_name),
+            *nodes
+        ])
+
+        handler = RegisterEventHandler(
+            event_handler=OnProcessExit(
+                target_action=ignition_spawn_entity,
+                on_exit=[group_action],
+            )
+        )
+        launch_processes.append(handler)
+    return launch_processes
+
+
+def launch_competition_bridges():
+    bridges = [
+        mbzirc_ign.bridges.score(),
+        mbzirc_ign.bridges.clock(),
+        mbzirc_ign.bridges.run_clock(),
+        mbzirc_ign.bridges.phase(),
+        mbzirc_ign.bridges.stream_status(),
+    ]
+    nodes = []
+    nodes.append(Node(
+        package='ros_ign_bridge',
+        executable='parameter_bridge',
+        output='screen',
+        arguments=[bridge.argument() for bridge in bridges],
+        remappings=[bridge.remapping() for bridge in bridges],
+    ))
+    return nodes
+
+
+def launch_vehicles(context, *args, **kwargs):
+    config_file = LaunchConfiguration('config_file').perform(context)
+    world_name = LaunchConfiguration('world').perform(context)
+    return spawn(context, config_file, world_name)
+
+
+def launch_simulation(context, *args, **kwargs):
+    world_name = LaunchConfiguration('world').perform(context)
+    ign_args = ['-v 4', '-r']
+    ign_args.append(f'{world_name}.sdf')
+
+    ign_gazebo = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource([os.path.join(
+        get_package_share_directory('ros_ign_gazebo'), 'launch'),
+        '/ign_gazebo.launch.py']),
+        launch_arguments = {'ign_args': ' '.join(ign_args)}.items())
+    return [ign_gazebo]
+
+
+def generate_launch_description():
+    return LaunchDescription([
+        # Launch Arguments
+        DeclareLaunchArgument(
+            'world',
+            default_value='simple_demo',
+            description='Name of world'),
+        DeclareLaunchArgument(
+            'config_file',
+            description='YAML configuration file to spawn'),
+        OpaqueFunction(function=launch_simulation),
+        # launch setup
+        OpaqueFunction(function=launch_vehicles),
+    ])

--- a/mbzirc_ign/launch/competition.launch.py
+++ b/mbzirc_ign/launch/competition.launch.py
@@ -12,147 +12,34 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ament_index_python.packages import get_package_share_directory
 
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
-from launch.actions import GroupAction
+from launch.actions import DeclareLaunchArgument
 from launch.actions import OpaqueFunction
-from launch.actions import RegisterEventHandler
-from launch.event_handlers import OnProcessExit
-from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
 
-from launch_ros.actions import Node
-from launch_ros.actions import PushRosNamespace
-
+import mbzirc_ign.launch
 from mbzirc_ign.model import Model
 
-import mbzirc_ign.bridges
 
-import os
+def launch(context, *args, **kwargs):
+    config_file = LaunchConfiguration('config_file').perform(context)
+    world_name = LaunchConfiguration('world').perform(context)
+    sim_mode = LaunchConfiguration('sim_mode').perform(context)
+    bridge_competition_topics = LaunchConfiguration('bridge_competition_topics').perform(context)
 
+    launch_processes = []
 
-def spawn(context, config_file, world_name):
     with open(config_file, 'r') as stream:
         models = Model.FromConfig(stream)
 
-    if type(models) != list:
-        # In the case that a single model is parsed, pack it in a list
-        models = [models]
+    launch_processes.extend(mbzirc_ign.launch.simulation(world_name))
+    launch_processes.extend(mbzirc_ign.launch.spawn(sim_mode, world_name, models))
 
-    launch_processes = []
-    bridges = []
-    nodes = []
+    if sim_mode == 'bridge' and bridge_competition_topics:
+        launch_processes.extend(mbzirc_ign.launch.competition_bridges())
 
-    # Only one instance of compeititon topics required
-    launch_processes.extend(launch_competition_bridges())
-
-    for model in models:
-        ignition_spawn_entity = Node(
-            package='ros_ign_gazebo',
-            executable='create',
-            output='screen',
-            arguments=model.spawn_args()
-        )
-        launch_processes.append(ignition_spawn_entity)
-
-        bridges, nodes = model.bridges(world_name)
-
-        if model.isUAV():
-            payload = model.payload_bridges(world_name)
-            payload_bridges = payload[0]
-            payload_nodes = payload[1]
-            payload_launches = payload[2]
-            bridges.extend(payload_bridges)
-            nodes.extend(payload_nodes)
-            launch_processes.extend(payload_launches)
-
-        if model.isFixedWingUAV():
-            nodes.append(Node(
-                package='mbzirc_ros',
-                executable='fixed_wing_bridge',
-                output='screen',
-                parameters=[{'model_name': model.model_name}],
-            ))
-
-        nodes.append(Node(
-            package='ros_ign_bridge',
-            executable='parameter_bridge',
-            output='screen',
-            arguments=[bridge.argument() for bridge in bridges],
-            remappings=[bridge.remapping() for bridge in bridges],
-        ))
-
-        # tf broadcaster
-        nodes.append(Node(
-            package='mbzirc_ros',
-            executable='pose_tf_broadcaster',
-            output='screen',
-            parameters=[
-                {'world_frame': world_name}
-            ]
-        ))
-
-        # video target relay
-        nodes.append(Node(
-            package='mbzirc_ros',
-            executable='video_target_relay',
-            output='screen',
-            parameters=[{'model_name': model.model_name}]
-        ))
-
-        group_action = GroupAction([
-            PushRosNamespace(model.model_name),
-            *nodes
-        ])
-
-        handler = RegisterEventHandler(
-            event_handler=OnProcessExit(
-                target_action=ignition_spawn_entity,
-                on_exit=[group_action],
-            )
-        )
-        launch_processes.append(handler)
     return launch_processes
-
-
-def launch_competition_bridges():
-    bridges = [
-        mbzirc_ign.bridges.score(),
-        mbzirc_ign.bridges.clock(),
-        mbzirc_ign.bridges.run_clock(),
-        mbzirc_ign.bridges.phase(),
-        mbzirc_ign.bridges.stream_status(),
-    ]
-    nodes = []
-    nodes.append(Node(
-        package='ros_ign_bridge',
-        executable='parameter_bridge',
-        output='screen',
-        arguments=[bridge.argument() for bridge in bridges],
-        remappings=[bridge.remapping() for bridge in bridges],
-    ))
-    return nodes
-
-
-def launch_vehicles(context, *args, **kwargs):
-    config_file = LaunchConfiguration('config_file').perform(context)
-    world_name = LaunchConfiguration('world').perform(context)
-    return spawn(context, config_file, world_name)
-
-
-def launch_simulation(context, *args, **kwargs):
-    world_name = LaunchConfiguration('world').perform(context)
-    ign_args = ['-v 4', '-r']
-    ign_args.append(f'{world_name}.sdf')
-
-    ign_gazebo = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource([os.path.join(
-        get_package_share_directory('ros_ign_gazebo'), 'launch'),
-        '/ign_gazebo.launch.py']),
-        launch_arguments = {'ign_args': ' '.join(ign_args)}.items())
-    return [ign_gazebo]
 
 
 def generate_launch_description():
@@ -163,9 +50,18 @@ def generate_launch_description():
             default_value='simple_demo',
             description='Name of world'),
         DeclareLaunchArgument(
+            'sim_mode',
+            default_value='full',
+            description='Simulation mode: "full", "sim", "bridge".'
+                        'full: spawns robot and launch ros_ign bridges, '
+                        'sim: spawns robot only, '
+                        'bridge: launch ros_ign bridges only.'),
+        DeclareLaunchArgument(
+            'bridge_competition_topics',
+            default_value='True',
+            description='True to bridge competition topics, False to disable bridge.'),
+        DeclareLaunchArgument(
             'config_file',
             description='YAML configuration file to spawn'),
-        OpaqueFunction(function=launch_simulation),
-        # launch setup
-        OpaqueFunction(function=launch_vehicles),
+        OpaqueFunction(function=launch),
     ])

--- a/mbzirc_ign/launch/spawn.launch.py
+++ b/mbzirc_ign/launch/spawn.launch.py
@@ -14,25 +14,28 @@
 
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
-from launch.actions import GroupAction
 from launch.actions import OpaqueFunction
-from launch.actions import RegisterEventHandler
-from launch.event_handlers import OnProcessExit
 from launch.substitutions import LaunchConfiguration
 
-from launch_ros.actions import Node
-from launch_ros.actions import PushRosNamespace
-
 import mbzirc_ign.bridges
+import mbzirc_ign.launch
 
 from mbzirc_ign.model import Model
 
 
-def spawn(context, model_type, world_name, model_name, position):
-    model = Model(model_name, model_type, position)
+def parse_from_cli(context, world_name):
+    robot_name = LaunchConfiguration('name').perform(context)
+    model_type = LaunchConfiguration('model').perform(context)
 
-    sim_mode = LaunchConfiguration('sim_mode').perform(context)
-    bridge_competition_topics = LaunchConfiguration('bridge_competition_topics').perform(context)
+    x_pos = LaunchConfiguration('x').perform(context)
+    y_pos = LaunchConfiguration('y').perform(context)
+    z_pos = LaunchConfiguration('z').perform(context)
+    r_rot = LaunchConfiguration('R').perform(context)
+    p_rot = LaunchConfiguration('P').perform(context)
+    y_rot = LaunchConfiguration('Y').perform(context)
+    position = [x_pos, y_pos, z_pos, r_rot, p_rot, y_rot]
+
+    model = Model(robot_name, model_type, position)
 
     slot0_payload = LaunchConfiguration('slot0').perform(context)
     slot1_payload = LaunchConfiguration('slot1').perform(context)
@@ -88,133 +91,48 @@ def spawn(context, model_type, world_name, model_name, position):
 
     model.set_gripper(gripper)
     model.set_payload(payloads)
-
-    launch_processes = []
-    if sim_mode == 'full' or sim_mode == 'sim':
-        ignition_spawn_entity = Node(
-            package='ros_ign_gazebo',
-            executable='create',
-            output='screen',
-            arguments=model.spawn_args()
-        )
-        launch_processes.append(ignition_spawn_entity)
-
-    bridges = []
-    nodes = []
-    payload_launches = []
-    if sim_mode == 'full' or sim_mode == 'bridge':
-        bridges, nodes = model.bridges(world_name)
-
-        [payload_bridges, payload_nodes, payload_launches] = model.payload_bridges(world_name)
-        bridges.extend(payload_bridges)
-        nodes.extend(payload_nodes)
-        payload_launches.extend(payload_launches)
-
-        if model.isFixedWingUAV():
-            nodes.append(Node(
-                package='mbzirc_ros',
-                executable='fixed_wing_bridge',
-                output='screen',
-                parameters=[{'model_name': model_name}],
-            ))
-
-        nodes.append(Node(
-            package='ros_ign_bridge',
-            executable='parameter_bridge',
-            output='screen',
-            arguments=[bridge.argument() for bridge in bridges],
-            remappings=[bridge.remapping() for bridge in bridges],
-            parameters=[{'lazy': True}],
-        ))
-
-        # tf broadcaster
-        nodes.append(Node(
-            package='mbzirc_ros',
-            executable='pose_tf_broadcaster',
-            output='screen',
-            parameters=[
-                {'world_frame': world_name}
-            ]
-        ))
-
-        # video target relay
-        nodes.append(Node(
-            package='mbzirc_ros',
-            executable='video_target_relay',
-            output='screen',
-            parameters=[{'model_name': model_name}]
-        ))
-
-        group_action = GroupAction([
-            PushRosNamespace(model_name),
-            *nodes
-        ])
-
-        if sim_mode == 'full':
-            handler = RegisterEventHandler(
-                event_handler=OnProcessExit(
-                    target_action=ignition_spawn_entity,
-                    on_exit=[group_action],
-                )
-            )
-            launch_processes.append(handler)
-        elif sim_mode == 'bridge':
-            launch_processes.append(group_action)
-
-        launch_processes.extend(payload_launches)
-
-    if sim_mode == 'bridge' and bridge_competition_topics:
-        launch_processes.extend(launch_competition_bridges())
-    return launch_processes
-
-
-def launch_competition_bridges():
-    bridges = [
-        mbzirc_ign.bridges.score(),
-        mbzirc_ign.bridges.clock(),
-        mbzirc_ign.bridges.run_clock(),
-        mbzirc_ign.bridges.phase(),
-        mbzirc_ign.bridges.stream_status(),
-    ]
-    nodes = []
-    nodes.append(Node(
-        package='ros_ign_bridge',
-        executable='parameter_bridge',
-        output='screen',
-        arguments=[bridge.argument() for bridge in bridges],
-        remappings=[bridge.remapping() for bridge in bridges],
-    ))
-
-    return nodes
+    return model
 
 
 def launch(context, *args, **kwargs):
-    robot_name = LaunchConfiguration('name').perform(context)
-    model_type = LaunchConfiguration('model').perform(context)
     world_name = LaunchConfiguration('world').perform(context)
+    sim_mode = LaunchConfiguration('sim_mode').perform(context)
+    bridge_competition_topics = LaunchConfiguration('bridge_competition_topics').perform(context)
 
-    x_pos = LaunchConfiguration('x').perform(context)
-    y_pos = LaunchConfiguration('y').perform(context)
-    z_pos = LaunchConfiguration('z').perform(context)
-    r_rot = LaunchConfiguration('R').perform(context)
-    p_rot = LaunchConfiguration('P').perform(context)
-    y_rot = LaunchConfiguration('Y').perform(context)
+    model = parse_from_cli(context, world_name)
 
-    position = [x_pos, y_pos, z_pos, r_rot, p_rot, y_rot]
-    return spawn(context, model_type, world_name, robot_name, position)
+    launch_processes = []
+
+    launch_processes.extend(mbzirc_ign.launch.spawn(sim_mode, world_name, model))
+    if sim_mode == 'bridge' and bridge_competition_topics:
+        launch_processes.extend(mbzirc_ign.launch.competition_bridges())
+
+    return launch_processes
 
 
 def generate_launch_description():
     return LaunchDescription([
         # Launch Arguments
         DeclareLaunchArgument(
-            'name',
-            default_value='',
-            description='Name of robot to spawn'),
-        DeclareLaunchArgument(
             'world',
             default_value='simple_demo',
             description='Name of world'),
+        DeclareLaunchArgument(
+            'sim_mode',
+            default_value='full',
+            description='Simulation mode: "full", "sim", "bridge".'
+                        'full: spawns robot and launch ros_ign bridges, '
+                        'sim: spawns robot only, '
+                        'bridge: launch ros_ign bridges only.'),
+        DeclareLaunchArgument(
+            'bridge_competition_topics',
+            default_value='True',
+            description='True to bridge competition topics, False to disable bridge.'),
+
+        DeclareLaunchArgument(
+            'name',
+            default_value='',
+            description='Name of robot to spawn'),
         DeclareLaunchArgument(
             'model',
             default_value='',
@@ -323,17 +241,6 @@ def generate_launch_description():
             'slot7_rpy',
             default_value='0 0 0',
             description='Roll, Pitch, Yaw in degrees of payload mount'),
-        DeclareLaunchArgument(
-            'sim_mode',
-            default_value='full',
-            description='Simulation mode: "full", "sim", "bridge".'
-                        'full: spawns robot and launch ros_ign bridges, '
-                        'sim: spawns robot only, '
-                        'bridge: launch ros_ign bridges only.'),
-        DeclareLaunchArgument(
-            'bridge_competition_topics',
-            default_value='True',
-            description='True to bridge competition topics, False to disable bridge.'),
         # launch setup
         OpaqueFunction(function=launch)
     ])

--- a/mbzirc_ign/launch/spawn_config.launch.py
+++ b/mbzirc_ign/launch/spawn_config.launch.py
@@ -12,139 +12,33 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
-from launch.actions import GroupAction
 from launch.actions import OpaqueFunction
-from launch.actions import RegisterEventHandler
-from launch.event_handlers import OnProcessExit
 from launch.substitutions import LaunchConfiguration
 
-from launch_ros.actions import Node
-from launch_ros.actions import PushRosNamespace
-
+import mbzirc_ign.launch
 from mbzirc_ign.model import Model
-
-import mbzirc_ign.bridges
-
-
-def spawn(context, config_file, world_name):
-    with open(config_file, 'r') as stream:
-        models = Model.FromConfig(stream)
-
-    if type(models) != list:
-        # In the case that a single model is parsed, pack it in a list
-        models = [models]
-
-    sim_mode = LaunchConfiguration('sim_mode').perform(context)
-    bridge_competition_topics = LaunchConfiguration('bridge_competition_topics').perform(context)
-
-    launch_processes = []
-    bridges = []
-    nodes = []
-
-    # Only one instance of compeititon topics required
-    if sim_mode == 'bridge' and bridge_competition_topics:
-        launch_processes.extend(launch_competition_bridges())
-
-    for model in models:
-        if sim_mode == 'full' or sim_mode == 'sim':
-            ignition_spawn_entity = Node(
-                package='ros_ign_gazebo',
-                executable='create',
-                output='screen',
-                arguments=model.spawn_args()
-            )
-            launch_processes.append(ignition_spawn_entity)
-
-        if sim_mode == 'full' or sim_mode == 'bridge':
-            bridges, nodes = model.bridges(world_name)
-
-            if model.isUAV():
-                payload = model.payload_bridges(world_name)
-                payload_bridges = payload[0]
-                payload_nodes = payload[1]
-                payload_launches = payload[2]
-                bridges.extend(payload_bridges)
-                nodes.extend(payload_nodes)
-                launch_processes.extend(payload_launches)
-
-            if model.isFixedWingUAV():
-                nodes.append(Node(
-                    package='mbzirc_ros',
-                    executable='fixed_wing_bridge',
-                    output='screen',
-                    parameters=[{'model_name': model.model_name}],
-                ))
-
-            nodes.append(Node(
-                package='ros_ign_bridge',
-                executable='parameter_bridge',
-                output='screen',
-                arguments=[bridge.argument() for bridge in bridges],
-                remappings=[bridge.remapping() for bridge in bridges],
-            ))
-
-            # tf broadcaster
-            nodes.append(Node(
-                package='mbzirc_ros',
-                executable='pose_tf_broadcaster',
-                output='screen',
-                parameters=[
-                    {'world_frame': world_name}
-                ]
-            ))
-
-            # video target relay
-            nodes.append(Node(
-                package='mbzirc_ros',
-                executable='video_target_relay',
-                output='screen',
-                parameters=[{'model_name': model.model_name}]
-            ))
-
-            group_action = GroupAction([
-                PushRosNamespace(model.model_name),
-                *nodes
-            ])
-
-            if sim_mode == 'full':
-                handler = RegisterEventHandler(
-                    event_handler=OnProcessExit(
-                        target_action=ignition_spawn_entity,
-                        on_exit=[group_action],
-                    )
-                )
-                launch_processes.append(handler)
-            elif sim_mode == 'bridge':
-                launch_processes.append(group_action)
-    return launch_processes
-
-
-def launch_competition_bridges():
-    bridges = [
-        mbzirc_ign.bridges.score(),
-        mbzirc_ign.bridges.clock(),
-        mbzirc_ign.bridges.run_clock(),
-        mbzirc_ign.bridges.phase(),
-        mbzirc_ign.bridges.stream_status(),
-    ]
-    nodes = []
-    nodes.append(Node(
-        package='ros_ign_bridge',
-        executable='parameter_bridge',
-        output='screen',
-        arguments=[bridge.argument() for bridge in bridges],
-        remappings=[bridge.remapping() for bridge in bridges],
-    ))
-
-    return nodes
 
 
 def launch(context, *args, **kwargs):
     config_file = LaunchConfiguration('config_file').perform(context)
     world_name = LaunchConfiguration('world').perform(context)
-    return spawn(context, config_file, world_name)
+    sim_mode = LaunchConfiguration('sim_mode').perform(context)
+    bridge_competition_topics = LaunchConfiguration('bridge_competition_topics').perform(context)
+
+    launch_processes = []
+
+    with open(config_file, 'r') as stream:
+        models = Model.FromConfig(stream)
+
+    launch_processes.extend(mbzirc_ign.launch.spawn(sim_mode, world_name, models))
+
+    if sim_mode == 'bridge' and bridge_competition_topics:
+        launch_processes.extend(mbzirc_ign.launch.competition_bridges())
+
+    return launch_processes
 
 
 def generate_launch_description():
@@ -154,10 +48,6 @@ def generate_launch_description():
             'world',
             default_value='simple_demo',
             description='Name of world'),
-
-        DeclareLaunchArgument(
-            'config_file',
-            description='YAML configuration file to spawn'),
         DeclareLaunchArgument(
             'sim_mode',
             default_value='full',
@@ -169,6 +59,8 @@ def generate_launch_description():
             'bridge_competition_topics',
             default_value='True',
             description='True to bridge competition topics, False to disable bridge.'),
-        # launch setup
-        OpaqueFunction(function=launch)
+        DeclareLaunchArgument(
+            'config_file',
+            description='YAML configuration file to spawn'),
+        OpaqueFunction(function=launch),
     ])

--- a/mbzirc_ign/src/mbzirc_ign/launch.py
+++ b/mbzirc_ign/src/mbzirc_ign/launch.py
@@ -78,14 +78,14 @@ def spawn(sim_mode, world_name, models):
         if sim_mode == 'full' or sim_mode == 'bridge':
             bridges, nodes = model.bridges(world_name)
 
-            if model.isUAV():
-                payload = model.payload_bridges(world_name)
-                payload_bridges = payload[0]
-                payload_nodes = payload[1]
-                payload_launches = payload[2]
-                bridges.extend(payload_bridges)
-                nodes.extend(payload_nodes)
-                launch_processes.extend(payload_launches)
+            payload = model.payload_bridges(world_name)
+            payload_bridges = payload[0]
+            payload_nodes = payload[1]
+            payload_launches = payload[2]
+
+            bridges.extend(payload_bridges)
+            nodes.extend(payload_nodes)
+            launch_processes.extend(payload_launches)
 
             if model.isFixedWingUAV():
                 nodes.append(Node(

--- a/mbzirc_ign/src/mbzirc_ign/launch.py
+++ b/mbzirc_ign/src/mbzirc_ign/launch.py
@@ -1,0 +1,139 @@
+# Copyright 2022 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ament_index_python.packages import get_package_share_directory
+
+from launch.actions import GroupAction
+from launch.actions import IncludeLaunchDescription
+from launch.actions import RegisterEventHandler
+from launch.event_handlers import OnProcessExit
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+
+from launch_ros.actions import Node
+from launch_ros.actions import PushRosNamespace
+
+import mbzirc_ign.bridges
+
+import os
+
+
+def simulation(world_name):
+    ign_args = ['-v 4', '-r']
+    ign_args.append(f'{world_name}.sdf')
+
+    ign_gazebo = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource([os.path.join(
+            get_package_share_directory('ros_ign_gazebo'), 'launch'),
+            '/ign_gazebo.launch.py']),
+        launch_arguments={'ign_args': ' '.join(ign_args)}.items())
+    return [ign_gazebo]
+
+
+def competition_bridges():
+    bridges = [
+        mbzirc_ign.bridges.score(),
+        mbzirc_ign.bridges.clock(),
+        mbzirc_ign.bridges.run_clock(),
+        mbzirc_ign.bridges.phase(),
+        mbzirc_ign.bridges.stream_status(),
+    ]
+    nodes = []
+    nodes.append(Node(
+        package='ros_ign_bridge',
+        executable='parameter_bridge',
+        output='screen',
+        arguments=[bridge.argument() for bridge in bridges],
+        remappings=[bridge.remapping() for bridge in bridges],
+    ))
+    return nodes
+
+
+def spawn(sim_mode, world_name, models):
+    if type(models) != list:
+        models = [models]
+
+    launch_processes = []
+    for model in models:
+        # Script to insert model in running simulation
+        if sim_mode == 'full' or sim_mode == 'sim':
+            ignition_spawn_entity = Node(
+                package='ros_ign_gazebo',
+                executable='create',
+                output='screen',
+                arguments=model.spawn_args()
+            )
+            launch_processes.append(ignition_spawn_entity)
+
+        if sim_mode == 'full' or sim_mode == 'bridge':
+            bridges, nodes = model.bridges(world_name)
+
+            if model.isUAV():
+                payload = model.payload_bridges(world_name)
+                payload_bridges = payload[0]
+                payload_nodes = payload[1]
+                payload_launches = payload[2]
+                bridges.extend(payload_bridges)
+                nodes.extend(payload_nodes)
+                launch_processes.extend(payload_launches)
+
+            if model.isFixedWingUAV():
+                nodes.append(Node(
+                    package='mbzirc_ros',
+                    executable='fixed_wing_bridge',
+                    output='screen',
+                    parameters=[{'model_name': model.model_name}],
+                ))
+
+            nodes.append(Node(
+                package='ros_ign_bridge',
+                executable='parameter_bridge',
+                output='screen',
+                arguments=[bridge.argument() for bridge in bridges],
+                remappings=[bridge.remapping() for bridge in bridges],
+            ))
+
+            # tf broadcaster
+            nodes.append(Node(
+                package='mbzirc_ros',
+                executable='pose_tf_broadcaster',
+                output='screen',
+                parameters=[
+                    {'world_frame': world_name}
+                ]
+            ))
+
+            # video target relay
+            nodes.append(Node(
+                package='mbzirc_ros',
+                executable='video_target_relay',
+                output='screen',
+                parameters=[{'model_name': model.model_name}]
+            ))
+
+            group_action = GroupAction([
+                PushRosNamespace(model.model_name),
+                *nodes
+            ])
+
+            if sim_mode == 'full':
+                handler = RegisterEventHandler(
+                    event_handler=OnProcessExit(
+                        target_action=ignition_spawn_entity,
+                        on_exit=[group_action],
+                    )
+                )
+                launch_processes.append(handler)
+            elif sim_mode == 'bridge':
+                launch_processes.append(group_action)
+    return launch_processes


### PR DESCRIPTION
Supports starting the simulation environment, spawning models and all supporting infrastructure with a single entry point:

For example spawning the coast with a single hexrotor.

```
ros2 launch mbzirc_ign competition.launch.py world:=coast config_file:=/home/mjcarroll/workspaces/mbzirc/src/mbzirc/mbzirc_ign/config/coast/hexrotor.yaml
```

Signed-off-by: Michael Carroll <michael@openrobotics.org>