### PR TITLE
Suggestions to #131

### DIFF
--- a/mbzirc_ign/src/mbzirc_ign/model.py
+++ b/mbzirc_ign/src/mbzirc_ign/model.py
@@ -122,7 +122,7 @@ class Model:
             nodes.append(Node(
                 package='mbzirc_ros',
                 executable='usv_bridge',
-                parameters=[{'model_name': self.model_name}],))
+            ))
 
         if self.has_valid_arm():
             # arm joint states

--- a/mbzirc_ros/CMakeLists.txt
+++ b/mbzirc_ros/CMakeLists.txt
@@ -5,6 +5,8 @@ project(mbzirc_ros)
 find_package(ament_cmake REQUIRED)
 
 find_package(geometry_msgs REQUIRED)
+find_package(ignition-math6 REQUIRED)
+set(IGN_MATH_VER ${ignition-math6_VERSION_MAJOR})
 find_package(ignition-msgs8 REQUIRED)
 find_package(ignition-transport11 REQUIRED)
 set(IGN_TRANSPORT_VER ${ignition-transport11_VERSION_MAJOR})
@@ -67,7 +69,7 @@ ament_target_dependencies(usv_bridge
   std_msgs
 )
 target_link_libraries(usv_bridge PUBLIC
-  ignition-math6::ignition-math6
+  ignition-math${IGN_MATH_VER}::ignition-math${IGN_MATH_VER}
 )
 
 # Resources

--- a/mbzirc_ros/src/usv_bridge.cc
+++ b/mbzirc_ros/src/usv_bridge.cc
@@ -50,13 +50,13 @@ class USVBridge : public rclcpp::Node
     // cmd thrust sub
     this->cmdThrustersSub =
        this->create_subscription<std_msgs::msg::Int16MultiArray>(
-       "cat/cmd_thrusters", 1,
+       "/cat/cmd_thrusters", 1,
        std::bind(&USVBridge::OnCmdThrusters, this, _1));
 
     // cmd pod sub
     this->cmdPodSub =
        this->create_subscription<std_msgs::msg::Int16MultiArray>(
-       "cat/cmd_pod", 1,
+       "/cat/cmd_pod", 1,
        std::bind(&USVBridge::OnCmdPod, this, _1));
   }
 

--- a/mbzirc_ros/src/usv_bridge.cc
+++ b/mbzirc_ros/src/usv_bridge.cc
@@ -35,53 +35,41 @@ class USVBridge : public rclcpp::Node
   /// \brief Constructor
   public: USVBridge() : Node("usv_bridge")
   {
-    this->declare_parameter<std::string>("model_name", "usv");
-    std::string name;
-    this->get_parameter("model_name", name);
-
     // cmd thrust pub
-    std::string leftCmdThrustTopic = "/" + name
-        + "/left/thrust/cmd_thrust";
-    std::string rightCmdThrustTopic = "/" + name
-        + "/right/thrust/cmd_thrust";
     this->leftCmdThrustPub = this->create_publisher<std_msgs::msg::Float64>(
-        leftCmdThrustTopic, 10);
+        "left/thrust/cmd_thrust", 10);
     this->rightCmdThrustPub = this->create_publisher<std_msgs::msg::Float64>(
-        rightCmdThrustTopic, 10);
+        "right/thrust/cmd_thrust", 10);
 
     // cmd pos pub
-    std::string leftCmdPosTopic = "/" + name
-        + "/left/thrust/joint/cmd_pos";
-    std::string rightCmdPosTopic = "/" + name
-        + "/right/thrust/joint/cmd_pos";
     this->leftCmdPosPub = this->create_publisher<std_msgs::msg::Float64>(
-        leftCmdPosTopic, 10);
+        "left/thrust/joint/cmd_pos", 10);
     this->rightCmdPosPub = this->create_publisher<std_msgs::msg::Float64>(
-        rightCmdPosTopic, 10);
+        "right/thrust/joint/cmd_pos", 10);
 
     // cmd thrust sub
     this->cmdThrustersSub =
        this->create_subscription<std_msgs::msg::Int16MultiArray>(
-       "/cat/cmd_thrusters", 1,
+       "cat/cmd_thrusters", 1,
        std::bind(&USVBridge::OnCmdThrusters, this, _1));
 
     // cmd pod sub
     this->cmdPodSub =
        this->create_subscription<std_msgs::msg::Int16MultiArray>(
-       "/cat/cmd_pod", 1,
+       "cat/cmd_pod", 1,
        std::bind(&USVBridge::OnCmdPod, this, _1));
   }
 
   /// \brief Callback when a thrust cmd is received
   /// \param[in] _msg Thrust cmd message
   private: void OnCmdThrusters(
-      const std::shared_ptr<std_msgs::msg::Int16MultiArray> _msg)
+      const std_msgs::msg::Int16MultiArray& _msg)
   {
     // there should only be 2 values
     //     index 0: left
     //     index 1: right
-    int16_t leftValue = _msg->data[0];
-    int16_t rightValue = _msg->data[1];
+    int16_t leftValue = _msg.data[0];
+    int16_t rightValue = _msg.data[1];
 
     // forward values to sim API
     std_msgs::msg::Float64 leftThrustMsg;
@@ -96,14 +84,14 @@ class USVBridge : public rclcpp::Node
   /// \brief Callback when a pod pos cmd is received
   /// \param[in] _msg Pod pos cmd message
   private: void OnCmdPod(
-      const std::shared_ptr<std_msgs::msg::Int16MultiArray> _msg)
+      const std_msgs::msg::Int16MultiArray& _msg)
   {
     // there should only be 2 values
     //     index 0: left
     //     index 1: right
     // values are expressed in hundreds of degrees
-    int16_t leftValue = _msg->data[0];
-    int16_t rightValue = _msg->data[1];
+    int16_t leftValue = _msg.data[0];
+    int16_t rightValue = _msg.data[1];
 
     // convert to sim frame
     // -90 deg in hw = 0 in sim


### PR DESCRIPTION
* Be explicit about ignition math in cmake
* Make use of namespaces rather than passing model name
* Push commands into namespace (eg `/usv/cat/cmd_pod` rather than `/cat/cmd_pod`)
* Prefer const ref callbacks.

Signed-off-by: Michael Carroll <michael@openrobotics.org>