### PR TITLE
Tweak vertical angle to match mbzirc_naive_radar

### DIFF
--- a/mbzirc_custom/mbzirc_naive_3d_scanning_radar/models/sensors/mbzirc_naive_3d_scanning_radar/model.sdf
+++ b/mbzirc_custom/mbzirc_naive_3d_scanning_radar/models/sensors/mbzirc_naive_3d_scanning_radar/model.sdf
@@ -24,10 +24,10 @@
               <max_angle>3.14159</max_angle>
             </horizontal>
             <vertical>
-              <samples>32</samples>
+              <samples>14</samples>
               <resolution>1</resolution>
-              <min_angle>-0.698132</min_angle>
-              <max_angle>0.0872665</max_angle>
+              <min_angle>-0.1745</min_angle>
+              <max_angle>0.1745</max_angle>
             </vertical>
           </scan>
           <range>


### PR DESCRIPTION
Changed the vertical angle range to match mbzirc_naive_radar, lowered the number of vertical samples to match the assumed resolution of 1.44 degrees.

Signed-off-by: Aaron Chong <aaronchongth@gmail.com>