### PR TITLE
Create unique gripper model per parent vehicle model

### DIFF
--- a/mbzirc_ign/hooks/resource_paths.dsv.in
+++ b/mbzirc_ign/hooks/resource_paths.dsv.in
@@ -1,5 +1,6 @@
 prepend-non-duplicate;IGN_GAZEBO_RESOURCE_PATH;@CMAKE_INSTALL_PREFIX@/share/@PROJECT_NAME@/worlds
 prepend-non-duplicate;IGN_GAZEBO_RESOURCE_PATH;@CMAKE_INSTALL_PREFIX@/share/@PROJECT_NAME@/models
+prepend-non-duplicate;IGN_GAZEBO_RESOURCE_PATH;@CMAKE_INSTALL_PREFIX@/share/@PROJECT_NAME@/models/tmp
 prepend-non-duplicate;IGN_GAZEBO_SYSTEM_PLUGIN_PATH;@CMAKE_INSTALL_PREFIX@/lib
 
 prepend-non-duplicate;LD_LIBRARY_PATH;@CMAKE_INSTALL_PREFIX@/lib

--- a/mbzirc_ign/hooks/resource_paths.sh
+++ b/mbzirc_ign/hooks/resource_paths.sh
@@ -1,5 +1,6 @@
 ament_prepend_unique_value IGN_GAZEBO_RESOURCE_PATH "$AMENT_CURRENT_PREFIX/share/mbzirc_ign/worlds"
 ament_prepend_unique_value IGN_GAZEBO_RESOURCE_PATH "$AMENT_CURRENT_PREFIX/share/mbzirc_ign/models"
+ament_prepend_unique_value IGN_GAZEBO_RESOURCE_PATH "$AMENT_CURRENT_PREFIX/share/mbzirc_ign/models/tmp"
 ament_prepend_unique_value IGN_GAZEBO_SYSTEM_PLUGIN_PATH "$AMENT_CURRENT_PREFIX/lib"
 
 ament_prepend_unique_value LD_LIBRARY_PATH "$AMENT_CURRENT_PREFIX/lib"

--- a/mbzirc_ign/src/SuctionGripper.cc
+++ b/mbzirc_ign/src/SuctionGripper.cc
@@ -154,15 +154,15 @@ void SuctionGripperPlugin::Configure(const Entity &_entity,
     this->dataPtr->node.Subscribe(prefix + "/contact_sensor_12", callback_12);
 
 
-    this->dataPtr->contactPublisherCenter = 
+    this->dataPtr->contactPublisherCenter =
       this->dataPtr->node.Advertise<msgs::Boolean>(prefix + "/contacts/center");
-    this->dataPtr->contactPublisherLeft = 
+    this->dataPtr->contactPublisherLeft =
       this->dataPtr->node.Advertise<msgs::Boolean>(prefix + "/contacts/left");
-    this->dataPtr->contactPublisherRight = 
+    this->dataPtr->contactPublisherRight =
       this->dataPtr->node.Advertise<msgs::Boolean>(prefix + "/contacts/right");
-    this->dataPtr->contactPublisherTop = 
+    this->dataPtr->contactPublisherTop =
       this->dataPtr->node.Advertise<msgs::Boolean>(prefix + "/contacts/top");
-    this->dataPtr->contactPublisherBottom = 
+    this->dataPtr->contactPublisherBottom =
       this->dataPtr->node.Advertise<msgs::Boolean>(prefix + "/contacts/bottom");
   }
   else
@@ -205,7 +205,7 @@ void SuctionGripperPlugin::PreUpdate(const UpdateInfo &_info,
     this->dataPtr->contactPublisherRight.Publish(contact);
     this->dataPtr->contactPublisherTop.Publish(contact);
     this->dataPtr->contactPublisherBottom.Publish(contact);
-  } 
+  }
   else
   {
     contact.set_data(this->dataPtr->contacts[1][1] != kNullEntity);
@@ -228,13 +228,13 @@ void SuctionGripperPlugin::PreUpdate(const UpdateInfo &_info,
   if (!this->dataPtr->jointCreated && this->dataPtr->suctionOn)
   {
     // check that two sensors are making contact with the same object
-    auto checkContacts = 
+    auto checkContacts =
       [&](std::pair<int, int> idx0, std::pair<int, int> idx1) -> bool {
         auto contact0 = this->dataPtr->contacts[idx0.first][idx0.second];
         auto contact1 = this->dataPtr->contacts[idx1.first][idx1.second];
-        return  
-          (contact0 != kNullEntity && 
-           contact1 != kNullEntity && 
+        return
+          (contact0 != kNullEntity &&
+           contact1 != kNullEntity &&
            contact0 == contact1);
       };
 
@@ -243,7 +243,7 @@ void SuctionGripperPlugin::PreUpdate(const UpdateInfo &_info,
       (checkContacts({1, 1}, {1, 0}) ||  // Center + left
        checkContacts({1, 1}, {1, 2}) ||  // Center + right
        checkContacts({1, 1}, {0, 1}) ||  // Center + top
-       checkContacts({1, 1}, {2, 1}));   // Center + bottom 
+       checkContacts({1, 1}, {2, 1}));   // Center + bottom
 
     if (contactMade)
     {
@@ -255,7 +255,7 @@ void SuctionGripperPlugin::PreUpdate(const UpdateInfo &_info,
       this->dataPtr->pendingJointCreation = true;
       this->dataPtr->childItem = this->dataPtr->contacts[1][0];
     }
-    else if (checkContacts({0, 1}, {2, 1}))  // top + bottom 
+    else if (checkContacts({0, 1}, {2, 1}))  // top + bottom
     {
       this->dataPtr->pendingJointCreation = true;
       this->dataPtr->childItem = this->dataPtr->contacts[0][1];

--- a/mbzirc_ign/src/mbzirc_ign/launch.py
+++ b/mbzirc_ign/src/mbzirc_ign/launch.py
@@ -26,6 +26,7 @@ from launch_ros.actions import PushRosNamespace
 import mbzirc_ign.bridges
 
 import os
+import shutil
 
 
 def simulation(world_name):


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

When spawning a UAV (or am on USV) with gripper, we run ERB to generate a new `model.sdf` file with a unique topic prefix name. The problem is that this file gets overwritten when there are multiple vehicles with grippers. The workaround here is to generate a whole new gripper model with the `model.df` in the mbzirc resource path. These generated gripper models will live in `<colcon_ws>/install/share/mbzirc_ign/models/tmp` directory. You'll need to source your setup file again to get this resource path.