### PR TITLE
Add HD long range camera

### DIFF
--- a/mbzirc_ign/models/sensors/mbzirc_hd_long_range_camera/model.config
+++ b/mbzirc_ign/models/sensors/mbzirc_hd_long_range_camera/model.config
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+
+<model>
+  <name>MBZIRC HD Camera</name>
+  <version>1.0</version>
+  <sdf version="1.6">model.sdf</sdf>
+
+  <author>
+    <name>Michael Carroll</name>
+    <email>michael@openrobotics.org</email>
+  </author>
+
+  <description>
+    RGB Camera with 1280x960 resolution
+  </description>
+</model>

--- a/mbzirc_ign/models/sensors/mbzirc_hd_long_range_camera/model.sdf
+++ b/mbzirc_ign/models/sensors/mbzirc_hd_long_range_camera/model.sdf
@@ -1,0 +1,52 @@
+<?xml version="1.0"?>
+<sdf version="1.9">
+    <model name="mbzirc_hd_long_range_camera">
+        <link name="sensor_link">
+            <inertial>
+                <mass>0.005</mass>
+                <inertia>
+                    <ixx>8.33e-06</ixx>
+                    <ixy>0</ixy>
+                    <ixz>0</ixz>
+                    <iyy>8.33e-06</iyy>
+                    <iyz>0</iyz>
+                    <izz>8.33e-06</izz>
+                </inertia>
+            </inertial>
+            <sensor name="camera" type="camera">
+                <always_on>1</always_on>
+                <update_rate>20</update_rate>
+                <camera name="camera">
+                    <horizontal_fov>1.0472</horizontal_fov>
+                    <lens>
+                        <intrinsics>
+                            <!-- fx = fy = width / ( 2 * tan (hfov / 2 ) ) -->
+                            <fx>1108.5</fx>
+                            <fy>1108.5</fy>
+                            <!-- cx = ( width + 1 ) / 2 -->
+                            <cx>640.5</cx>
+                            <!-- cy = ( height + 1 ) / 2 -->
+                            <cy>480.5</cy>
+                            <s>0</s>
+                        </intrinsics>
+                    </lens>
+                    <image>
+                        <width>1280</width>
+                        <height>960</height>
+                        <format>R8G8B8</format>
+                    </image>
+                    <clip>
+                        <near>0.01</near>
+                        <far>2000</far>
+                    </clip>
+                    <noise>
+                        <type>gaussian</type>
+                        <mean>0</mean>
+                        <stddev>0.007</stddev>
+                    </noise>
+                </camera>
+            </sensor>
+        </link>
+        <frame name="mount_point"/>
+    </model>
+</sdf>

--- a/mbzirc_ign/src/mbzirc_ign/payload_bridges.py
+++ b/mbzirc_ign/src/mbzirc_ign/payload_bridges.py
@@ -3,7 +3,8 @@ from mbzirc_ign.bridge import Bridge, BridgeDirection
 
 def camera_models():
     models = ['mbzirc_vga_camera',
-              'mbzirc_hd_camera']
+              'mbzirc_hd_camera',
+              'mbzirc_hd_long_range_camera']
     return models
 
 

--- a/mbzirc_ign/src/mbzirc_ign/test_bridges.py
+++ b/mbzirc_ign/src/mbzirc_ign/test_bridges.py
@@ -273,6 +273,10 @@ class TestPayloadBridges(unittest.TestCase):
         self.assertEqual(len(bridges), 2)
 
         bridges = payload_bridges.payload_bridges(
+            self.world_name, self.model_name, 'mbzirc_hd_long_range_camera', self.idx)
+        self.assertEqual(len(bridges), 2)
+
+        bridges = payload_bridges.payload_bridges(
             self.world_name, self.model_name, 'mbzirc_planar_lidar', self.idx)
         self.assertEqual(len(bridges), 2)
 

--- a/mbzirc_ros/test/launch/test_ros_api.launch.py
+++ b/mbzirc_ros/test/launch/test_ros_api.launch.py
@@ -56,7 +56,7 @@ def generate_test_description():
                'model' : 'mbzirc_quadrotor',
                'z'     : '0.08',}
     # add hd camera
-    arguments['slot0'] = 'mbzirc_hd_camera'
+    arguments['slot0'] = 'mbzirc_hd_long_range_camera'
     spawn_quadrotor = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
             os.path.join(


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

Added `mbzirc_hd_long_range_camera` sensor model.

It's a copy of the `mbzirc_hd_camera` model with the far clip plan increased from `300` to `2000`

The idea is to increase range of camera. To avoid breaking existing code, we add a new camera model instead of modifying the exiting one. 