### PR TITLE
Enable log recording

### DIFF
--- a/mbzirc_ign/worlds/coast.sdf
+++ b/mbzirc_ign/worlds/coast.sdf
@@ -345,6 +345,11 @@
         <noise_floor>-90</noise_floor>
       </radio_config>
     </plugin>
+    <plugin
+      filename="ignition-gazebo-log-system"
+      name="ignition::gazebo::systems::LogRecord">
+      <record_path>/tmp/ign/mbzirc/playback</record_path>
+    </plugin>
 
     <scene>
       <sky></sky>

--- a/mbzirc_ign/worlds/playback.sdf
+++ b/mbzirc_ign/worlds/playback.sdf
@@ -1,0 +1,153 @@
+<?xml version="1.0" ?>
+
+<sdf version="1.9">
+  <world name="default">
+
+    <gui fullscreen="0">
+      <!-- GUI plugins -->
+      <plugin filename="MinimalScene" name="3D View">
+        <ignition-gui>
+          <title>3D View</title>
+          <property type="bool" key="showTitleBar">false</property>
+          <property type="string" key="state">docked</property>
+        </ignition-gui>
+        <engine>ogre2</engine>
+        <scene>scene</scene>
+        <ambient_light>0.4 0.4 0.4</ambient_light>
+        <background_color>0.8 0.8 0.8</background_color>
+        <camera_pose>-6 0 6 0 0.5 0</camera_pose>
+        <camera_clip>
+          <near>0.25</near>
+          <far>10000</far>
+        </camera_clip>
+      </plugin>
+
+      <plugin filename="EntityContextMenuPlugin" name="Entity context menu">
+        <ignition-gui>
+          <property key="state" type="string">floating</property>
+          <property key="width" type="double">5</property>
+          <property key="height" type="double">5</property>
+          <property key="showTitleBar" type="bool">false</property>
+        </ignition-gui>
+      </plugin>
+
+      <plugin filename="GzSceneManager" name="Scene Manager">
+        <ignition-gui>
+          <property key="resizable" type="bool">false</property>
+          <property key="width" type="double">5</property>
+          <property key="height" type="double">5</property>
+          <property key="state" type="string">floating</property>
+          <property key="showTitleBar" type="bool">false</property>
+        </ignition-gui>
+      </plugin>
+
+      <plugin filename="InteractiveViewControl" name="Interactive view control">
+        <ignition-gui>
+          <property key="resizable" type="bool">false</property>
+          <property key="width" type="double">5</property>
+          <property key="height" type="double">5</property>
+          <property key="state" type="string">floating</property>
+          <property key="showTitleBar" type="bool">false</property>
+        </ignition-gui>
+      </plugin>
+
+      <plugin filename="CameraTracking" name="Camera Tracking">
+        <ignition-gui>
+          <property key="resizable" type="bool">false</property>
+          <property key="width" type="double">5</property>
+          <property key="height" type="double">5</property>
+          <property key="state" type="string">floating</property>
+          <property key="showTitleBar" type="bool">false</property>
+        </ignition-gui>
+      </plugin>
+
+      <plugin filename="SelectEntities" name="Select Entities">
+        <ignition-gui>
+          <property key="resizable" type="bool">false</property>
+          <property key="width" type="double">5</property>
+          <property key="height" type="double">5</property>
+          <property key="state" type="string">floating</property>
+          <property key="showTitleBar" type="bool">false</property>
+        </ignition-gui>
+      </plugin>
+
+      <plugin filename="VisualizationCapabilities" name="Visualization Capabilities">
+        <ignition-gui>
+          <property key="resizable" type="bool">false</property>
+          <property key="width" type="double">5</property>
+          <property key="height" type="double">5</property>
+          <property key="state" type="string">floating</property>
+          <property key="showTitleBar" type="bool">false</property>
+        </ignition-gui>
+      </plugin>
+
+      <!-- Play / pause / step -->
+      <plugin filename="WorldControl" name="World control">
+        <ignition-gui>
+          <title>World control</title>
+          <property type="bool" key="showTitleBar">false</property>
+          <property type="bool" key="resizable">false</property>
+          <property type="double" key="height">72</property>
+          <property type="double" key="width">121</property>
+          <property type="double" key="z">1</property>
+          <property type="string" key="state">floating</property>
+          <anchors target="3D View">
+            <line own="left" target="left"/>
+            <line own="bottom" target="bottom"/>
+          </anchors>
+        </ignition-gui>
+        <play_pause>true</play_pause>
+        <step>true</step>
+        <start_paused>true</start_paused>
+        <use_event>true</use_event>
+      </plugin>
+
+      <!-- Playback Scrubber -->
+      <plugin filename="PlaybackScrubber" name="PlaybackScrubber">
+        <ignition-gui>
+          <property type="bool" key="showTitleBar">false</property>
+          <property type="double" key="height">90</property>
+          <property type="double" key="width">350</property>
+          <property type="double" key="z">1</property>
+          <property key="cardBackground" type="string">#66666666</property>
+          <property type="string" key="state">floating</property>
+          <anchors target="3D View">
+            <line own="horizontalCenter" target="horizontalCenter"/>
+            <line own="bottom" target="bottom"/>
+          </anchors>
+        </ignition-gui>
+      </plugin>
+
+      <!-- Inspector -->
+      <plugin filename="ComponentInspector" name="Component inspector">
+        <ignition-gui>
+          <property type="bool" key="showTitleBar">false</property>
+          <property type="string" key="state">docked</property>
+        </ignition-gui>
+      </plugin>
+
+      <!-- Entity tree -->
+      <plugin filename="EntityTree" name="Entity tree">
+        <ignition-gui>
+          <property type="bool" key="showTitleBar">false</property>
+          <property type="string" key="state">docked</property>
+        </ignition-gui>
+      </plugin>
+    </gui>
+
+    <plugin
+      filename="ignition-gazebo-user-commands-system"
+      name="ignition::gazebo::systems::UserCommands">
+    </plugin>
+    <plugin
+      filename="ignition-gazebo-scene-broadcaster-system"
+      name="ignition::gazebo::systems::SceneBroadcaster">
+    </plugin>
+    <plugin
+      filename="ignition-gazebo-log-system"
+      name="ignition::gazebo::systems::LogPlayback">
+      <playback_path>/tmp/ign/mbzirc/playback</playback_path>
+    </plugin>
+
+  </world>
+</sdf>

--- a/mbzirc_ign/worlds/simple_demo.sdf
+++ b/mbzirc_ign/worlds/simple_demo.sdf
@@ -86,6 +86,11 @@
         <noise_floor>-90</noise_floor>
       </radio_config>
     </plugin>
+    <plugin
+      filename="ignition-gazebo-log-system"
+      name="ignition::gazebo::systems::LogRecord">
+      <record_path>/tmp/ign/mbzirc/playback</record_path>
+    </plugin>
 
     <scene>
       <sky></sky>


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>


Adds log recording to `simple_demo.sdf` and `coast.sdf` world.

To test:

1. Launch coast world with a few robots and let it run for some time
    ```
    ros2 launch mbzirc_ign competition.launch.py world:=coast config_file:=`ros2 pkg prefix mbzirc_ign`/share/mbzirc_ign/config/coast/config_team.yaml
    ```

1. Close the simulator. Verify that the log is created: `/tmp/ign/mbzirc/playback/state.tlog`

1. Launch simulator again in playback mode

    ```sh
    ign gazebo -v 4 `ros2 pkg prefix mbzirc_ign`/share/mbzirc_ign/worlds/playback.sdf
    ```

![mbzirc_playback](https://user-images.githubusercontent.com/4000684/178616866-861a4efd-f0e4-4860-a53a-35a2b1783f85.png)

