### PR TITLE
Launch bridges when sim_mode is 'full'

### DIFF
--- a/mbzirc_ign/launch/competition.launch.py
+++ b/mbzirc_ign/launch/competition.launch.py
@@ -39,7 +39,7 @@ def launch(context, *args, **kwargs):
     launch_processes.extend(mbzirc_ign.launch.simulation(world_name, headless))
     launch_processes.extend(mbzirc_ign.launch.spawn(sim_mode, world_name, models, robot))
 
-    if sim_mode == 'bridge' and bridge_competition_topics:
+    if (sim_mode == 'bridge' or sim_mode == 'full') and bridge_competition_topics:
         launch_processes.extend(mbzirc_ign.launch.competition_bridges())
 
     return launch_processes

--- a/mbzirc_ign/launch/spawn.launch.py
+++ b/mbzirc_ign/launch/spawn.launch.py
@@ -107,7 +107,7 @@ def launch(context, *args, **kwargs):
     launch_processes = []
 
     launch_processes.extend(mbzirc_ign.launch.spawn(sim_mode, world_name, model))
-    if sim_mode == 'bridge' and bridge_competition_topics:
+    if (sim_mode == 'bridge' or sim_mode == 'full') and bridge_competition_topics:
         launch_processes.extend(mbzirc_ign.launch.competition_bridges())
 
     return launch_processes

--- a/mbzirc_ign/launch/spawn_config.launch.py
+++ b/mbzirc_ign/launch/spawn_config.launch.py
@@ -37,7 +37,7 @@ def launch(context, *args, **kwargs):
 
     launch_processes.extend(mbzirc_ign.launch.spawn(sim_mode, world_name, models, robot))
 
-    if sim_mode == 'bridge' and bridge_competition_topics:
+    if (sim_mode == 'bridge' or sim_mode == 'full') and bridge_competition_topics:
         launch_processes.extend(mbzirc_ign.launch.competition_bridges())
 
     return launch_processes


### PR DESCRIPTION
There seems to be a bug when launching the simulation via `competition.launch.py` at least. The problem is that some of the bridges are not started.

I think that this is because the bridges are only started when `sim_mode` is equal to `bridge`. However that default `sim_mode` is `full`, which should also start the bridges.

How to test it?

Launch the simulation:
```
ros2 launch mbzirc_ign competition.launch.py world:=coast config_file:=`ros2 pkg prefix mbzirc_ign`/share/mbzirc_ign/config/coast/config_team.yaml
```

Check the ROS 2 topics:
```
ros2 topic list
```

You should see:
```
/clock
/mbzirc/phase
/mbzirc/run_clock
/mbzirc/score
/mbzirc/target/stream/status
```