### PR TITLE
Update large objects and vessels geometry

### DIFF
--- a/mbzirc_ign/worlds/coast.sdf
+++ b/mbzirc_ign/worlds/coast.sdf
@@ -944,9 +944,9 @@
     </include>
     <include>
       <name>large_dry_box_a</name>
-      <pose relative_to="Vessel A">0.08 -0.57 0.05 0 0 -0.3</pose>
+      <pose relative_to="Vessel A">-1.9 -0.0 0.05 0 0 -1.466</pose>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Large Dry Box
+        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Large Dry Box Handles
       </uri>
       <plugin filename="ignition-gazebo-detachable-joint-system" name="ignition::gazebo::systems::DetachableJoint">
        <parent_link>link</parent_link>
@@ -957,9 +957,9 @@
     </include>
     <include>
       <name>large_dry_box_a_duplicate</name>
-      <pose relative_to="Vessel A">0.7 0.23 0.05 0 0 0.2</pose>
+      <pose relative_to="Vessel A">0.9 -0.12 0.05 0 0 0.2</pose>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Large Dry Box
+        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Large Dry Box Handles
       </uri>
       <plugin filename="ignition-gazebo-detachable-joint-system" name="ignition::gazebo::systems::DetachableJoint">
        <parent_link>link</parent_link>
@@ -971,14 +971,14 @@
 
     <include>
       <name>small_case_b</name>
-      <pose relative_to="Vessel B">-0.35 1.6 0.80768 1.57079632679 0 0.2</pose>
+      <pose relative_to="Vessel B">-0.35 1.6 0.73768 1.57079632679 0 0.2</pose>
       <uri>
         https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Small Case
       </uri>
     </include>
     <include>
       <name>small_case_b_duplicate</name>
-      <pose relative_to="Vessel B">-2.28 -1.0 0.80768 1.57079632679 0 1</pose>
+      <pose relative_to="Vessel B">-2.28 -1.0 0.73768 1.57079632679 0 1</pose>
       <uri>
         https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Small Case
       </uri>
@@ -991,9 +991,9 @@
     </include>
     <include>
       <name>large_grey_box_b</name>
-      <pose relative_to="Vessel B">0.25 -0.9 0.792 0 0 -0.3</pose>
+      <pose relative_to="Vessel B">0.25 -0.9 0.722 0 0 -0.3</pose>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Large Grey Box
+        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Large Grey Box Handles
       </uri>
       <plugin filename="ignition-gazebo-detachable-joint-system" name="ignition::gazebo::systems::DetachableJoint">
        <parent_link>link</parent_link>
@@ -1004,9 +1004,9 @@
     </include>
     <include>
       <name>large_grey_box_b_duplicate</name>
-      <pose relative_to="Vessel B">3.07 0.1 1.07 0 0 1.2</pose>
+      <pose relative_to="Vessel B">3.07 0.1 1.0 0 0 1.2</pose>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Large Grey Box
+        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Large Grey Box Handles
       </uri>
       <plugin filename="ignition-gazebo-detachable-joint-system" name="ignition::gazebo::systems::DetachableJoint">
        <parent_link>link</parent_link>
@@ -1018,14 +1018,14 @@
 
     <include>
       <name>small_dry_bag_c</name>
-      <pose relative_to="Vessel C">-2.5 0.167 0.792 0 0 0.0</pose>
+      <pose relative_to="Vessel C">-2.5 0.167 0.722 0 0 0.0</pose>
       <uri>
         https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Small Dry Bag
       </uri>
     </include>
     <include>
       <name>small_dry_bag_c_duplicate</name>
-      <pose relative_to="Vessel C">2.75 -1.078 1.0687 0 0 -0.8</pose>
+      <pose relative_to="Vessel C">2.75 -1.078 0.9987 0 0 -0.8</pose>
       <uri>
         https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Small Dry Bag
       </uri>
@@ -1038,9 +1038,9 @@
     </include>
     <include>
       <name>large_ammo_can_c</name>
-      <pose relative_to="Vessel C">0.27 0.3 0.792 0 0 1.3</pose>
+      <pose relative_to="Vessel C">0.27 0.3 0.722 0 0 1.3</pose>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Large Ammo Can
+        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Large Ammo Can Handles
       </uri>
       <plugin filename="ignition-gazebo-detachable-joint-system" name="ignition::gazebo::systems::DetachableJoint">
        <parent_link>link</parent_link>
@@ -1051,9 +1051,9 @@
     </include>
     <include>
       <name>large_ammo_can_c_duplicate</name>
-      <pose relative_to="Vessel C">3.17 1.58 1.0838 0 0 -0.6</pose>
+      <pose relative_to="Vessel C">3.17 1.58 1.0138 0 0 -0.6</pose>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Large Ammo Can
+        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Large Ammo Can Handles
       </uri>
       <plugin filename="ignition-gazebo-detachable-joint-system" name="ignition::gazebo::systems::DetachableJoint">
        <parent_link>link</parent_link>
@@ -1065,14 +1065,14 @@
 
     <include>
       <name>small_blue_box_d</name>
-      <pose relative_to="Vessel D">-2.5 -1.9 0.7807 0 0 0.0</pose>
+      <pose relative_to="Vessel D">-2.5 -1.9 0.7107 0 0 0.0</pose>
       <uri>
         https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Small Blue Box
       </uri>
     </include>
     <include>
       <name>small_blue_box_d_duplicate</name>
-      <pose relative_to="Vessel D">2.75 -1.078 1.0603 0 0 -0.8</pose>
+      <pose relative_to="Vessel D">2.75 -1.078 0.9903 0 0 -0.8</pose>
       <uri>
         https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Small Blue Box
       </uri>
@@ -1085,9 +1085,9 @@
     </include>
     <include>
       <name>large_crate_d</name>
-      <pose relative_to="Vessel D">0.27 1.73 0.779 0 0 1.3</pose>
+      <pose relative_to="Vessel D">0.27 1.73 0.709 0 0 1.3</pose>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Large Crate
+        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Large Crate Handles
       </uri>
       <plugin filename="ignition-gazebo-detachable-joint-system" name="ignition::gazebo::systems::DetachableJoint">
        <parent_link>link</parent_link>
@@ -1098,9 +1098,9 @@
     </include>
     <include>
       <name>large_crate_d_duplicate</name>
-      <pose relative_to="Vessel D">3.17 1.58 1.103 0 0 -0.6</pose>
+      <pose relative_to="Vessel D">3.17 1.58 1.033 0 0 -0.6</pose>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Large Crate
+        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Large Crate Handles
       </uri>
       <plugin filename="ignition-gazebo-detachable-joint-system" name="ignition::gazebo::systems::DetachableJoint">
        <parent_link>link</parent_link>
@@ -1132,9 +1132,9 @@
     </include>
     <include>
       <name>large_dry_box_e</name>
-      <pose relative_to="Vessel E">-1.9 -1.61 0.4229 0 0 0.3</pose>
+      <pose relative_to="Vessel E">-1.9 -1.0 0.4229 0 0 0.3</pose>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Large Dry Box
+        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Large Dry Box Handles
       </uri>
       <plugin filename="ignition-gazebo-detachable-joint-system" name="ignition::gazebo::systems::DetachableJoint">
        <parent_link>link</parent_link>
@@ -1147,7 +1147,7 @@
       <name>large_dry_box_e_duplicate</name>
       <pose relative_to="Vessel E">-5.22 0.25 0.4229 0 0 0.6</pose>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Large Dry Box
+        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Large Dry Box Handles
       </uri>
       <plugin filename="ignition-gazebo-detachable-joint-system" name="ignition::gazebo::systems::DetachableJoint">
        <parent_link>link</parent_link>
@@ -1181,7 +1181,7 @@
       <name>large_ammo_can_f</name>
       <pose relative_to="Vessel F">3.78 1.22 1.246 0 0 0.3</pose>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Large Ammo Can
+        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Large Ammo Can Handles
       </uri>
       <plugin filename="ignition-gazebo-detachable-joint-system" name="ignition::gazebo::systems::DetachableJoint">
        <parent_link>link</parent_link>
@@ -1194,7 +1194,7 @@
       <name>large_ammo_can_f_duplicate</name>
       <pose relative_to="Vessel F">1.46 -1.25 1.186 0 0 0.6</pose>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Large Ammo Can
+        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Large Ammo Can Handles
       </uri>
       <plugin filename="ignition-gazebo-detachable-joint-system" name="ignition::gazebo::systems::DetachableJoint">
        <parent_link>link</parent_link>
@@ -1206,14 +1206,14 @@
 
     <include>
       <name>small_dry_bag_handle_g</name>
-      <pose relative_to="Vessel G">-8.07 -1.07 1.6593 0 0 -0.5</pose>
+      <pose relative_to="Vessel G">-5.81 0.723 1.4855 0 0 -0.5</pose>
       <uri>
         https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Small Dry Bag Handle
       </uri>
     </include>
     <include>
       <name>small_dry_bag_handle_g_duplicate</name>
-      <pose relative_to="Vessel G">-7.31 0.5 1.61 0 0 1.1</pose>
+      <pose relative_to="Vessel G">-4.37 -0.9 1.1686 0 0 1.1</pose>
       <uri>
         https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Small Dry Bag Handle
       </uri>
@@ -1226,9 +1226,9 @@
     </include>
     <include>
       <name>large_crate_g</name>
-      <pose relative_to="Vessel G">-4.75 0.81 1.4794 0 0 -1.3</pose>
+      <pose relative_to="Vessel G">-1.81 -0.37 1.07 0 0 0</pose>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Large Crate
+        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Large Crate Handles
       </uri>
       <plugin filename="ignition-gazebo-detachable-joint-system" name="ignition::gazebo::systems::DetachableJoint">
        <parent_link>link</parent_link>
@@ -1239,9 +1239,9 @@
     </include>
     <include>
       <name>large_crate_g_duplicate</name>
-      <pose relative_to="Vessel G">-3.48 -1.624 1.4305 0 0 0.0</pose>
+      <pose relative_to="Vessel G">-3.43 -0.72 1.1095 0 0 0.2</pose>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Large Crate
+        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Large Crate Handles
       </uri>
       <plugin filename="ignition-gazebo-detachable-joint-system" name="ignition::gazebo::systems::DetachableJoint">
        <parent_link>link</parent_link>

--- a/mbzirc_ign/worlds/simple_demo.sdf
+++ b/mbzirc_ign/worlds/simple_demo.sdf
@@ -286,9 +286,9 @@
 
     <include>
       <name>large_dry_box_a</name>
-      <pose relative_to="Vessel A">0.08 -0.57 0.05 0 0 -0.3</pose>
+      <pose relative_to="Vessel A">-1.9 -0.0 0.05 0 0 -1.466</pose>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Large Dry Box
+        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Large Dry Box Handles
       </uri>
       <plugin filename="ignition-gazebo-detachable-joint-system" name="ignition::gazebo::systems::DetachableJoint">
        <parent_link>link</parent_link>
@@ -300,9 +300,9 @@
 
     <include>
       <name>large_dry_box_a_duplicate</name>
-      <pose relative_to="Vessel A">0.7 0.23 0.05 0 0 0.2</pose>
+      <pose relative_to="Vessel A">0.9 -0.12 0.05 0 0 0.2</pose>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Large Dry Box
+        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Large Dry Box Handles
       </uri>
       <plugin filename="ignition-gazebo-detachable-joint-system" name="ignition::gazebo::systems::DetachableJoint">
        <parent_link>link</parent_link>


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

There are 2 main changes:
* Replaced large objects with a new version that has handles on all four sides. 
* Scaled down Vessels B, C, D, and G

All these updated models are on Fuel:
https://app.gazebosim.org/OpenRobotics/fuel/collections/mbzirc

The new large objects on Fule have the suffix `Handles` in their names. The handles are at least 1m apart to make room for UAVs to get close to each other and grasp the handles.

![large_obj_handles](https://user-images.githubusercontent.com/4000684/171521549-0ee73455-6bd3-4a7d-9f40-e6be3efb8a8c.png)

Vessels B, C, and D have been scaled down to 90% of its original size, while Vessel G has been scaled down to 70% of its original size. Screenshot below shows that the USV with arm should no longer have any problem reaching into Vessel G for grasping the target objects.

![vessel_g_scale](https://user-images.githubusercontent.com/4000684/171521535-281b39d6-f3fd-418a-801a-81e6f64ec95a.png)
