### PR TITLE
Revert thruster joint limits

### DIFF
--- a/mbzirc_ign/models/mbzirc_usv_base/model.sdf
+++ b/mbzirc_ign/models/mbzirc_usv_base/model.sdf
@@ -546,8 +546,8 @@
     <axis>
       <xyz>0 0 1</xyz>
       <limit>
-        <lower>0</lower>
-        <upper>3.14159</upper>
+        <lower>-1.57079</lower>
+        <upper>1.57079</upper>
         <effort>10</effort>
         <velocity>0.2618</velocity>
       </limit>
@@ -576,8 +576,8 @@
     <axis>
       <xyz>0 0 1</xyz>
       <limit>
-        <lower>0</lower>
-        <upper>3.14159</upper>
+        <lower>-1.57079</lower>
+        <upper>1.57079</upper>
         <effort>10</effort>
         <velocity>0.2618</velocity>
       </limit>


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

https://github.com/osrf/mbzirc/pull/119 updated the thruster rotation limits to match the image on the [website](https://www.mbzirc.com/grand-challenge#loop-10) (near the bottom). However, it was just confirmed that the image on the website is incorrect. So this PR reverts limits back to -90 to +90.


To test:

```
# launch simple demo world with USV
ros2 launch mbzirc_ros competition_local.launch.py ign_args:="-v 4 -r simple_demo.sdf"
ros2 launch mbzirc_ign spawn.launch.py name:=usv world:=simple_demo model:=usv type:=usv x:=15 y:=0 z:=0.3 R:=0 P:=0 Y:=0

# Rotate thrusters to left and right
ros2 topic pub --once /usv/left/thrust/joint/cmd_pos std_msgs/msg/Float64 'data: -1'
ros2 topic pub --once /usv/left/thrust/joint/cmd_pos std_msgs/msg/Float64 'data: 1'
```