### PR TITLE
Adds a simple Maritime radar.

### DIFF
--- a/mbzirc_custom/mbzirc_naive_spinning_radar/CMakeLists.txt
+++ b/mbzirc_custom/mbzirc_naive_spinning_radar/CMakeLists.txt
@@ -3,15 +3,61 @@ cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 project(mbzirc_naive_spinning_radar)
 
 find_package(ament_cmake REQUIRED)
+find_package(ignition-math6 REQUIRED)
+set(IGN_MATH_VER ${ignition-math6_VERSION_MAJOR})
+find_package(ignition-msgs8 REQUIRED)
+set(IGN_MSGS_VER ${ignition-msgs8_VERSION_MAJOR})
+find_package(ignition-transport11 REQUIRED)
+set(IGN_TRANSPORT_VER ${ignition-transport11_VERSION_MAJOR})
+find_package(ignition-plugin1 REQUIRED COMPONENTS loader register)
+set(IGN_PLUGIN_VER ${ignition-plugin1_VERSION_MAJOR})
+find_package(ignition-sensors6 REQUIRED)
+set(IGN_SENSORS_VER ${ignition-sensors6_VERSION_MAJOR})
+find_package(ignition-gazebo6 REQUIRED)
+set(IGN_GAZEBO_VER ${ignition-gazebo6_VERSION_MAJOR})
+find_package(radar_msgs REQUIRED)
+find_package(ros_ign_bridge REQUIRED)
+find_package(rclcpp REQUIRED)
 
 # Hooks
 ament_environment_hooks("hooks/resource_paths.dsv.in")
 ament_environment_hooks("hooks/resource_paths.sh")
 
+# build the ign-gazebo system
+add_library(MaritimeRadar SHARED
+    src/MaritimeRadar.cc
+)
+target_link_libraries(MaritimeRadar PUBLIC
+  ignition-gazebo${IGN_GAZEBO_VER}::core
+  ignition-msgs${IGN_MSGS_VER}::ignition-msgs${IGN_MSGS_VER}
+  ignition-plugin${IGN_PLUGIN_VER}::ignition-plugin${IGN_PLUGIN_VER}
+  ignition-transport${IGN_TRANSPORT_VER}::ignition-transport${IGN_TRANSPORT_VER}
+  ignition-sensors${IGN_SENSORS_VER}::ignition-sensors${IGN_SENSORS_VER}
+  ignition-math${IGN_MATH_VER}::ignition-math${IGN_MATH_VER}
+)
+
+# build the bridge process
+add_executable(maritime_radar_bridge src/maritime_radar_bridge.cc)
+ament_target_dependencies(maritime_radar_bridge
+  PUBLIC
+  rclcpp
+  radar_msgs
+  ros_ign_bridge
+)
+target_link_libraries(maritime_radar_bridge PUBLIC
+  #ignition-msgs${IGN_MSGS_VER}::ignition-msgs${IGN_MSGS_VER}
+  ignition-transport${IGN_TRANSPORT_VER}::ignition-transport${IGN_TRANSPORT_VER}
+)
 # Uncomment the install call below to install the example naive spinning radar
 # model
-# install(DIRECTORY
-#   models
-#   DESTINATION share/${PROJECT_NAME})
+install(DIRECTORY
+  models
+  DESTINATION share/${PROJECT_NAME})
+install(
+  TARGETS MaritimeRadar
+  DESTINATION lib)
+install(TARGETS
+  maritime_radar_bridge
+  DESTINATION lib/${PROJECT_NAME})
 
 ament_package()

--- a/mbzirc_custom/mbzirc_naive_spinning_radar/models/sensors/mbzirc_naive_spinning_radar/model.sdf
+++ b/mbzirc_custom/mbzirc_naive_spinning_radar/models/sensors/mbzirc_naive_spinning_radar/model.sdf
@@ -28,22 +28,26 @@
       </inertial>
       <sensor name="lidar" type="gpu_ray">
         <pose>0 0 0 1.57079 0 0</pose>
-        <update_rate>30</update_rate>
+        <!-- Make sure lidar can fill every bin. For a 60RPM radar 1 rotation
+        takes 1 second. Since the radar has an angular resolution of 1.44degrees
+        in one second there need to be 250 scans :o-->
+        <update_rate>250</update_rate>
         <lidar>
           <scan>
             <horizontal>
               <samples>256</samples>
               <resolution>1</resolution>
-              <min_angle>-0.17</min_angle>
-              <max_angle>0.17</max_angle>
+              <min_angle>-0.34</min_angle>
+              <max_angle>0.08</max_angle>
             </horizontal>
           </scan>
           <range>
-            <min>6</min>
-            <max>5000</max>
+            <min>1</min>
+            <max>1500</max>
             <resolution>1</resolution>
           </range>
           <noise>
+            <!-- TODO: Tweak this the RS24 has  -->
             <type>gaussian</type>
             <mean>0</mean>
             <stddev>2</stddev>
@@ -72,6 +76,11 @@
     <plugin
         filename="libignition-gazebo-joint-state-publisher-system.so"
         name="ignition::gazebo::systems::JointStatePublisher">
+      <joint_name>sensor_joint</joint_name>
+    </plugin>
+    <plugin
+      filename="libMaritimeRadar.so"
+      name="mbzirc::MaritimeRadar">
       <joint_name>sensor_joint</joint_name>
     </plugin>
     <frame name="mount_point"/>

--- a/mbzirc_custom/mbzirc_naive_spinning_radar/src/MaritimeRadar.cc
+++ b/mbzirc_custom/mbzirc_naive_spinning_radar/src/MaritimeRadar.cc
@@ -1,0 +1,260 @@
+#include "MaritimeRadar.hh"
+
+#include <ignition/gazebo/Model.hh>
+#include <ignition/gazebo/components/JointPosition.hh>
+#include <ignition/plugin/Register.hh>
+
+using namespace mbzirc;
+using namespace ignition;
+using namespace gazebo;
+
+///////////////////////////////////////////////////
+MaritimeRadar::MaritimeRadar()
+{
+
+}
+
+///////////////////////////////////////////////////
+MaritimeRadar::~MaritimeRadar()
+{
+
+}
+
+///////////////////////////////////////////////////
+void MaritimeRadar::Configure(const ignition::gazebo::Entity &_entity,
+                            const std::shared_ptr<const sdf::Element> &_sdf,
+                            ignition::gazebo::EntityComponentManager &_ecm,
+                            ignition::gazebo::EventManager &_eventMgr)
+{
+  gazebo::Model model(_entity);
+
+  // TODO(arjo): This is a hack to get the laser
+  std::string laserTopic =
+    "/world/coast/model/usv/model/sensor_0/link/sensor_link/sensor/lidar/scan";
+  if (_sdf->HasElement("laser_topic"))
+  {
+    laserTopic = _sdf->Get<std::string>("laser_topic");
+  }
+  node.Subscribe(laserTopic,
+    &MaritimeRadar::OnRadarScan, this);
+
+  // Get the joint name
+  auto jointName = _sdf->Get<std::string>("joint_name");
+  this->jointEntity = model.JointByName(_ecm, jointName);
+
+  // Get the angular resolution
+  if(_sdf->HasElement("angular_resolution"))
+  {
+    this->angularResolution = _sdf->Get<double>("angular_resolution");
+  }
+
+  // Get the linear resolution
+  if(_sdf->HasElement("linear_resolution"))
+  {
+    this->resolution = _sdf->Get<double>("linear_resolution");
+  }
+
+  // Get the maximum range
+  if(_sdf->HasElement("max_range"))
+  {
+    this->angularResolution = _sdf->Get<double>("max_range");
+  }
+
+  // Get the minimum range
+  if(_sdf->HasElement("min_range"))
+  {
+    this->angularResolution = _sdf->Get<double>("min_range");
+  }
+
+  // Get range buckets
+  std::size_t numRangeBuckets = floor(maxRange/resolution) + 1;
+  std::size_t numAngularBuckets = ceil(2 * IGN_PI /angularResolution) + 1;
+  radarBin.resize(numAngularBuckets);
+
+  for (std::size_t i = 0; i < numAngularBuckets; ++i)
+  {
+    radarBin[i].resize(numRangeBuckets, 0);
+  }
+
+  // Create debug image
+  // TODO(arjo): Make this configuarable.
+  this->image.set_width(this->debugImageWidth);
+  this->image.set_height(this->debugImageWidth);
+  this->image.set_step(this->debugImageWidth);
+  this->image.set_pixel_format_type(msgs::PixelFormatType::L_INT8);
+  this->image.mutable_data()->resize(
+    this->debugImageWidth * this->debugImageWidth);
+
+  // Create debug publisher
+  if (_sdf->HasElement("debug_image_topic"))
+  {
+    this->debugImageTopic = _sdf->Get<std::string>("debug_image_topic");
+  }
+  this->debugPub  = this->node.Advertise<msgs::Image>(debugImageTopic);
+
+  // Create radar spoke publisher
+  if (_sdf->HasElement("radar_spoke_topic"))
+  {
+    this->radarSpokeTopic = _sdf->Get<std::string>("radar_spoke_topic");
+  }
+  this->linePub  = this->node.Advertise<msgs::Float_V>(this->radarSpokeTopic);
+}
+
+///////////////////////////////////////////////////
+void MaritimeRadar::PostUpdate(
+  const ignition::gazebo::UpdateInfo &_info,
+  const ignition::gazebo::EntityComponentManager &_ecm)
+{
+  if (_info.paused)
+    return;
+
+  auto jointPosComp =
+    _ecm.Component<components::JointPosition>(this->jointEntity);
+  if (jointPosComp == nullptr)
+  {
+    ignerr << "No joint position component found for entity ["
+           << this->jointEntity << "]\n";
+    return;
+  }
+  // We just created the joint position component, give one iteration for the
+  // physics system to update its size
+  if (jointPosComp == nullptr || jointPosComp->Data().empty())
+    return;
+
+  // Sanity check: Make sure that the joint has an index
+  if (jointPosComp->Data().size() == 0)
+  {
+    return;
+  }
+
+  std::size_t index = floor(
+    fmod(jointPosComp->Data()[0], 2 * IGN_PI) /  angularResolution);
+
+  std::lock_guard<std::mutex> lock(this->mtx);
+  if (index != this->radarBinIndex)
+  {
+    this->PublishScan();
+    this->ClearScanBuffer((index) % this->radarBin.size());
+    this->radarBinIndex = index;
+    this->numBeams = 0;
+  }
+}
+
+///////////////////////////////////////////////////
+void MaritimeRadar::PreUpdate(
+  const ignition::gazebo::UpdateInfo &_info,
+  ignition::gazebo::EntityComponentManager &_ecm)
+{
+  if (_info.paused)
+    return;
+
+  // We need to track the joint position in order to know when to publish
+  auto jointPosComp =
+    _ecm.Component<components::JointPosition>(this->jointEntity);
+  if (jointPosComp == nullptr)
+  {
+    _ecm.CreateComponent(jointEntity, components::JointPosition());
+  }
+}
+
+///////////////////////////////////////////////////
+void MaritimeRadar::PublishScan()
+{
+  if(this->radarBin.size() < radarBinIndex +1)
+    return;
+  // Publish just a single radar bin
+  //
+  ignition::msgs::Float_V lineBin;
+  // First field of the float array is the angle
+  lineBin.add_data(this->radarBinIndex * this->angularResolution);
+  // Second field is the angular resolution
+  lineBin.add_data(this->angularResolution);
+  // Third field is the linear resolution
+  lineBin.add_data(this->resolution);
+  // Rest of the fields are the range bins
+  for (std::size_t i = 0; i < this->radarBin[radarBinIndex].size(); ++i)
+  {
+    // Convert to DB reflection
+    // Equation can be found here: https://en.wikipedia.org/wiki/Decibel
+    // TODO(arjo): Add some noise to this.
+    // Sea state vs radar noise model can be found here:
+    // https://www.mathworks.com/help/radar/ug/sea-clutter-simulation-for-maritime-radar-system.html
+    lineBin.add_data(
+      10 * log10(this->radarBin[radarBinIndex][i]/this->numBeams));
+  }
+  linePub.Publish(lineBin);
+
+  // The code below this point is for publishing debug images with a polar plot
+  // of radar hits/misses
+  // Convert to a message and publish
+  if(this->radarBinIndex == 0)
+  {
+    // Reset whenever we go back to 0
+    for (int i = 0; i < this->image.data().size(); i++)
+    {
+      (*this->image.mutable_data())[i] = 0;
+    }
+  }
+
+  // Plot current scan line
+  // TODO(arjo): plot using bressenham algorithm for cleaner lines
+  for (int j = 0; j  < this->radarBin[radarBinIndex].size(); j++)
+  {
+    double x =
+      cos(radarBinIndex * this->angularResolution)
+      * debugImageWidth/2 * (j * resolution / maxRange);
+    double y =
+      sin(radarBinIndex * this->angularResolution)
+      * debugImageWidth/2 * (j * resolution / maxRange);
+
+    std::size_t pixel_x = x + debugImageWidth/2;
+    std::size_t pixel_y = y + debugImageWidth/2;
+
+    std::size_t index = pixel_x * this->image.step() + pixel_y;
+    if (this->image.data().size() > index)
+    {
+      if(this->radarBin[radarBinIndex][j] > 0 || (*this->image.mutable_data())[index] > 0)
+        (*this->image.mutable_data())[index] = 255;
+    }
+  }
+  this->debugPub.Publish(this->image);
+}
+
+///////////////////////////////////////////////////
+void MaritimeRadar::ClearScanBuffer(std::size_t _index)
+{
+  // Clear the radar buffer for given index
+  for (std::size_t j = 0; j < radarBin[_index].size(); ++j)
+  {
+    radarBin[_index][j] = 0;
+  }
+}
+
+///////////////////////////////////////////////////
+void MaritimeRadar::OnRadarScan(const ignition::msgs::LaserScan &_msg)
+{
+  // We only want one radarbin
+  std::lock_guard<std::mutex> lock(this->mtx);
+
+  // Take the point cloud and project it onto a polar 2D plot.
+  auto minAngle = _msg.angle_min();
+  auto angle = minAngle;
+  this->numBeams += _msg.ranges_size();
+  for (int  i = 0; i < _msg.ranges_size(); ++i)
+  {
+    double range = _msg.ranges(i);
+    angle+=this->angularResolution;
+    auto projectedRange = cos(angle)*range;
+    if (projectedRange > maxRange || projectedRange < minRange)
+      continue;
+
+    // Register the range in the radar bin
+    this->radarBin[this->radarBinIndex][floor(projectedRange/resolution)]++;
+  }
+}
+
+IGNITION_ADD_PLUGIN(mbzirc::MaritimeRadar,
+                    ignition::gazebo::System,
+                    MaritimeRadar::ISystemConfigure,
+                    MaritimeRadar::ISystemPreUpdate,
+                    MaritimeRadar::ISystemPostUpdate)

--- a/mbzirc_custom/mbzirc_naive_spinning_radar/src/MaritimeRadar.hh
+++ b/mbzirc_custom/mbzirc_naive_spinning_radar/src/MaritimeRadar.hh
@@ -1,0 +1,158 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#ifndef MBZIRC_CUSTOMIZATIONS_MARITIMERADAR_HH_
+#define MBZIRC_CUSTOMIZATIONS_MARITIMERADAR_HH_
+
+#include <memory>
+
+#include <sdf/sdf.hh>
+#include <ignition/gazebo/System.hh>
+#include <ignition/transport/Node.hh>
+#include <ignition/msgs/laserscan.pb.h>
+#include <ignition/msgs/image.pb.h>
+#include <ignition/msgs/float_v.pb.h>
+
+namespace mbzirc
+{
+  /// \brief An example class to simulate a radar that generates range
+  /// and bearing data. Essentially it takes a LiDAR and projects it
+  /// onto a polar plot. The range noise of the lidar should be tuned to be
+  /// within the limits of the radar's noise uncertainty.
+  ///
+  /// # Parameters
+  /// * laser_topic - The topic of the associated LiDAR.
+  /// * angular_resolution - The angular resolution of each spoke. Normally
+  ///   marine radars publish their position and a sample image of returns along
+  ///   a given "spoke".
+  /// * linear_resolution - The linear resolution of each range bin. Marine
+  /// radars usually return a 1D array for range bins for a given angle.
+  /// * max_range - The maximum range of the radar.
+  /// * min_range - The minimum range of the radar.
+  /// * debug_image_topic - The topic to publish the debug image. This is a
+  ///   ignition::msgs::Image message with the full polarplot and scan line,
+  ///   Useful for debugging.
+  /// * radar_spoke_topic - The topic to publish the radar spoke. This is a
+  ///   ignition::msgs::Float_V message with the range bins for a given angle.
+  ///   The first number in this float_v message is the angle of the spoke.
+  ///   The second number is the angular resolution of the spoke. The third
+  ///   number is the linear resolution of the spoke. The rest of the numbers
+  ///   are the range bins for the spoke with measurements in DB.
+  /// By default this system has been tuned to us the Wartsila RS24 radar
+  /// parameters.
+  class MaritimeRadar:
+        public ignition::gazebo::System,
+        public ignition::gazebo::ISystemConfigure,
+        public ignition::gazebo::ISystemPostUpdate,
+        public ignition::gazebo::ISystemPreUpdate
+  {
+    /// \brief Constructor
+    public: MaritimeRadar();
+
+    /// \brief Destructor
+    public: ~MaritimeRadar() override;
+
+    // Documentation inherited.
+    public: void Configure(const ignition::gazebo::Entity &_entity,
+                           const std::shared_ptr<const sdf::Element> &_sdf,
+                           ignition::gazebo::EntityComponentManager &_ecm,
+                           ignition::gazebo::EventManager &_eventMgr) override;
+
+    // Documentation inherited
+    public: void PostUpdate(
+                const ignition::gazebo::UpdateInfo &_info,
+                const ignition::gazebo::EntityComponentManager &_ecm) override;
+
+    // Documentation inherited
+    public: void PreUpdate(
+                const ignition::gazebo::UpdateInfo &_info,
+                ignition::gazebo::EntityComponentManager &_ecm) override;
+
+    /// \brief Callback for laser scan messages
+    /// This turns the lidar sensor and plots the range data as individual bins.
+    public: void OnRadarScan(const ignition::msgs::LaserScan &_msg);
+
+    /// \brief Publishes a RADAR scan message. This function
+    public: void PublishScan();
+
+    /// \brief clear the current scan buffer
+    /// \param[in] index - Spoke to be cleared.
+    public: void ClearScanBuffer(std::size_t index);
+
+    /// \brief Minimum range (m)
+    public: double minRange{1.0};
+
+    /// \brief Maximum range (m)
+    public: double maxRange{1500.0};
+
+    /// \brief Resolution (in metres)
+    public: double resolution{0.75};
+
+    /// \brief Minimum vertical angle (rad)
+    public: double minVerticalAngle{-0.1745};
+
+    /// \brief Maximum vertical angle (rad)
+    public: double maxVerticalAngle{0.1745};
+
+    /// \brief Angular resolution (rad)
+    public: double angularResolution{IGN_DTOR(1.44)};
+
+    /// \brief Sensor update rate
+    public: double updateRate{1.0};
+
+    /// \brief Number of beams of the sampling GPURay
+    public: size_t numBeams{0};
+
+    /// \brief Joint Position
+    public: std::size_t radarBinIndex;
+
+    /// \brief stores radar scan data for each beam.
+    public: std::vector<std::vector<double>> radarBin;
+
+    /// \brief Noise to be applied to radar data
+    ///public: ignition::sensors::NoisePtr noise;
+
+    /// \brief Entity ID of the sensor
+    public: ignition::gazebo::Entity entity{ignition::gazebo::kNullEntity};
+
+    /// \brief Entity ID of the rotary joint.
+    public: ignition::gazebo::Entity jointEntity{ignition::gazebo::kNullEntity};
+
+    /// \brief Ignition tranport node
+    public: ignition::transport::Node node;
+
+    /// \brief Ignition transport publisher for publishing sensor data
+    public: ignition::transport::Node::Publisher linePub;
+
+    /// \brief Ignition transport publisher for publishing sensor data
+    public: ignition::transport::Node::Publisher debugPub;
+
+    /// \brief Image used for debugging radar scan.
+    public: ignition::msgs::Image image;
+
+    public: ignition::msgs::Float_V lineBin;
+
+    public: const size_t debugImageWidth{640};
+
+    public: std::string debugImageTopic{"/radar/debug_image"};
+
+    public: std::string radarSpokeTopic{"/radar/scan"};
+
+    public: std::mutex mtx;
+  };
+}
+
+#endif

--- a/mbzirc_custom/mbzirc_naive_spinning_radar/src/maritime_radar_bridge.cc
+++ b/mbzirc_custom/mbzirc_naive_spinning_radar/src/maritime_radar_bridge.cc
@@ -1,0 +1,133 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <ignition/msgs/float_v.pb.h>
+#include <ignition/transport/Node.hh>
+
+#include <ros_ign_bridge/convert/std_msgs.hpp>
+
+#include <radar_msgs/msg/radar_scan.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+using namespace std::chrono_literals;
+
+/// \brief Bridge for converting ign msgs to ros
+class MaritimeRadarBridge : public rclcpp::Node
+{
+  public:
+    MaritimeRadarBridge():
+      Node("maritime_radar_bridge")
+    {
+      // declare a parameter that lets user specifies the ign topic
+      // which will be bridged
+      this->declare_parameter<std::string>("topic", "radar/scan");
+      this->get_parameter("topic", this->topic);
+
+      // create the ros publisher
+      // the topic name will be remapped by the bridge node
+      this->rosPub = this->create_publisher<radar_msgs::msg::RadarScan>(
+          "radar/scan", 10);
+
+      // create a timer to periodically check for ros subscribers
+      this->timer = this->create_wall_timer(100ms,
+          std::bind(&MaritimeRadarBridge::CheckSubscribers, this));
+    }
+
+  /// \brief Periodically check subcription count on the radar topic.
+  /// If subscribers are present, we initiate subscription to the ignition
+  /// topics, convert ign msgs to ros msgs, then publish to ros topics .
+  private: void CheckSubscribers()
+  {
+    if (this->rosPub->get_subscription_count() > 0u)
+      this->SensorConnect();
+  }
+
+  /// \brief Callback when ros subscriber connects to the ros topic
+  private: void SensorConnect()
+  {
+    // return if we are already subscribed to the ign topic
+    if (this->subscribed)
+      return;
+    this->ignNode.Subscribe(this->topic, &MaritimeRadarBridge::OnData, this);
+    this->subscribed = true;
+  }
+
+  /// \brief Callback when msgs are received on the ign topic
+  /// \param[in] _msg Float_V msgs with data arranged in the following format:
+  /// [range, azimuth, elevation, range2, azimuth2, elevation2, ...]
+  public: void OnData(const ignition::msgs::Float_V &_msg)
+  {
+    // unsubscribe from the ign topic if there are no more ros subscribers
+    if (this->rosPub->get_subscription_count() == 0u && this->subscribed)
+    {
+      this->ignNode.Unsubscribe(this->topic);
+      this->subscribed = false;
+      return;
+    }
+
+    // make sure data is in the expected format
+    if (_msg.data().size() % 3 != 0)
+      return;
+
+    // pack ros msg and publish
+    // convert ign header to ros header
+    radar_msgs::msg::RadarScan rosMsg;
+    ros_ign_bridge::convert_ign_to_ros(_msg.header(), rosMsg.header);
+
+    if(_msg.data().size() < 3)
+    {
+      RCLCPP_ERROR(get_logger(),
+        "Malformatted radarscan. Scan must be at least of length 3");
+      return;
+    }
+
+    float angle = _msg.data(0);
+    float linearRes = _msg.data(2);
+    for (int i = 3 ; i < _msg.data_size(); i++)
+    {
+      radar_msgs::msg::RadarReturn returnMsg;
+      returnMsg.azimuth = angle;
+      returnMsg.range = (i-3) * linearRes;
+      returnMsg.amplitude = _msg.data(i);
+      rosMsg.returns.push_back(returnMsg);
+    }
+
+    this->rosPub->publish(rosMsg);
+  }
+
+  /// \brief timer with callback to check for publisher subscription count
+  private: rclcpp::TimerBase::SharedPtr timer;
+
+  /// \brief Sensor data topic
+  private: std::string topic;
+
+  /// \brief If we are subscribed to the ign topic
+  private: bool subscribed{false};
+
+  /// \brief Ignition transport node
+  private: ignition::transport::Node ignNode;
+
+  /// \brief ROS Publisher for the radar msgs
+  private: rclcpp::Publisher<radar_msgs::msg::RadarScan>::SharedPtr rosPub;
+};
+
+int main (int argc, const char** argv)
+{
+  rclcpp::init(argc, argv);
+  rclcpp::spin(std::make_shared<MaritimeRadarBridge>());
+  rclcpp::shutdown();
+}


### PR DESCRIPTION
The following PR adds a simple maritime RADAR. It is by no means complete but since I dont have time on this project anymore I'll leave this here.  Bascially, the way this works is very simple. We extend the naive spiinning radar example with a simple plugin. This plugin projects the radar onto a polar coordinate frame. It combines the current lidar position and the lidar return and projects it into a polar plot like maritime radars do. The end user will receive a `ignition.msgs.Float_V`. The first bin contains the angle the radar is currently facing, the second bin will contain the resolution of the bin and the third item is the resolution of each bin. The rest of the FloatV will contain the sampled bins for each location.

Here's a gif of it in action:
![ezgif com-gif-maker](https://user-images.githubusercontent.com/542272/171113965-0b3c9ccf-30b9-409a-9012-986a2615ebcf.gif)

> PS: I'm sorry I accidentally pushed to main. I have reverted the mistake. The disaster has been averted, but we probably want to lock the main branch to prevent such mistakes.

## Some things to work on

* [ ] Performance. Currently the performance of the system is at 25%RTF when we load the radar simulation. There are some low hanging fruits which I have marked with TODOs that should help boost the performance. In particular we are doing a lot of copying when filling the message. Pre-allocating the message could save some compute time.
* [ ] ROS Bridge.  Currently the function in the rosbridge looks correct but for whatever reason Im unable to link against the local protobuf runtime. (The Naive RADAR bridge is doing the same for me)
* Unit/integration tests

## Stretch Goals
* Integrate rain and sea state noise in (see todos in `MaritimeRadar.cc`)

For completeness the NaiveRadar should really just populate the RadarTracks message instead of the RadarScan message.

Signed-off-by: Arjo Chakravarty <arjo@openrobotics.org>