### PR TITLE
Support overriding RF range params and add a long range model

### DIFF
--- a/mbzirc_ign/models/sensors/mbzirc_rf_long_range/model.config
+++ b/mbzirc_ign/models/sensors/mbzirc_rf_long_range/model.config
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+
+<model>
+  <name>MBZIRC RF Long Range</name>
+  <version>1.0</version>
+  <sdf version="1.6">model.sdf</sdf>
+
+  <author>
+    <name>Carlos Agüero</name>
+    <email>caguero@openrobotics.org</email>
+  </author>
+
+  <description>
+    A long range RF range sensor.
+  </description>
+</model>

--- a/mbzirc_ign/models/sensors/mbzirc_rf_long_range/model.sdf
+++ b/mbzirc_ign/models/sensors/mbzirc_rf_long_range/model.sdf
@@ -1,0 +1,36 @@
+<?xml version="1.0"?>
+<sdf version="1.9">
+  <model name="mbzirc_rf_long_range">
+    <link name="sensor_link">
+      <inertial>
+        <mass>0.005</mass>
+        <inertia>
+          <ixx>8.33e-06</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>8.33e-06</iyy>
+          <iyz>0</iyz>
+          <izz>8.33e-06</izz>
+        </inertia>
+      </inertial>
+    </link>
+    <frame name="mount_point"/>
+    <plugin
+      filename="libRFRange.so"
+      name="ignition::gazebo::systems::RFRangeSensor">
+      <!-- this overrides default RF Range system settings in the world -->
+      <!-- todo(iche033) check if param values are reasonable -->
+      <range_config>
+        <max_range>500000.0</max_range>
+        <fading_exponent>2.6</fading_exponent>
+        <l0>40</l0>
+        <sigma>20.0</sigma>
+        <rssi_1>-15</rssi_1>
+      </range_config>
+      <radio_config>
+        <tx_power>30</tx_power>
+        <noise_floor>-90</noise_floor>
+      </radio_config>
+    </plugin>
+  </model>
+</sdf>

--- a/mbzirc_ign/src/RFRange.cc
+++ b/mbzirc_ign/src/RFRange.cc
@@ -116,6 +116,19 @@ struct RFPower
   }
 };
 
+using RFRangeConfig =
+  ignition::gazebo::components::Component<
+    RangeConfiguration,
+    class RFRangeConfigTag>;
+IGN_GAZEBO_REGISTER_COMPONENT("mbzirc_components.RFRangeConfig", RFRangeConfig)
+
+using RFRadioConfig =
+  ignition::gazebo::components::Component<
+    RadioConfiguration,
+    class RFRadioConfigTag>;
+IGN_GAZEBO_REGISTER_COMPONENT("mbzirc_components.RFRadioConfig", RFRadioConfig)
+
+
 //////////////////////////////////////////////////
 RFRangeSensor::RFRangeSensor()
 {
@@ -142,6 +155,48 @@ void RFRangeSensor::Configure(const Entity &_entity,
     pose += modelPose->Data();
     _ecm.CreateComponent(entity, gazebo::components::WorldPose(pose));
   }
+
+  if (_sdf->HasElement("range_config"))
+  {
+    sdf::ElementPtr elem = _sdf->Clone()->GetElement("range_config");
+
+    RangeConfiguration rangeConfig;
+    rangeConfig.maxRange =
+      elem->Get<double>("max_range", rangeConfig.maxRange).first;
+
+    rangeConfig.fadingExponent =
+      elem->Get<double>("fading_exponent",
+        rangeConfig.fadingExponent).first;
+
+    rangeConfig.l0 =
+      elem->Get<double>("l0", rangeConfig.l0).first;
+
+    rangeConfig.sigma =
+      elem->Get<double>("sigma", rangeConfig.sigma).first;
+
+    rangeConfig.rssi1 =
+      elem->Get<double>("rssi_1", rangeConfig.rssi1).first;
+    enableComponent<RFRangeConfig>(_ecm, entity, true);
+    auto rangeConfigComp = _ecm.Component<RFRangeConfig>(entity);
+    rangeConfigComp->Data() = rangeConfig;
+  }
+
+  if (_sdf->HasElement("radio_config"))
+  {
+    sdf::ElementPtr elem = _sdf->Clone()->GetElement("radio_config");
+
+    RadioConfiguration radioConfig;
+    radioConfig.txPower =
+      elem->Get<double>("tx_power", radioConfig.txPower).first;
+
+    radioConfig.noiseFloor =
+      elem->Get<double>("noise_floor",
+        radioConfig.noiseFloor).first;
+    enableComponent<RFRadioConfig>(_ecm, entity, true);
+    auto radioConfigComp = _ecm.Component<RFRadioConfig>(entity);
+    radioConfigComp->Data() = radioConfig;
+  }
+
 }
 
 /// \brief Private RFRange data class.
@@ -246,6 +301,9 @@ class gazebo::systems::RFRangePrivate
   /// \brief Random number generator.
   public: std::default_random_engine rndEngine{rd()};
 
+  /// \brief True if RF configurations has been overriden
+  public: bool rfConfigOverriden = false;
+
   /// \brief The size in bytes of the request sent between sensors.
   public: static constexpr uint64_t kPayloadSize = 100;
 };
@@ -318,6 +376,7 @@ RFPower RFRangePrivate::LogNormalReceivedPower(
   const double kPL = this->rangeConfig.l0 +
     10 * this->rangeConfig.fadingExponent * log10(kRange);
 
+   std::cerr << "range sigma " << rangeConfig.sigma << std::endl;
   return {_txPower - kPL, this->rangeConfig.sigma};
 }
 
@@ -446,6 +505,32 @@ void RFRange::PreUpdate(
 
         // We store the ID of the robot model.
         this->dataPtr->entityMap[modelId] = rfRangeData;
+
+        // let sensor override default RF config params
+        // The same config must be used for all sensors so the first sensor with
+        // RF config params set will be used.
+        if (!this->dataPtr->rfConfigOverriden)
+        {
+          auto rangeConfigComp = _ecm.Component<RFRangeConfig>(_entity);
+          if (rangeConfigComp)
+          {
+            this->dataPtr->rangeConfig = rangeConfigComp->Data();
+            this->dataPtr->rfConfigOverriden = true;
+          }
+          auto radioConfigComp = _ecm.Component<RFRadioConfig>(_entity);
+          if (radioConfigComp)
+          {
+            this->dataPtr->radioConfig = radioConfigComp->Data();
+            this->dataPtr->rfConfigOverriden = true;
+          }
+          if (this->dataPtr->rfConfigOverriden)
+          {
+            igndbg << "RFRange sensor range configuration override:" << std::endl
+                   << this->dataPtr->rangeConfig << std::endl;
+            igndbg << "RFRange sensor radio configuration override:" << std::endl
+                   << this->dataPtr->radioConfig << std::endl;
+          }
+        }
 
         return true;
       });


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

Depends on #151

Updated the RF range sensor to check to see if the plugin contains RF configuration params, and if so, it will create `RFRangeConfig` and RFRadioConfig` components that will override the default params set by the world RFRange system

Adds a long range RF range sensor - This model has its own RF config params which will override the defautl settings. The params still need to be tuned.

Note: the assumption here is that all robots must use the same RF range sensor. If two different RF range sensor models are specified, the long range version will always be used.