### PR TITLE
Add competition auditing to the game logic system

### DIFF
--- a/mbzirc_ign/CMakeLists.txt
+++ b/mbzirc_ign/CMakeLists.txt
@@ -131,7 +131,7 @@ if(BUILD_TESTING)
       test/${TEST_TARGET}.cc
     )
     target_include_directories(${TEST_TARGET}
-      PRIVATE ${CMAKE_BINARY_DIR} ${CMAKE_BINARY_DIR}/proto)
+      PRIVATE ${CMAKE_BINARY_DIR} ${CMAKE_BINARY_DIR}/proto
     target_link_libraries(${TEST_TARGET} ignition-gazebo${IGN_GAZEBO_VER}::ignition-gazebo${IGN_GAZEBO_VER})
     set_tests_properties(${TEST_TARGET} PROPERTIES TIMEOUT 300)
   endforeach()

--- a/mbzirc_ign/CMakeLists.txt
+++ b/mbzirc_ign/CMakeLists.txt
@@ -131,7 +131,7 @@ if(BUILD_TESTING)
       test/${TEST_TARGET}.cc
     )
     target_include_directories(${TEST_TARGET}
-      PRIVATE ${CMAKE_BINARY_DIR} ${CMAKE_BINARY_DIR}/proto
+      PRIVATE ${CMAKE_BINARY_DIR} ${CMAKE_BINARY_DIR}/proto)
     target_link_libraries(${TEST_TARGET} ignition-gazebo${IGN_GAZEBO_VER}::ignition-gazebo${IGN_GAZEBO_VER})
     set_tests_properties(${TEST_TARGET} PROPERTIES TIMEOUT 300)
   endforeach()

--- a/mbzirc_ign/src/Components.hh
+++ b/mbzirc_ign/src/Components.hh
@@ -28,8 +28,8 @@ namespace components
 {
   using NoData = ignition::gazebo::components::NoData;
 
-  /// \brief A component that identifies an entity as being a spawned platform.
-  using Usv = ignition::gazebo::components::Component<NoData, class CompetitorPlatformTag>;
+  /// \brief A component that identifies an entity as being a Usv 
+  using Usv = ignition::gazebo::components::Component<NoData, class UsvTag>;
   IGN_GAZEBO_REGISTER_COMPONENT("mbzirc_components.Usv", Usv)
 
 }  // namespace components

--- a/mbzirc_ign/src/Components.hh
+++ b/mbzirc_ign/src/Components.hh
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef MBZIRC_IGN__COMPONENTS_HH_
+#define MBZIRC_IGN__COMPONENTS_HH_
+
+#include <ignition/gazebo/components/Component.hh>
+#include <ignition/gazebo/components/Factory.hh>
+#include <ignition/gazebo/components/Serialization.hh>
+
+namespace mbzirc
+{
+namespace components
+{
+  using NoData = ignition::gazebo::components::NoData;
+
+  /// \brief A component that identifies an entity as being a spawned platform.
+  using Usv = ignition::gazebo::components::Component<NoData, class CompetitorPlatformTag>;
+  IGN_GAZEBO_REGISTER_COMPONENT("mbzirc_components.Usv", Usv)
+
+}  // namespace components
+}  // namespace mbzirc
+
+#endif  // MBZIRC_IGN__COMPONENTS_HH_
+
+

--- a/mbzirc_ign/src/GameLogicPlugin.cc
+++ b/mbzirc_ign/src/GameLogicPlugin.cc
@@ -39,7 +39,7 @@
 #include <ignition/gazebo/components/Camera.hh>
 #include <ignition/gazebo/components/CanonicalLink.hh>
 #include <ignition/gazebo/components/DetachableJoint.hh>
-#include <ignition/gazebo/components/GpuLidar.hh> 
+#include <ignition/gazebo/components/GpuLidar.hh>
 #include <ignition/gazebo/components/Link.hh>
 #include <ignition/gazebo/components/Model.hh>
 #include <ignition/gazebo/components/Name.hh>
@@ -244,7 +244,7 @@ class mbzirc::GameLogicPluginPrivate
   /// \param[in] Immutable reference to Entity Component Manager
   public: void EnumerateCompetitorSensors(Entity _entity, const EntityComponentManager &_ecm);
 
-  /// \brief Evalutate all competitor platforms and sensors for compliance 
+  /// \brief Evalutate all competitor platforms and sensors for compliance
   public: bool AuditCompetitorConfiguration(const EntityComponentManager &_ecm);
 
   /// \brief Check if robots are inside geofence boundary. Time penalties are
@@ -1860,7 +1860,7 @@ void GameLogicPluginPrivate::DisableDroppedObjects(
   }
   this->objectsToDisable.clear();
 }
-  
+
 /////////////////////////////////////////////////
 void GameLogicPluginPrivate::EnumerateCompetitorPlatforms(
   const EntityComponentManager &_ecm)
@@ -1899,6 +1899,25 @@ void GameLogicPluginPrivate::EnumerateCompetitorPlatforms(
           this->robots[entity] = info;
           this->EnumerateCompetitorSensors(entity, _ecm);
           igndbg << "New Competitor Platform: " << info.robotName << " with " << info.sensors.size() << "sensors\n";
+
+
+          // Subscribe to battery state in order to log battery events.
+          std::string batteryTopic = std::string("/model/") +
+            info.robotName + "/battery/linear_battery/state";
+          this->node.Subscribe(batteryTopic,
+              &GameLogicPluginPrivate::OnBatteryMsg, this);
+        }
+        // store camera / rgbd camera sensor
+        // later used for target confirmation in image stream
+        auto camComp = _ecm.Component<gazebo::components::Camera>(_entity);
+        if (camComp)
+        {
+          this->cameraSensors.insert(_entity);
+        }
+        auto rgbdComp = _ecm.Component<gazebo::components::RgbdCamera>(_entity);
+        if (rgbdComp)
+        {
+          this->cameraSensors.insert(_entity);
         }
       }
       return true;

--- a/mbzirc_ign/src/MbzircTypes.hh
+++ b/mbzirc_ign/src/MbzircTypes.hh
@@ -1,0 +1,135 @@
+#ifndef MBZIRCTYPES_HH_
+#define MBZIRCTYPES_HH_
+
+#include <ignition/gazebo/Entity.hh>
+#include <ignition/math/Vector3.hh>
+
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+namespace mbzirc
+{
+constexpr const char* kTargetReported = "target_reported";
+constexpr const char* kTargetRetrieval = "target_retrieval";
+
+constexpr const char* kPhaseSetup = "setup";
+constexpr const char* kPhaseStarted = "started";
+constexpr const char* kPhaseVesselIdSuccess = "vessel_id_success";
+constexpr const char* kPhaseSmallObjectIdSuccess = "small_object_id_success";
+constexpr const char* kPhaseSmallObjectRetrieveSuccess = "small_object_retrieve_success";
+constexpr const char* kPhaseLargeObjectIdSuccess = "large_object_id_success";
+constexpr const char* kPhaseLargeObjectRetrieveSuccess = "large_object_retrieve_success";
+constexpr const char* kPhaseFinished = "finished";
+
+/// \brief Represents a sensor attached to a competitor platform
+struct SensorInfo
+{
+  /// \brief Entity that the sensor is attached to
+  ignition::gazebo::Entity sensorEntity;
+
+  /// \brief Name of the platform slot the sensor is attached to
+  std::string slotName;
+
+  /// \brief Sensor type in (camera, rgbd_camera, gpu_lidar)
+  std::string sensorType;
+};
+
+/// \brief Structure to hold information about competitor platforms
+struct PlatformInfo
+{
+  /// \brief Entity of tAhe platform
+  ignition::gazebo::Entity modelEntity;
+
+  /// \brief Name of the platform
+  std::string robotName;
+
+  /// \brief Spawn position of the platform
+  ignition::math::Vector3d initialPos;
+
+  /// \brief Is the platform inside the competition boundary
+  bool inCompetitionBoundary = {true};
+      
+  /// \brief Is the platform inside the starting area 
+  bool inStartingArea = {true};
+
+  /// \brief Is the platform disabled 
+  bool isDisabled = {false};
+
+  /// \brief Sensors attached to the platform
+  std::vector<SensorInfo> sensors;
+};
+
+/// \brief Target vessel, objects, and report status
+struct Target
+{
+  /// \brief Name of target vessel
+  std::string vessel;
+
+  /// \brief List of small target objects
+  std::unordered_set<std::string> smallObjects;
+
+  /// \brief List of large target objects
+  std::unordered_set<std::string> largeObjects;
+
+  /// \brief Indicates if vessel has been reported
+  bool vesselReported = false;
+
+  /// \brief Set of small objects that have been reported.
+  std::unordered_set<std::string> smallObjectsReported;
+
+  /// \brief Set of large objects that have been reported.
+  std::unordered_set<std::string> largeObjectsReported;
+
+  /// \brief Set of small objects that have been retrieved.
+  std::unordered_set<std::string> smallObjectsRetrieved;
+
+  /// \brief Set of large objects that have been retrieved.
+  std::unordered_set<std::string> largeObjectsRetrieved;
+};
+
+/// \brief Information of target in stream
+struct TargetInStream
+{
+  /// \brief Type of target: vessel, small, large
+  std::string type;
+
+  /// \brief Image x position
+  unsigned int x = 0;
+
+  /// \brief Image y position
+  unsigned int y = 0;
+};
+
+enum class PenaltyType
+{
+  /// \brief Failure to ID target vessel
+  TARGET_VESSEL_ID_1 = 0,
+  TARGET_VESSEL_ID_2 = 1,
+  TARGET_VESSEL_ID_3 = 2,
+
+  /// \brief Failure to ID small object
+  SMALL_OBJECT_ID_1 = 3,
+  SMALL_OBJECT_ID_2 = 4,
+  SMALL_OBJECT_ID_3 = 5,
+
+  /// \brief Failure to ID large object
+  LARGE_OBJECT_ID_1 = 6,
+  LARGE_OBJECT_ID_2 = 7,
+  LARGE_OBJECT_ID_3 = 8,
+
+  /// \brief Failure to retrieve / place small object
+  SMALL_OBJECT_RETRIEVE_1 = 9,
+  SMALL_OBJECT_RETRIEVE_2 = 10,
+
+  /// \brief Failure to retrieve / place large object
+  LARGE_OBJECT_RETRIEVE_1 = 11,
+  LARGE_OBJECT_RETRIEVE_2 = 12,
+
+  /// \brief Failure to remain in demonstration area boundary
+  BOUNDARY_1 = 13,
+  BOUNDARY_2 = 14,
+};
+
+}  // namespace mbzirc
+#endif  // MBZIRCTYPES_HH_

--- a/mbzirc_ign/src/SimpleHydrodynamics.cc
+++ b/mbzirc_ign/src/SimpleHydrodynamics.cc
@@ -25,6 +25,7 @@
 #include "ignition/gazebo/Link.hh"
 #include "ignition/gazebo/Model.hh"
 
+#include "Components.hh"
 #include "SimpleHydrodynamics.hh"
 
 using namespace ignition;
@@ -112,6 +113,8 @@ void SimpleHydrodynamics::Configure(const Entity &_entity,
     EventManager &/*_eventMgr*/)
 {
   this->dataPtr->model = Model(_entity);
+
+  _ecm.CreateComponent(_entity, mbzirc::components::Usv());
 
   // Parse required elements.
   if (!_sdf->HasElement("link_name"))

--- a/mbzirc_ign/worlds/coast.sdf
+++ b/mbzirc_ign/worlds/coast.sdf
@@ -1396,6 +1396,10 @@
         <center>0 0 10.96</center>
         <size>3162.28 3162.28 221.92</size>
       </geofence>
+      <start_area>
+        <center>-1487.5 0 5</center>
+        <size>75 50 10</size>
+      </start_area>
       <target>
         <vessel>Vessel B</vessel>
         <small_object>small_case_b</small_object>
@@ -1404,6 +1408,27 @@
         <large_object>large_grey_box_b_duplicate</large_object>
       </target>
     </plugin>
+
+    <!-- uncomment to see visualization of the start area -->
+    <!--
+    <model name="start_area">
+      <static>true</static>
+      <link name="link">
+        <pose>0 0 0 0 0 0</pose>
+        <visual name="visual">
+          <pose>-1487.5 0 5 0 0 0</pose>
+          <geometry>
+            <box>
+              <size>75 50 10</size>
+            </box>
+          </geometry>
+          <material>
+            <diffuse>0 1 0 0.5</diffuse>
+          </material>
+        </visual>
+      </link>
+    </model>
+    -->
 
     <!-- uncomment to see visualization of the competition area -->
     <!--

--- a/mbzirc_ign/worlds/faster_than_realtime.sdf
+++ b/mbzirc_ign/worlds/faster_than_realtime.sdf
@@ -335,6 +335,10 @@
         <center>0 0 48.46</center>
         <size>140 140 146.92</size>
       </geofence>
+      <start_area>
+        <center>0 0 0</center>
+        <size>30 30 10</size>
+      </start_area>
       <target>
         <vessel>Vessel A</vessel>
         <small_object>small_box_a</small_object>
@@ -343,6 +347,48 @@
         <large_object>large_box_a_duplicate</large_object>
       </target>
     </plugin>
+
+    <!-- uncomment to see visualization of the start area -->
+    <!--
+    <model name="start_area">
+      <static>true</static>
+      <link name="link">
+        <pose>0 0 0 0 0 0</pose>
+        <visual name="visual">
+          <pose>0 0 5 0 0 0</pose>
+          <geometry>
+            <box>
+              <size>10 10 10</size>
+            </box>
+          </geometry>
+          <material>
+            <diffuse>0 1 0 0.5</diffuse>
+          </material>
+        </visual>
+      </link>
+    </model>
+    -->
+
+    <!-- uncomment to see visualization of the competition area -->
+    <!--
+    <model name="competition_area">
+      <static>true</static>
+      <link name="link">
+        <pose>0 0 0 0 0 0</pose>
+        <visual name="visual">
+          <pose>0 0 48.46 0 0 0</pose>
+          <geometry>
+            <box>
+              <size>140 140 146.92</size>
+            </box>
+          </geometry>
+          <material>
+            <diffuse>0 1 0 0.5</diffuse>
+          </material>
+        </visual>
+      </link>
+    </model>
+    -->
 
     <model name="ocean_entity_detector">
       <static>true</static>

--- a/mbzirc_ign/worlds/simple_demo.sdf
+++ b/mbzirc_ign/worlds/simple_demo.sdf
@@ -418,6 +418,10 @@
         <center>0 0 48.46</center>
         <size>140 140 146.92</size>
       </geofence>
+      <start_area>
+        <center>0 0 0</center>
+        <size>30 30 10</size>
+      </start_area>
       <target>
         <vessel>Vessel A</vessel>
         <small_object>small_blue_box_a</small_object>
@@ -426,6 +430,27 @@
         <large_object>large_dry_box_a_duplicate</large_object>
       </target>
     </plugin>
+
+    <!-- uncomment to see visualization of the start area -->
+    <!--
+    <model name="start_area">
+      <static>true</static>
+      <link name="link">
+        <pose>0 0 0 0 0 0</pose>
+        <visual name="visual">
+          <pose>0 0 0 0 0 0</pose>
+          <geometry>
+            <box>
+              <size>30 30 10</size>
+            </box>
+          </geometry>
+          <material>
+            <diffuse>0 1 0 0.5</diffuse>
+          </material>
+        </visual>
+      </link>
+    </model>
+    -->
 
     <!-- uncomment to see visualization of the competition area -->
     <!--

--- a/mbzirc_ros/test/ros_api/test_ros_api.cc
+++ b/mbzirc_ros/test/ros_api/test_ros_api.cc
@@ -121,7 +121,7 @@ TEST(RosApiTest, SimTopics)
   // phase
   MyTestClass<std_msgs::msg::String> phase("/mbzirc/phase");
   waitUntilBoolVarAndSpin(
-    node, phase.callbackExecuted, 10ms, 500);
+    node, phase.callbackExecuted, 10ms, 3500);
   EXPECT_TRUE(phase.callbackExecuted);
 
   // run_clock


### PR DESCRIPTION
Adds checking for competition configuration issues.

* There can be no more than 30 rendering sensors
* There can be no more than 1 USV
* All vehicles must be spawned within the start area.

The configuration is checked at the time the competition is started.

To test, start a world:
```
ros2 launch mbzirc_ros competition_local.launch.py ign_args:="-v 4 -r simple_demo.sdf"
```

Spawn a USV outside of the start area
```
ros2 launch mbzirc_ign spawn.launch.py name:=usv world:=simple_demo model:=mbzirc_usv type:=usv x:=-40 y:=2 z:=1.05 R:=0 P:=0 Y:=0 slot0:=mbzirc_hd_camera
```

Or spawn 2 usvs

And then change the competition phase:
```
ign service -s /mbzirc/skip_to_phase --reqtype ignition.msgs.StringMsg --reptype ignition.msgs.Boolean --timeout 300 --req 'data: "started"'
```

And an error will be displayed:

```
[ign gazebo-1] [Err] [GameLogicPlugin.cc:2123] Invalid configuration detected: 
[ign gazebo-1] Total usvs (2) exceeds maximum allowed (1)
```

In competition, this can be upgraded to a termination condition.

Signed-off-by: Michael Carroll <michael@openrobotics.org>