### PR TITLE
Add script to generate docker compose file for running simulation on local machine

### DIFF
--- a/docker/compose/README.md
+++ b/docker/compose/README.md
@@ -1,0 +1,36 @@
+# README
+
+`gen_docker_compose.py`: Script to generate docker compose file for launching
+simulation, bridge, and team containers locally.
+
+## Dependencies
+
+Requires python `jinja2`. Install by running the following command:
+
+
+```sh
+sudo apt install python3-jinja2
+```
+
+## Usage
+
+Example usage:
+
+```sh
+python3 gen_docker_compose.py --config `ros2 pkg prefix mbzirc_seed`/share/mbzirc_seed/config/team.yaml --image mbzirc_seed
+```
+
+The script has 2 required args:
+
+* `--config <path_to_team_config_file>`: Team configuration yaml file containing the robots and sensors to spawn into simulation
+* `--image <team_image>`: Name of team solution docker image
+
+Other optional args:
+
+* `--world <world_name>`: Name of the world to launch. Defaults to `coast`.
+* `--headless <headless>`: `1` or `0`. `1` (True) to launch simulation headless (no GUI). Defaults to `0`.
+* `--out <output_file_path>`: Path of output docker compose yaml file. Defaults to `mbzirc_compose.yaml`.
+
+
+
+

--- a/docker/compose/README.md
+++ b/docker/compose/README.md
@@ -30,7 +30,3 @@ Other optional args:
 * `--world <world_name>`: Name of the world to launch. Defaults to `coast`.
 * `--headless <headless>`: `1` or `0`. `1` (True) to launch simulation headless (no GUI). Defaults to `0`.
 * `--out <output_file_path>`: Path of output docker compose yaml file. Defaults to `mbzirc_compose.yaml`.
-
-
-
-

--- a/docker/compose/cyclonedds.xml
+++ b/docker/compose/cyclonedds.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+  <CycloneDDS xmlns="https://cdds.io/config" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://cdds.io/config https://raw.githubusercontent.com/eclipse-cyclonedds/cyclonedds/master/etc/cyclonedds.xsd">
+    <Domain id="any">
+        <General>
+            <NetworkInterfaceAddress>eth0</NetworkInterfaceAddress>
+        </General>
+    </Domain>
+</CycloneDDS>

--- a/docker/compose/gen_docker_compose.py
+++ b/docker/compose/gen_docker_compose.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+
+# Copyright 2022 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import sys
+import yaml
+
+from jinja2 import Template
+
+
+def parse_args():
+    parser = argparse.ArgumentParser('Team vehicle configuration.')
+    parser.add_argument('--config', dest='config_file', type=str,
+                        help='Set config file')
+    parser.add_argument('--out', dest='out_file', type=str,
+                        help='Set output file')
+    args = parser.parse_args()
+    return args
+
+
+def run_main():
+    args = parse_args()
+
+    if not args.config_file:
+      print("Usage: python3 gen_docker_compose.py --config <config_file>")
+      sys.exit(1)
+
+    config_dict = None
+    with open(args.config_file, "r") as stream:
+        try:
+            config_dict = yaml.safe_load(stream)
+        except yaml.YAMLError as ex:
+            print(ex)
+
+    template = """
+    services:
+      sim:
+        image: cloudsim_sim
+        command: world:=coast config_file:=/home/developer/config/{{ config_file }} sim_mode:=sim
+        networks:
+          sim_net:
+            ipv4_address: 172.28.1.1
+        environment:
+          - DISPLAY
+          - QT_X11_NO_MITSHM=1
+          - XAUTHORITY=/tmp/.docker.xauth
+          - IGN_PARTITION=sim
+          - IGN_IP=172.28.1.1
+        privileged: true
+        runtime: nvidia
+        security_opt:
+          - seccomp=unconfined
+        volumes:
+          - "/tmp/.docker.xauth:/tmp/.docker.xauth"
+          - "/tmp/.X11-unix:/tmp/.X11-unix"
+          - "/etc/localtime:/etc/localtime:ro"
+          - "/dev/input:/dev/input"
+          - "./:/home/developer/config/"
+      {% for robot in config_dict -%}
+      bridge{{ loop.index }}:
+        image: cloudsim_bridge
+        command: world:=coast config_file:=/home/developer/config/{{ config_file }} sim_mode:=bridge robot:={{ robot["model_name"] }}
+        networks:
+          relay_net{{ loop.index }}:
+            ipv4_address: 172.{{29 + loop.index - 1 }}.1.1
+          sim_net:
+            ipv4_address: 172.28.1.{{ loop.index + 1 }}
+        environment:
+          - IGN_PARTITION=sim
+          - IGN_IP=172.28.1.{{ loop.index + 1 }}
+          - ROS_DOMAIN_ID={{ loop.index - 1 }}
+        volumes:
+          - "./:/home/developer/config/"
+        depends_on:
+          - "sim"
+      solution{{ loop.index }}:
+        image: mbzirc_sim
+        stdin_open: true
+        tty: true
+        networks:
+          relay_net{{ loop.index }}:
+            ipv4_address: 172.{{ 29 + loop.index - 1 }}.1.2
+        runtime: nvidia
+        environment:
+          - ROS_DOMAIN_ID={{ loop.index - 1 }}
+        depends_on:
+          - "bridge{{ loop.index }}"
+      {% endfor %}
+    networks:
+      sim_net:
+        ipam:
+          driver: default
+          config:
+            - subnet: 172.28.0.0/16
+
+      {% for robot in config_dict -%}
+      relay_net{{ loop.index }}:
+        internal: true
+        ipam:
+          driver: default
+          config:
+            - subnet: 172.{{ 29 + loop.index - 1 }}.0.0/16
+      {% endfor %}
+    """
+
+    data = { "config_file": args.config_file, "config_dict": config_dict }
+    j2_template = Template(template)
+    out = j2_template.render(data)
+    out_name = 'mbzirc_compose.yaml'
+    if args.out_file:
+        out_name = args.out_file
+    f = open(out_name, 'w')
+    f.write(out)
+    f.close()
+    print(f'Docker compose file written to: {out_name}')
+
+if __name__ == '__main__':
+    run_main()
+

--- a/docker/compose/gen_docker_compose.py
+++ b/docker/compose/gen_docker_compose.py
@@ -31,6 +31,10 @@ def parse_args():
                         help='Set team solution image')
     parser.add_argument('--out', dest='out_file', type=str,
                         help='Set output docker compose yaml file')
+    parser.add_argument('--world', dest='world', type=str, default='coast',
+                        help='Name of world')
+    parser.add_argument('--headless', dest='headless', type=bool, default='False',
+                        help='True to run simulation headless (no GUI)')
     args = parser.parse_args()
     return args
 
@@ -62,7 +66,7 @@ def run_main():
     services:
       sim:
         image: cloudsim_sim
-        command: world:=coast config_file:=/home/developer/config/config.yaml sim_mode:=sim
+        command: world:={{ world }} config_file:=/home/developer/config/config.yaml sim_mode:=sim headless:={{ headless }}
         networks:
           sim_net:
             ipv4_address: 172.28.1.1
@@ -87,7 +91,7 @@ def run_main():
       {% for robot in config_dict -%}
       bridge{{ loop.index }}:
         image: cloudsim_bridge
-        command: world:=coast config_file:=/home/developer/config/config.yaml sim_mode:=bridge robot:={{ robot["model_name"] }}
+        command: world:={{ world }} config_file:=/home/developer/config/config.yaml sim_mode:=bridge robot:={{ robot["model_name"] }}
         networks:
           relay_net{{ loop.index }}:
             ipv4_address: 172.{{29 + loop.index - 1 }}.1.1
@@ -134,7 +138,10 @@ def run_main():
     """
 
     data = { "image": args.image,
-             "config_dict": config_dict }
+             "config_dict": config_dict,
+             "world": args.world,
+             "headless": args.headless,
+             "world": args.world}
     j2_template = Template(template)
     out = j2_template.render(data)
     out_name = 'mbzirc_compose.yaml'

--- a/docker/compose/gen_docker_compose.py
+++ b/docker/compose/gen_docker_compose.py
@@ -29,7 +29,7 @@ def parse_args():
                         help='Set config file')
     parser.add_argument('--image', dest='image', type=str,
                         help='Set team solution image')
-    parser.add_argument('--out', dest='out_file', type=str,
+    parser.add_argument('--out', dest='out_file', type=str, default='mbzirc_compose.yaml',
                         help='Set output docker compose yaml file')
     parser.add_argument('--world', dest='world', type=str, default='coast',
                         help='Name of world')
@@ -144,9 +144,7 @@ def run_main():
              "world": args.world}
     j2_template = Template(template)
     out = j2_template.render(data)
-    out_name = 'mbzirc_compose.yaml'
-    if args.out_file:
-        out_name = args.out_file
+    out_name = getattr(args, 'out_file')
     f = open(out_name, 'w')
     f.write(out)
     f.close()

--- a/docker/compose/gen_docker_compose.py
+++ b/docker/compose/gen_docker_compose.py
@@ -33,7 +33,7 @@ def parse_args():
                         help='Set output docker compose yaml file')
     parser.add_argument('--world', dest='world', type=str, default='coast',
                         help='Name of world')
-    parser.add_argument('--headless', dest='headless', type=bool, default='False',
+    parser.add_argument('--headless', dest='headless', type=int, default=0,
                         help='True to run simulation headless (no GUI)')
     args = parser.parse_args()
     return args
@@ -140,7 +140,7 @@ def run_main():
     data = { "image": args.image,
              "config_dict": config_dict,
              "world": args.world,
-             "headless": args.headless,
+             "headless": 'True' if args.headless else 'False',
              "world": args.world}
     j2_template = Template(template)
     out = j2_template.render(data)

--- a/docker/compose/gen_docker_compose.py
+++ b/docker/compose/gen_docker_compose.py
@@ -16,6 +16,7 @@
 
 import argparse
 import os
+import shutil
 import sys
 import yaml
 
@@ -46,7 +47,7 @@ def run_main():
     config_filename = 'config.yaml'
     if os.path.exists(config_filename):
         os.remove('config.yaml')
-    os.symlink(args.config_file, config_filename)
+    shutil.copyfile(args.config_file, config_filename)
 
     # parse the config yaml file to get vehicle names
     config_dict = None
@@ -57,6 +58,7 @@ def run_main():
             print(ex)
 
     template = """
+    version: '2.4'
     services:
       sim:
         image: cloudsim_sim
@@ -92,7 +94,7 @@ def run_main():
         environment:
           - IGN_PARTITION=sim
           - IGN_IP=172.28.1.{{ loop.index + 1 }}
-          - ROS_DOMAIN_ID={{ loop.index - 1 }}
+          # - ROS_DOMAIN_ID={{ loop.index - 1 }}
         volumes:
           - "./:/home/developer/config/"
         depends_on:
@@ -107,8 +109,8 @@ def run_main():
           relay_net{{ loop.index }}:
             ipv4_address: 172.{{ 29 + loop.index - 1 }}.1.2
         runtime: nvidia
-        environment:
-          - ROS_DOMAIN_ID={{ loop.index - 1 }}
+        # environment:
+        #   - ROS_DOMAIN_ID={{ loop.index - 1 }}
         depends_on:
           - "bridge{{ loop.index }}"
       {% endfor %}
@@ -120,7 +122,7 @@ def run_main():
             - subnet: 172.28.0.0/16
       {% for robot in config_dict -%}
       relay_net{{ loop.index }}:
-        # internal: true
+        internal: true
         ipam:
           driver: default
           config:

--- a/docker/compose/gen_docker_compose.py
+++ b/docker/compose/gen_docker_compose.py
@@ -72,6 +72,8 @@ def run_main():
           - XAUTHORITY=/tmp/.docker.xauth
           - IGN_PARTITION=sim
           - IGN_IP=172.28.1.1
+          - ROS_LOCALHOST_ONLY=1
+          - ROS_DOMAIN_ID=99
         privileged: true
         runtime: nvidia
         security_opt:
@@ -94,14 +96,15 @@ def run_main():
         environment:
           - IGN_PARTITION=sim
           - IGN_IP=172.28.1.{{ loop.index + 1 }}
-          # - ROS_DOMAIN_ID={{ loop.index - 1 }}
+          - ROS_DOMAIN_ID={{ loop.index }}
+          - CYCLONEDDS_URI=file:///home/developer/config/cyclonedds.xml
         volumes:
           - "./:/home/developer/config/"
         depends_on:
           - "sim"
       solution{{ loop.index }}:
         image: {{ image }}
-        command: robot_name:={{ robot["model_name"] }}
+        command: {{ robot["model_name"] }}
         # uncommment to enable interactive shell
         # stdin_open: true
         # tty: true
@@ -109,8 +112,8 @@ def run_main():
           relay_net{{ loop.index }}:
             ipv4_address: 172.{{ 29 + loop.index - 1 }}.1.2
         runtime: nvidia
-        # environment:
-        #   - ROS_DOMAIN_ID={{ loop.index - 1 }}
+        environment:
+          - ROS_DOMAIN_ID={{ loop.index }}
         depends_on:
           - "bridge{{ loop.index }}"
       {% endfor %}
@@ -122,7 +125,7 @@ def run_main():
             - subnet: 172.28.0.0/16
       {% for robot in config_dict -%}
       relay_net{{ loop.index }}:
-        internal: true
+        # internal: true
         ipam:
           driver: default
           config:

--- a/docker/compose/gen_docker_compose.py
+++ b/docker/compose/gen_docker_compose.py
@@ -99,8 +99,10 @@ def run_main():
           - "sim"
       solution{{ loop.index }}:
         image: {{ image }}
-        stdin_open: true
-        tty: true
+        command: robot_name:={{ robot["model_name"] }}
+        # uncommment to enable interactive shell
+        # stdin_open: true
+        # tty: true
         networks:
           relay_net{{ loop.index }}:
             ipv4_address: 172.{{ 29 + loop.index - 1 }}.1.2

--- a/docker/mbzirc_seed/Dockerfile
+++ b/docker/mbzirc_seed/Dockerfile
@@ -107,5 +107,5 @@ RUN /bin/sh -c 'echo ". /opt/ros/galactic/setup.bash" >> ~/.bashrc' \
  && /bin/sh -c 'echo ". ~/mbzirc_ws/install/setup.sh" >> ~/.bashrc'
 
 # Copy entry point script, and set the entrypoint
-COPY mbzirc_seed/run_solution.bash ./
+COPY docker/mbzirc_seed/run_solution.bash ./
 ENTRYPOINT ["./run_solution.bash"]

--- a/docker/mbzirc_seed/Dockerfile
+++ b/docker/mbzirc_seed/Dockerfile
@@ -1,0 +1,111 @@
+# Ubuntu 20.04 with nvidia-docker2 beta opengl support
+FROM osrf/mbzirc:mbzirc_models_latest
+
+USER root
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+# Tools useful during development
+RUN apt-get update -qq \
+ && apt-get install --no-install-recommends -y -qq \
+        build-essential \
+        atop \
+        cmake \
+        cppcheck \
+        expect \
+        gdb \
+        git \
+        gnutls-bin \
+        libbluetooth-dev \
+        libccd-dev \
+        libcwiid-dev \
+        libfcl-dev \
+        libgoogle-glog-dev \
+        libspnav-dev \
+        libusb-dev \
+        python3-dbg \
+        python3-empy \
+        python3-numpy \
+        python3-setuptools \
+        python3-pip \
+        python3-venv \
+        software-properties-common \
+        vim \
+        net-tools \
+        iputils-ping \
+        xvfb \
+        curl \
+ && apt-get clean -qq
+
+# set up ros2 repo
+RUN /bin/sh -c 'curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg' \
+  && /bin/sh -c 'echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/ros2.list > /dev/null'
+
+# install ignition fortress
+RUN apt-get update \
+  && apt-get install -y ignition-fortress \
+  && rm -rf /var/lib/apt/lists/* \
+  && apt-get clean -qq
+
+# install rosdep
+RUN apt-get update \
+  && apt install -y python3-rosdep \
+  && rm -rf /var/lib/apt/lists/* \
+  && apt-get clean -qq \
+  && rosdep init \
+  && rosdep update
+
+# install ROS2
+RUN apt-get update \
+  && apt-get install -y ros-galactic-ros-base \
+  && rm -rf /var/lib/apt/lists/* \
+  && apt-get clean -qq
+
+# install colcon
+RUN apt-get -qq update && apt-get -q -y install \
+  python3-vcstool \
+  python3-colcon-common-extensions \
+  && rm -rf /var/lib/apt/lists/* \
+  && apt-get -qq clean
+
+# Commands below run as the developer user
+USER $USERNAME
+
+# Make a couple folders for organizing docker volumes
+RUN mkdir ~/workspaces ~/other
+
+# When running a container start in the developer's home folder
+WORKDIR /home/$USERNAME
+
+# Prepare the colcon workspace
+RUN mkdir -p mbzirc_ws/src
+
+# clone ros_ign bridge
+RUN cd /home/$USERNAME/mbzirc_ws/src \
+ && git clone https://github.com/osrf/ros_ign.git -b galactic
+
+WORKDIR /home/$USERNAME/mbzirc_ws
+
+COPY . src/mbzirc
+
+ENV IGNITION_VERSION fortress
+
+RUN sudo apt-get update \
+  && rosdep update \
+  && rosdep install -r --from-paths src -i -y --rosdistro galactic \
+  && sudo rm -rf /var/lib/apt/lists/* \
+  && sudo apt-get clean -qq
+
+# Be sure that mbzirc_ros is present in the compilation by calling info
+RUN /bin/bash -c 'source /opt/ros/galactic/setup.bash \
+  && colcon info mbzirc_ros \
+  && colcon build --merge-install'
+# TODO(jrivero): implement build arg to clean build/ log/ while releasing
+# && rm -fr build/ log/
+
+RUN /bin/sh -c 'echo ". /opt/ros/galactic/setup.bash" >> ~/.bashrc' \
+ && /bin/sh -c 'echo ". ~/mbzirc_ws/install/setup.sh" >> ~/.bashrc'
+
+# Copy entry point script, and set the entrypoint
+COPY mbzirc_seed/run_solution.bash ./
+ENTRYPOINT ["./run_solution.bash"]

--- a/docker/mbzirc_seed/Dockerfile
+++ b/docker/mbzirc_seed/Dockerfile
@@ -96,12 +96,9 @@ RUN sudo apt-get update \
   && sudo rm -rf /var/lib/apt/lists/* \
   && sudo apt-get clean -qq
 
-# Be sure that mbzirc_ros is present in the compilation by calling info
+# build mbzirc_seed
 RUN /bin/bash -c 'source /opt/ros/galactic/setup.bash \
-  && colcon info mbzirc_ros \
-  && colcon build --merge-install'
-# TODO(jrivero): implement build arg to clean build/ log/ while releasing
-# && rm -fr build/ log/
+  && colcon build --merge-install ros_ign_interfaces mbzirc_seed'
 
 RUN /bin/sh -c 'echo ". /opt/ros/galactic/setup.bash" >> ~/.bashrc' \
  && /bin/sh -c 'echo ". ~/mbzirc_ws/install/setup.sh" >> ~/.bashrc'

--- a/docker/mbzirc_seed/Dockerfile
+++ b/docker/mbzirc_seed/Dockerfile
@@ -98,7 +98,7 @@ RUN sudo apt-get update \
 
 # build mbzirc_seed
 RUN /bin/bash -c 'source /opt/ros/galactic/setup.bash \
-  && colcon build --merge-install ros_ign_interfaces mbzirc_seed'
+  && colcon build --merge-install --packages-select ros_ign_interfaces mbzirc_seed'
 
 RUN /bin/sh -c 'echo ". /opt/ros/galactic/setup.bash" >> ~/.bashrc' \
  && /bin/sh -c 'echo ". ~/mbzirc_ws/install/setup.sh" >> ~/.bashrc'

--- a/docker/mbzirc_seed/run_solution.bash
+++ b/docker/mbzirc_seed/run_solution.bash
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+. /opt/ros/galactic/setup.bash
+. ~/mbzirc_ws/install/setup.sh
+
+mkdir -p /tmp/ign/logs
+
+export ROS_LOG_DIR=/tmp/ign/logs/ros
+unbuffer ros2 launch mbzirc_seed mbzirc_seed.launch.py "$@"  2>&1 | tee /home/developer/.ros/solution.log

--- a/docker/mbzirc_seed/run_solution.bash
+++ b/docker/mbzirc_seed/run_solution.bash
@@ -6,4 +6,4 @@
 mkdir -p /tmp/ign/logs
 
 export ROS_LOG_DIR=/tmp/ign/logs/ros
-unbuffer ros2 launch mbzirc_seed mbzirc_seed.launch.py "$@"  2>&1 | tee /home/developer/.ros/solution.log
+unbuffer ros2 launch mbzirc_seed mbzirc_seed.launch.py robot_name:="$@"  2>&1 | tee /home/developer/.ros/solution.log

--- a/mbzirc_ign/launch/competition.launch.py
+++ b/mbzirc_ign/launch/competition.launch.py
@@ -26,19 +26,20 @@ def launch(context, *args, **kwargs):
     config_file = LaunchConfiguration('config_file').perform(context)
     world_name = LaunchConfiguration('world').perform(context)
     sim_mode = LaunchConfiguration('sim_mode').perform(context)
-    bridge_competition_topics = LaunchConfiguration('bridge_competition_topics').perform(context)
+    bridge_competition_topics = LaunchConfiguration(
+        'bridge_competition_topics').perform(context).lower() == 'true'
     robot = LaunchConfiguration('robot').perform(context)
-    headless = LaunchConfiguration('headless').perform(context)
+    headless = LaunchConfiguration('headless').perform(context).lower() == 'true'
 
     launch_processes = []
 
     with open(config_file, 'r') as stream:
         models = Model.FromConfig(stream)
 
-    launch_processes.extend(mbzirc_ign.launch.simulation(world_name, headless == 'True'))
+    launch_processes.extend(mbzirc_ign.launch.simulation(world_name, headless))
     launch_processes.extend(mbzirc_ign.launch.spawn(sim_mode, world_name, models, robot))
 
-    if sim_mode == 'bridge' and bridge_competition_topics == 'True':
+    if sim_mode == 'bridge' and bridge_competition_topics:
         launch_processes.extend(mbzirc_ign.launch.competition_bridges())
 
     return launch_processes

--- a/mbzirc_ign/launch/competition.launch.py
+++ b/mbzirc_ign/launch/competition.launch.py
@@ -28,13 +28,14 @@ def launch(context, *args, **kwargs):
     sim_mode = LaunchConfiguration('sim_mode').perform(context)
     bridge_competition_topics = LaunchConfiguration('bridge_competition_topics').perform(context)
     robot = LaunchConfiguration('robot').perform(context)
+    headless = LaunchConfiguration('headless').perform(context)
 
     launch_processes = []
 
     with open(config_file, 'r') as stream:
         models = Model.FromConfig(stream)
 
-    launch_processes.extend(mbzirc_ign.launch.simulation(world_name))
+    launch_processes.extend(mbzirc_ign.launch.simulation(world_name, headless))
     launch_processes.extend(mbzirc_ign.launch.spawn(sim_mode, world_name, models, robot))
 
     if sim_mode == 'bridge' and bridge_competition_topics:
@@ -69,5 +70,9 @@ def generate_launch_description():
             default_value='',
             description='Name of robot to spawn if specified. '
                         'This must match one of the robots in the config_file'),
+        DeclareLaunchArgument(
+            'headless',
+            default_value='False',
+            description='True to run simulation headless (no GUI). '),
         OpaqueFunction(function=launch),
     ])

--- a/mbzirc_ign/launch/competition.launch.py
+++ b/mbzirc_ign/launch/competition.launch.py
@@ -35,10 +35,10 @@ def launch(context, *args, **kwargs):
     with open(config_file, 'r') as stream:
         models = Model.FromConfig(stream)
 
-    launch_processes.extend(mbzirc_ign.launch.simulation(world_name, headless))
+    launch_processes.extend(mbzirc_ign.launch.simulation(world_name, headless == 'True'))
     launch_processes.extend(mbzirc_ign.launch.spawn(sim_mode, world_name, models, robot))
 
-    if sim_mode == 'bridge' and bridge_competition_topics:
+    if sim_mode == 'bridge' and bridge_competition_topics == 'True':
         launch_processes.extend(mbzirc_ign.launch.competition_bridges())
 
     return launch_processes

--- a/mbzirc_ign/launch/spawn.launch.py
+++ b/mbzirc_ign/launch/spawn.launch.py
@@ -106,7 +106,7 @@ def launch(context, *args, **kwargs):
     launch_processes = []
 
     launch_processes.extend(mbzirc_ign.launch.spawn(sim_mode, world_name, model))
-    if sim_mode == 'bridge' and bridge_competition_topics:
+    if sim_mode == 'bridge' and bridge_competition_topics == 'True':
         launch_processes.extend(mbzirc_ign.launch.competition_bridges())
 
     return launch_processes

--- a/mbzirc_ign/launch/spawn.launch.py
+++ b/mbzirc_ign/launch/spawn.launch.py
@@ -99,14 +99,15 @@ def parse_from_cli(context, world_name):
 def launch(context, *args, **kwargs):
     world_name = LaunchConfiguration('world').perform(context)
     sim_mode = LaunchConfiguration('sim_mode').perform(context)
-    bridge_competition_topics = LaunchConfiguration('bridge_competition_topics').perform(context)
+    bridge_competition_topics = LaunchConfiguration(
+        'bridge_competition_topics').perform(context).lower() == 'true'
 
     model = parse_from_cli(context, world_name)
 
     launch_processes = []
 
     launch_processes.extend(mbzirc_ign.launch.spawn(sim_mode, world_name, model))
-    if sim_mode == 'bridge' and bridge_competition_topics == 'True':
+    if sim_mode == 'bridge' and bridge_competition_topics:
         launch_processes.extend(mbzirc_ign.launch.competition_bridges())
 
     return launch_processes

--- a/mbzirc_ign/launch/spawn_config.launch.py
+++ b/mbzirc_ign/launch/spawn_config.launch.py
@@ -36,7 +36,7 @@ def launch(context, *args, **kwargs):
 
     launch_processes.extend(mbzirc_ign.launch.spawn(sim_mode, world_name, models, robot))
 
-    if sim_mode == 'bridge' and bridge_competition_topics:
+    if sim_mode == 'bridge' and bridge_competition_topics == 'True':
         launch_processes.extend(mbzirc_ign.launch.competition_bridges())
 
     return launch_processes

--- a/mbzirc_ign/launch/spawn_config.launch.py
+++ b/mbzirc_ign/launch/spawn_config.launch.py
@@ -26,7 +26,8 @@ def launch(context, *args, **kwargs):
     config_file = LaunchConfiguration('config_file').perform(context)
     world_name = LaunchConfiguration('world').perform(context)
     sim_mode = LaunchConfiguration('sim_mode').perform(context)
-    bridge_competition_topics = LaunchConfiguration('bridge_competition_topics').perform(context)
+    bridge_competition_topics = LaunchConfiguration(
+        'bridge_competition_topics').perform(context).lower() == 'true'
     robot = LaunchConfiguration('robot').perform(context)
 
     launch_processes = []
@@ -36,7 +37,7 @@ def launch(context, *args, **kwargs):
 
     launch_processes.extend(mbzirc_ign.launch.spawn(sim_mode, world_name, models, robot))
 
-    if sim_mode == 'bridge' and bridge_competition_topics == 'True':
+    if sim_mode == 'bridge' and bridge_competition_topics:
         launch_processes.extend(mbzirc_ign.launch.competition_bridges())
 
     return launch_processes

--- a/mbzirc_ign/src/mbzirc_ign/launch.py
+++ b/mbzirc_ign/src/mbzirc_ign/launch.py
@@ -28,8 +28,10 @@ import mbzirc_ign.bridges
 import os
 
 
-def simulation(world_name):
+def simulation(world_name, headless=False):
     ign_args = ['-v 4', '-r']
+    if headless:
+        ign_args.append('-s')
     ign_args.append(f'{world_name}.sdf')
 
     ign_gazebo = IncludeLaunchDescription(


### PR DESCRIPTION
Add a `gen_docker_compose.py` python script to generate a docker compose yaml file for launching simulation, bridge, and team containers locally. 

The script has 2 required args:
* `--config <path_to_team_config_file>`: Team configuration yaml file containing the robots and sensors to spawn into simulation
* `--image <team_image>`: Name of team solution docker image

Other optional args:
* `--world <world_name>`: Name of the world to launch. Defaults to `coast`
* `--headless <headless>`: `1` or `0`. `1` (True) to launch simulation headless (no GUI). Defaults to `0`.
* `--out <output_file_path>`: Path of output docker compose yaml file. Defaults to `mbzirc_compose.yaml`.

To test launching the containers with docker compose, you'll need to build the docker images locally from this branch:

```sh
cd <path_to_mbzirc_ws>/src/mbzirc
bash docker/build.bash mbzirc_sim
bash docker/build.bash cloudsim_sim
bash docker/build.bash cloudsim_bridge
bash docker/build.bash mbzirc_seed
```

Example usage with the `mbzirc_seed` solution docker image from pull request #144

```sh
python3 gen_docker_compose.py --config `ros2 pkg prefix mbzirc_seed`/share/mbzirc_seed/config/team.yaml --image mbzirc_seed
```

This generates a `mbzirc_compose.yaml` file. To launch the whole setup, run:

```
docker compose -f mbzirc_compose.yaml up -d
```

Once launched, the gazebo window should pop up. After a while, simulation should start running and the 2 quadrotors and 1 USV will be moving. 

![mbzirc_seed_coast](https://user-images.githubusercontent.com/4000684/173739752-9bb42b50-f864-4584-9a87-0a8a50858493.png)


To bring down all the containers:

```
docker compose -f mbzirc_compose.yaml down 
```

