### PR TITLE
compute range values from cluster of points

### DIFF
--- a/mbzirc_custom/mbzirc_naive_3d_scanning_radar/models/sensors/mbzirc_naive_3d_scanning_radar/model.sdf
+++ b/mbzirc_custom/mbzirc_naive_3d_scanning_radar/models/sensors/mbzirc_naive_3d_scanning_radar/model.sdf
@@ -18,21 +18,21 @@
         <lidar>
           <scan>
             <horizontal>
-              <samples>250</samples>
+              <samples>1500</samples>
               <resolution>1</resolution>
               <min_angle>-3.14159</min_angle>
               <max_angle>3.14159</max_angle>
             </horizontal>
             <vertical>
-              <samples>14</samples>
+              <samples>5</samples>
               <resolution>1</resolution>
-              <min_angle>-0.1745</min_angle>
-              <max_angle>0.1745</max_angle>
+              <min_angle>-0.017</min_angle>
+              <max_angle>0.017</max_angle>
             </vertical>
           </scan>
           <range>
             <min>2</min>
-            <max>3000</max>
+            <max>3500</max>
             <resolution>1.5</resolution>
           </range>
           <noise>

--- a/mbzirc_custom/mbzirc_naive_3d_scanning_radar/src/Naive3dScanningRadar.cc
+++ b/mbzirc_custom/mbzirc_naive_3d_scanning_radar/src/Naive3dScanningRadar.cc
@@ -103,6 +103,14 @@ void Naive3dScanningRadar::OnRadarScan(const ignition::msgs::LaserScan &_msg)
   frame->set_key("frame_id");
   frame->add_value(this->frameId);
 
+  // \todo(anyone) make this configurable
+  int subsampleSize = 6;
+
+  // We use a lidar with  higher number of samples. We then downsample
+  // by computing an average of range values within a cluster of points
+  // (subsampleSize). This is done to simulate a radar "beam" that has a
+  // a beam width so that we are not just sampling using a ray.
+
   // Start with -1 x vertical angle step so we just need additions onwards
   double curr_elevation =
     _msg.vertical_angle_min() - _msg.vertical_angle_step();
@@ -113,16 +121,46 @@ void Naive3dScanningRadar::OnRadarScan(const ignition::msgs::LaserScan &_msg)
 
     // Start with -1 x angle step so we just need additions onwards
     double curr_azimuth = _msg.angle_min() - _msg.angle_step();
-    for (uint32_t j = 0; j < _msg.count(); ++j)
+    for (uint32_t j = 0; j < _msg.count(); j += subsampleSize)
     {
-      curr_azimuth += _msg.angle_step();
-      double curr_range = _msg.ranges(ranges_before_channel + j);
+      double azimuth = 0.0;
+      double range = IGN_DBL_INF;
+      unsigned int rangeSampleCount = 0u;
 
-      if (curr_range < _msg.range_min() || curr_range > _msg.range_max())
+      // loop through cluster of points and get avg azimuth and range
+      for (unsigned int k = 0; k < subsampleSize; ++k)
+      {
+        curr_azimuth += _msg.angle_step();
+        azimuth += curr_azimuth;
+        double r = _msg.ranges(ranges_before_channel + j + k);
+        // filter out inf range values so we compute avg range only from
+        // valid range values
+        if (r < _msg.range_min() || r > _msg.range_max())
+          continue;
+        if (rangeSampleCount == 0u)
+        {
+          range = r;
+        }
+        else
+        {
+          range += r;
+          rangeSampleCount++;
+        }
+      }
+
+      // compute avg range
+      if (rangeSampleCount > 0)
+        range = range / rangeSampleCount;
+
+      // don't publish inf range data
+      if (range < _msg.range_min() || range > _msg.range_max())
         continue;
 
-      radarScanMsg.add_data(curr_range);
-      radarScanMsg.add_data(curr_azimuth);
+      // compute current avg azimuth
+      azimuth = azimuth / subsampleSize;
+
+      radarScanMsg.add_data(range);
+      radarScanMsg.add_data(azimuth);
       radarScanMsg.add_data(curr_elevation);
     }
   }

--- a/mbzirc_custom/mbzirc_naive_3d_scanning_radar/src/Naive3dScanningRadar.cc
+++ b/mbzirc_custom/mbzirc_naive_3d_scanning_radar/src/Naive3dScanningRadar.cc
@@ -124,7 +124,7 @@ void Naive3dScanningRadar::OnRadarScan(const ignition::msgs::LaserScan &_msg)
     for (uint32_t j = 0; j < _msg.count(); j += subsampleSize)
     {
       double azimuth = 0.0;
-      double range = IGN_DBL_INF;
+      double range = ignition::math::INF_D;
       unsigned int rangeSampleCount = 0u;
 
       // loop through cluster of points and get avg azimuth and range


### PR DESCRIPTION
After doing more testing with the radar implementation, we noticed that with the current angular resolution, it's very difficult to detect vessels, especially if they are far away. In the real world, the radar beam is more of a cone shape as opposed to a thin ray. Distant objects will still be detected but just with higher error. 

This PR changes the way we are sampling range output from the lidar. Instead of changing the implementation to use a cone, we use a lidar with a higher sample count but then downsample from the output values, i.e. For every cluster of points, we take it's average range values. 

With this change, the radar is able to detect a few vessels at a time. Over time, it should be able to detect all vessels. It may be faster if the user rotates the vessel to get a better sweep of the environment. After discussion, we also chose to lower the vertical field of view with lower sample count since most radars do not output elevation data (or produce bad elevation data).


Here is a visualization of the raw lidar hit points with the increased sample count:

![radar_scan_visualization](https://user-images.githubusercontent.com/4000684/176590064-ddd7bfda-1e84-4c89-a207-5e1d3396dbb8.gif)

Signed-off-by: Ian Chen <ichen@osrfoundation.org
