### PR TITLE
Move scanning radar to new model

### DIFF
--- a/mbzirc_custom/mbzirc_naive_3d_scanning_radar/models/sensors/mbzirc_naive_3d_scanning_radar/model.sdf
+++ b/mbzirc_custom/mbzirc_naive_3d_scanning_radar/models/sensors/mbzirc_naive_3d_scanning_radar/model.sdf
@@ -13,20 +13,6 @@
           <izz>8.33e-06</izz>
         </inertia>
       </inertial>
-    </link>
-
-    <link name="sensor_link">
-      <inertial>
-        <mass>0.005</mass>
-        <inertia>
-          <ixx>8.33e-06</ixx>
-          <ixy>0</ixy>
-          <ixz>0</ixz>
-          <iyy>8.33e-06</iyy>
-          <iyz>0</iyz>
-          <izz>8.33e-06</izz>
-        </inertia>
-      </inertial>
       <sensor name='gpu_lidar' type='gpu_lidar'>
         <pose relative_to='sensor_link'>0 0 0 0 0 0</pose>
         <update_rate>1</update_rate>
@@ -35,8 +21,8 @@
             <horizontal>
               <samples>250</samples>
               <resolution>1</resolution>
-              <min_angle>-1.570796</min_angle>
-              <max_angle>1.570796</max_angle>
+              <min_angle>-3.14159</min_angle>
+              <max_angle>3.14159</max_angle>
             </horizontal>
             <vertical>
               <samples>32</samples>
@@ -53,19 +39,14 @@
           <noise>
             <type>gaussian</type>
             <mean>0</mean>
-            <stddev>2</stddev>
+            <stddev>0.75</stddev>
           </noise>
+          <visibility_mask>55</visibility_mask>
         </lidar>
         <alwaysOn>1</alwaysOn>
         <visualize>true</visualize>
       </sensor>
     </link>
-
-    <joint name="sensor_joint" type="fixed">
-      <pose>0 0 0 0 0 0</pose>
-      <parent>base_link</parent>
-      <child>sensor_link</child>
-    </joint>
 
     <plugin
       filename="libNaive3dScanningRadar.so"

--- a/mbzirc_custom/mbzirc_naive_spinning_radar/CMakeLists.txt
+++ b/mbzirc_custom/mbzirc_naive_spinning_radar/CMakeLists.txt
@@ -1,0 +1,17 @@
+cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
+
+project(mbzirc_naive_spinning_radar)
+
+find_package(ament_cmake REQUIRED)
+
+# Hooks
+ament_environment_hooks("hooks/resource_paths.dsv.in")
+ament_environment_hooks("hooks/resource_paths.sh")
+
+# Uncomment the install call below to install the example naive spinning radar
+# model
+# install(DIRECTORY
+#   models
+#   DESTINATION share/${PROJECT_NAME})
+
+ament_package()

--- a/mbzirc_custom/mbzirc_naive_spinning_radar/hooks/resource_paths.dsv.in
+++ b/mbzirc_custom/mbzirc_naive_spinning_radar/hooks/resource_paths.dsv.in
@@ -1,0 +1,3 @@
+prepend-non-duplicate;IGN_GAZEBO_RESOURCE_PATH;@CMAKE_INSTALL_PREFIX@/share/@PROJECT_NAME@/models
+prepend-non-duplicate;IGN_GAZEBO_SYSTEM_PLUGIN_PATH;@CMAKE_INSTALL_PREFIX@/lib
+prepend-non-duplicate;LD_LIBRARY_PATH;@CMAKE_INSTALL_PREFIX@/lib

--- a/mbzirc_custom/mbzirc_naive_spinning_radar/hooks/resource_paths.sh
+++ b/mbzirc_custom/mbzirc_naive_spinning_radar/hooks/resource_paths.sh
@@ -1,0 +1,3 @@
+ament_prepend_unique_value IGN_GAZEBO_RESOURCE_PATH "$AMENT_CURRENT_PREFIX/share/@PROJECT_NAME@/models"
+ament_prepend_unique_value IGN_GAZEBO_SYSTEM_PLUGIN_PATH "$AMENT_CURRENT_PREFIX/lib"
+ament_prepend_unique_value LD_LIBRARY_PATH "$AMENT_CURRENT_PREFIX/lib"

--- a/mbzirc_custom/mbzirc_naive_spinning_radar/models/sensors/mbzirc_naive_spinning_radar/model.config
+++ b/mbzirc_custom/mbzirc_naive_spinning_radar/models/sensors/mbzirc_naive_spinning_radar/model.config
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+
+<model>
+  <name>MBZIRC Naive Spinning Radar</name>
+  <version>1.0</version>
+  <sdf version="1.9">model.sdf</sdf>
+
+  <author>
+    <name>Ian Chen</name>
+    <email>ichen@openrobotics.org</email>
+  </author>
+
+  <description>
+    A simple naive spinning radar sensor model
+  </description>
+</model>

--- a/mbzirc_custom/mbzirc_naive_spinning_radar/models/sensors/mbzirc_naive_spinning_radar/model.sdf
+++ b/mbzirc_custom/mbzirc_naive_spinning_radar/models/sensors/mbzirc_naive_spinning_radar/model.sdf
@@ -1,0 +1,79 @@
+<?xml version="1.0"?>
+<sdf version="1.9">
+  <model name="mbzirc_naive_spinning_radar">
+    <link name="base_link">
+      <inertial>
+        <mass>0.005</mass>
+        <inertia>
+          <ixx>8.33e-06</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>8.33e-06</iyy>
+          <iyz>0</iyz>
+          <izz>8.33e-06</izz>
+        </inertia>
+      </inertial>
+    </link>
+    <link name="sensor_link">
+      <inertial>
+        <mass>0.005</mass>
+        <inertia>
+          <ixx>8.33e-06</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>8.33e-06</iyy>
+          <iyz>0</iyz>
+          <izz>8.33e-06</izz>
+        </inertia>
+      </inertial>
+      <sensor name="lidar" type="gpu_ray">
+        <pose>0 0 0 1.57079 0 0</pose>
+        <update_rate>30</update_rate>
+        <lidar>
+          <scan>
+            <horizontal>
+              <samples>256</samples>
+              <resolution>1</resolution>
+              <min_angle>-0.17</min_angle>
+              <max_angle>0.17</max_angle>
+            </horizontal>
+          </scan>
+          <range>
+            <min>6</min>
+            <max>5000</max>
+            <resolution>1</resolution>
+          </range>
+          <noise>
+            <type>gaussian</type>
+            <mean>0</mean>
+            <stddev>2</stddev>
+          </noise>
+          <visibility_mask>55</visibility_mask>
+        </lidar>
+      </sensor>
+    </link>
+    <joint name="sensor_joint" type="revolute">
+      <pose>0 0 0 0 0 0</pose>
+      <parent>base_link</parent>
+      <child>sensor_link</child>
+      <axis>
+        <xyz>0 0 1</xyz>
+      </axis>
+    </joint>
+    <!-- Joint Controller - velocity control -->
+    <plugin
+        filename="ignition-gazebo-joint-controller-system"
+        name="ignition::gazebo::systems::JointController">
+      <joint_name>sensor_joint</joint_name>
+      <!-- velocity in rad/sec -->
+      <initial_velocity>6.283185</initial_velocity>
+    </plugin>
+    <!-- Joint state publisher -->
+    <plugin
+        filename="libignition-gazebo-joint-state-publisher-system.so"
+        name="ignition::gazebo::systems::JointStatePublisher">
+      <joint_name>sensor_joint</joint_name>
+    </plugin>
+    <frame name="mount_point"/>
+  </model>
+</sdf>

--- a/mbzirc_custom/mbzirc_naive_spinning_radar/package.xml
+++ b/mbzirc_custom/mbzirc_naive_spinning_radar/package.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>mbzirc_naive_spinning_radar</name>
+  <version>0.0.0</version>
+  <description>Custom MBZIRC Naive Spinning Radar Model</description>
+
+  <maintainer email="ichen@openrobotics.org">Ian Chen</maintainer>
+
+  <license>Apache License 2.0</license>
+
+  <author>Ian Chen</author>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>mbzirc_ros</depend>
+  <depend>mbzirc_ign</depend>
+  <depend>launch</depend>
+  <depend>launch_ros</depend>
+  <depend>ros_ign_gazebo</depend>
+  <depend>radar_msgs</depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/mbzirc_ign/worlds/coast.sdf
+++ b/mbzirc_ign/worlds/coast.sdf
@@ -930,9 +930,9 @@
     </include>
     <include>
       <name>large_dry_box_a</name>
-      <pose relative_to="Vessel A">0.08 -0.57 0.05 0 0 -0.3</pose>
+      <pose relative_to="Vessel A">-1.9 -0.0 0.05 0 0 -1.466</pose>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Large Dry Box
+        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Large Dry Box Handles
       </uri>
       <plugin filename="ignition-gazebo-detachable-joint-system" name="ignition::gazebo::systems::DetachableJoint">
        <parent_link>link</parent_link>
@@ -943,9 +943,9 @@
     </include>
     <include>
       <name>large_dry_box_a_duplicate</name>
-      <pose relative_to="Vessel A">0.7 0.23 0.05 0 0 0.2</pose>
+      <pose relative_to="Vessel A">0.9 -0.12 0.05 0 0 0.2</pose>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Large Dry Box
+        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Large Dry Box Handles
       </uri>
       <plugin filename="ignition-gazebo-detachable-joint-system" name="ignition::gazebo::systems::DetachableJoint">
        <parent_link>link</parent_link>
@@ -957,14 +957,14 @@
 
     <include>
       <name>small_case_b</name>
-      <pose relative_to="Vessel B">-0.35 1.6 0.80768 1.57079632679 0 0.2</pose>
+      <pose relative_to="Vessel B">-0.35 1.6 0.73768 1.57079632679 0 0.2</pose>
       <uri>
         https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Small Case
       </uri>
     </include>
     <include>
       <name>small_case_b_duplicate</name>
-      <pose relative_to="Vessel B">-2.28 -1.0 0.80768 1.57079632679 0 1</pose>
+      <pose relative_to="Vessel B">-2.28 -1.0 0.73768 1.57079632679 0 1</pose>
       <uri>
         https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Small Case
       </uri>
@@ -977,9 +977,9 @@
     </include>
     <include>
       <name>large_grey_box_b</name>
-      <pose relative_to="Vessel B">0.25 -0.9 0.792 0 0 -0.3</pose>
+      <pose relative_to="Vessel B">0.25 -0.9 0.722 0 0 -0.3</pose>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Large Grey Box
+        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Large Grey Box Handles
       </uri>
       <plugin filename="ignition-gazebo-detachable-joint-system" name="ignition::gazebo::systems::DetachableJoint">
        <parent_link>link</parent_link>
@@ -990,9 +990,9 @@
     </include>
     <include>
       <name>large_grey_box_b_duplicate</name>
-      <pose relative_to="Vessel B">3.07 0.1 1.07 0 0 1.2</pose>
+      <pose relative_to="Vessel B">3.07 0.1 1.0 0 0 1.2</pose>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Large Grey Box
+        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Large Grey Box Handles
       </uri>
       <plugin filename="ignition-gazebo-detachable-joint-system" name="ignition::gazebo::systems::DetachableJoint">
        <parent_link>link</parent_link>
@@ -1004,14 +1004,14 @@
 
     <include>
       <name>small_dry_bag_c</name>
-      <pose relative_to="Vessel C">-2.5 0.167 0.792 0 0 0.0</pose>
+      <pose relative_to="Vessel C">-2.5 0.167 0.722 0 0 0.0</pose>
       <uri>
         https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Small Dry Bag
       </uri>
     </include>
     <include>
       <name>small_dry_bag_c_duplicate</name>
-      <pose relative_to="Vessel C">2.75 -1.078 1.0687 0 0 -0.8</pose>
+      <pose relative_to="Vessel C">2.75 -1.078 0.9987 0 0 -0.8</pose>
       <uri>
         https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Small Dry Bag
       </uri>
@@ -1024,9 +1024,9 @@
     </include>
     <include>
       <name>large_ammo_can_c</name>
-      <pose relative_to="Vessel C">0.27 0.3 0.792 0 0 1.3</pose>
+      <pose relative_to="Vessel C">0.27 0.3 0.722 0 0 1.3</pose>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Large Ammo Can
+        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Large Ammo Can Handles
       </uri>
       <plugin filename="ignition-gazebo-detachable-joint-system" name="ignition::gazebo::systems::DetachableJoint">
        <parent_link>link</parent_link>
@@ -1037,9 +1037,9 @@
     </include>
     <include>
       <name>large_ammo_can_c_duplicate</name>
-      <pose relative_to="Vessel C">3.17 1.58 1.0838 0 0 -0.6</pose>
+      <pose relative_to="Vessel C">3.17 1.58 1.0138 0 0 -0.6</pose>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Large Ammo Can
+        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Large Ammo Can Handles
       </uri>
       <plugin filename="ignition-gazebo-detachable-joint-system" name="ignition::gazebo::systems::DetachableJoint">
        <parent_link>link</parent_link>
@@ -1051,14 +1051,14 @@
 
     <include>
       <name>small_blue_box_d</name>
-      <pose relative_to="Vessel D">-2.5 -1.9 0.7807 0 0 0.0</pose>
+      <pose relative_to="Vessel D">-2.5 -1.9 0.7107 0 0 0.0</pose>
       <uri>
         https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Small Blue Box
       </uri>
     </include>
     <include>
       <name>small_blue_box_d_duplicate</name>
-      <pose relative_to="Vessel D">2.75 -1.078 1.0603 0 0 -0.8</pose>
+      <pose relative_to="Vessel D">2.75 -1.078 0.9903 0 0 -0.8</pose>
       <uri>
         https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Small Blue Box
       </uri>
@@ -1071,9 +1071,9 @@
     </include>
     <include>
       <name>large_crate_d</name>
-      <pose relative_to="Vessel D">0.27 1.73 0.779 0 0 1.3</pose>
+      <pose relative_to="Vessel D">0.27 1.73 0.709 0 0 1.3</pose>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Large Crate
+        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Large Crate Handles
       </uri>
       <plugin filename="ignition-gazebo-detachable-joint-system" name="ignition::gazebo::systems::DetachableJoint">
        <parent_link>link</parent_link>
@@ -1084,9 +1084,9 @@
     </include>
     <include>
       <name>large_crate_d_duplicate</name>
-      <pose relative_to="Vessel D">3.17 1.58 1.103 0 0 -0.6</pose>
+      <pose relative_to="Vessel D">3.17 1.58 1.033 0 0 -0.6</pose>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Large Crate
+        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Large Crate Handles
       </uri>
       <plugin filename="ignition-gazebo-detachable-joint-system" name="ignition::gazebo::systems::DetachableJoint">
        <parent_link>link</parent_link>
@@ -1118,9 +1118,9 @@
     </include>
     <include>
       <name>large_dry_box_e</name>
-      <pose relative_to="Vessel E">-1.9 -1.61 0.4229 0 0 0.3</pose>
+      <pose relative_to="Vessel E">-1.9 -1.0 0.4229 0 0 0.3</pose>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Large Dry Box
+        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Large Dry Box Handles
       </uri>
       <plugin filename="ignition-gazebo-detachable-joint-system" name="ignition::gazebo::systems::DetachableJoint">
        <parent_link>link</parent_link>
@@ -1133,7 +1133,7 @@
       <name>large_dry_box_e_duplicate</name>
       <pose relative_to="Vessel E">-5.22 0.25 0.4229 0 0 0.6</pose>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Large Dry Box
+        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Large Dry Box Handles
       </uri>
       <plugin filename="ignition-gazebo-detachable-joint-system" name="ignition::gazebo::systems::DetachableJoint">
        <parent_link>link</parent_link>
@@ -1167,7 +1167,7 @@
       <name>large_ammo_can_f</name>
       <pose relative_to="Vessel F">3.78 1.22 1.246 0 0 0.3</pose>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Large Ammo Can
+        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Large Ammo Can Handles
       </uri>
       <plugin filename="ignition-gazebo-detachable-joint-system" name="ignition::gazebo::systems::DetachableJoint">
        <parent_link>link</parent_link>
@@ -1180,7 +1180,7 @@
       <name>large_ammo_can_f_duplicate</name>
       <pose relative_to="Vessel F">1.46 -1.25 1.186 0 0 0.6</pose>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Large Ammo Can
+        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Large Ammo Can Handles
       </uri>
       <plugin filename="ignition-gazebo-detachable-joint-system" name="ignition::gazebo::systems::DetachableJoint">
        <parent_link>link</parent_link>
@@ -1192,14 +1192,14 @@
 
     <include>
       <name>small_dry_bag_handle_g</name>
-      <pose relative_to="Vessel G">-8.07 -1.07 1.6593 0 0 -0.5</pose>
+      <pose relative_to="Vessel G">-5.81 0.723 1.4355 0 0 -0.5</pose>
       <uri>
         https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Small Dry Bag Handle
       </uri>
     </include>
     <include>
       <name>small_dry_bag_handle_g_duplicate</name>
-      <pose relative_to="Vessel G">-7.31 0.5 1.61 0 0 1.1</pose>
+      <pose relative_to="Vessel G">-4.37 -0.9 1.1686 0 0 1.1</pose>
       <uri>
         https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Small Dry Bag Handle
       </uri>
@@ -1212,9 +1212,9 @@
     </include>
     <include>
       <name>large_crate_g</name>
-      <pose relative_to="Vessel G">-4.75 0.81 1.4794 0 0 -1.3</pose>
+      <pose relative_to="Vessel G">-1.81 -0.37 1.07 0 0 0</pose>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Large Crate
+        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Large Crate Handles
       </uri>
       <plugin filename="ignition-gazebo-detachable-joint-system" name="ignition::gazebo::systems::DetachableJoint">
        <parent_link>link</parent_link>
@@ -1225,9 +1225,9 @@
     </include>
     <include>
       <name>large_crate_g_duplicate</name>
-      <pose relative_to="Vessel G">-3.48 -1.624 1.4305 0 0 0.0</pose>
+      <pose relative_to="Vessel G">-3.43 -0.72 1.1095 0 0 0.2</pose>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Large Crate
+        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Large Crate Handles
       </uri>
       <plugin filename="ignition-gazebo-detachable-joint-system" name="ignition::gazebo::systems::DetachableJoint">
        <parent_link>link</parent_link>

--- a/mbzirc_ign/worlds/simple_demo.sdf
+++ b/mbzirc_ign/worlds/simple_demo.sdf
@@ -286,9 +286,9 @@
 
     <include>
       <name>large_dry_box_a</name>
-      <pose relative_to="Vessel A">0.08 -0.57 0.05 0 0 -0.3</pose>
+      <pose relative_to="Vessel A">-1.9 -0.0 0.05 0 0 -1.466</pose>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Large Dry Box
+        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Large Dry Box Handles
       </uri>
       <plugin filename="ignition-gazebo-detachable-joint-system" name="ignition::gazebo::systems::DetachableJoint">
        <parent_link>link</parent_link>
@@ -300,9 +300,9 @@
 
     <include>
       <name>large_dry_box_a_duplicate</name>
-      <pose relative_to="Vessel A">0.7 0.23 0.05 0 0 0.2</pose>
+      <pose relative_to="Vessel A">0.9 -0.12 0.05 0 0 0.2</pose>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Large Dry Box
+        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Large Dry Box Handles
       </uri>
       <plugin filename="ignition-gazebo-detachable-joint-system" name="ignition::gazebo::systems::DetachableJoint">
        <parent_link>link</parent_link>


### PR DESCRIPTION
Restores the spinning radar as the [custom sensor tutorial](https://github.com/osrf/mbzirc/wiki/Custom-Sensors#adapting-existing-sensor) that depends on it

I also updated some of the 3d scanning radar model's params