### PR TITLE
Checking if gipper model name is a substring instead of direct compare

### DIFF
--- a/mbzirc_ign/models/mbzirc_hexrotor/model.sdf.erb
+++ b/mbzirc_ign/models/mbzirc_hexrotor/model.sdf.erb
@@ -11,10 +11,10 @@ end
 
 $attitude_gain = '4 4 2'
 $motor_constant = '1.269e-05'
-if $gripper_model == 'mbzirc_oberon7_gripper'
+if $gripper_model.include?('mbzirc_oberon7_gripper')
   $attitude_gain = '25 25 2'
   $motor_constant = '1.98e-05'
-elsif $gripper_model == 'mbzirc_suction_gripper'
+elsif $gripper_model.include?('mbzirc_suction_gripper')
   $attitude_gain = '25 25 2'
   $motor_constant = '1.40e-05'
 end

--- a/mbzirc_ign/models/mbzirc_quadrotor/model.sdf.erb
+++ b/mbzirc_ign/models/mbzirc_quadrotor/model.sdf.erb
@@ -11,10 +11,10 @@ end
 
 $attitude_gain = '2 3 0.15'
 $motor_constant = '8.54858e-06'
-if $gripper_model == 'mbzirc_oberon7_gripper'
+if $gripper_model.include?('mbzirc_oberon7_gripper')
   $attitude_gain = '10 10 0.15'
   $motor_constant = '3.95e-05'
-elsif $gripper_model == 'mbzirc_suction_gripper'
+elsif $gripper_model.include?('mbzirc_suction_gripper')
   $attitude_gain = '10 10 0.15'
   $motor_constant = '2.52e-05'
 end


### PR DESCRIPTION
Signed-off-by: Aaron Chong <aaronchongth@gmail.com>

Since the gripper models are now named with the models they attach to, we should check for `include?` in the template.