### PR TITLE
Fix coast world systems

### DIFF
--- a/mbzirc_ign/worlds/coast.sdf
+++ b/mbzirc_ign/worlds/coast.sdf
@@ -312,20 +312,6 @@
     <plugin
       filename="ignition-gazebo-contact-system"
       name="ignition::gazebo::systems::Contact">
-      filename="ignition-gazebo-rf-comms-system"
-      name="ignition::gazebo::systems::RFComms">
-      <range_config>
-        <max_range>500000.0</max_range>
-        <fading_exponent>2.6</fading_exponent>
-        <l0>40</l0>
-        <sigma>10.0</sigma>
-      </range_config>
-      <radio_config>
-        <capacity>1000000</capacity>
-        <tx_power>25</tx_power>
-        <noise_floor>-90</noise_floor>
-        <modulation>QPSK</modulation>
-      </radio_config>
     </plugin>
     <plugin
       filename="ignition-gazebo-rf-comms-system"
@@ -338,7 +324,7 @@
       </range_config>
       <radio_config>
         <capacity>1000000</capacity>
-        <tx_power>20</tx_power>
+        <tx_power>25</tx_power>
         <noise_floor>-90</noise_floor>
         <modulation>QPSK</modulation>
       </radio_config>


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

Fixes #139 

Fix system params in coast world, which seem like they are from a bad merge. The `tx_power` should now be 25 as of https://github.com/osrf/mbzirc/pull/113