### PR TITLE
Fix radar sample count

### DIFF
--- a/mbzirc_custom/mbzirc_naive_3d_scanning_radar/src/Naive3dScanningRadar.cc
+++ b/mbzirc_custom/mbzirc_naive_3d_scanning_radar/src/Naive3dScanningRadar.cc
@@ -144,8 +144,8 @@ void Naive3dScanningRadar::OnRadarScan(const ignition::msgs::LaserScan &_msg)
         else
         {
           range += r;
-          rangeSampleCount++;
         }
+        rangeSampleCount++;
       }
 
       // compute avg range


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

The radar works by using downsampling from raw lidar range values. When a number of valid consecutive hits / range values are found, it generates a radar reading with a range value. I noticed that the count of valid range values are only incremented on second valid range value. This PR fixes the issue. Before this change, we need at least 2 valid rays to generate a radar reading. After this change, we only need 1 valid lidar ray to generate a radar reading.

Given that the raw lidar rays are already dense, we usually get more than 1 consecutive hits. The improvement in the number of valid radar returns is small.

To test, launch coast world and spawn a USV with the radar model:

```
ros2 launch mbzirc_ros competition_local.launch.py ign_args:="-v 4 -r coast.sdf"
ros2 launch mbzirc_ign spawn.launch.py name:=usv world:=coast model:=usv x:=-1462 y:=-16.5 z:=0.3 R:=0 P:=0 Y:=0 slot0:=mbzirc_naive_3d_scanning_radar
```

Here is a python script to print out all the radar values in front of the USV:

<details><summary>subscriber.py</summary>

```py
import rclpy
from rclpy.node import Node
from radar_msgs.msg import RadarScan


class MinimalSubscriber(Node):

    def __init__(self):
        super().__init__('minimal_subscriber')
        self.subscription = self.create_subscription(
            RadarScan,
            '/usv/slot0/radar/scan',
            self.listener_callback,
            10)
        self.subscription  # prevent unused variable warning

    def listener_callback(self, msg):
        n_returns = len(msg.returns)
        self.get_logger().info('returns: {}'.format(n_returns))
        for ret in msg.returns:
            if ret.azimuth > -1.5 and ret.azimuth < 1.5:
                print(f'Azimuth: {ret.azimuth}, Range: {ret.range}, Elevation: {ret.elevation}')


def main(args=None):
    rclpy.init(args=args)

    minimal_subscriber = MinimalSubscriber()
    rclpy.spin(minimal_subscriber)
    minimal_subscriber.destroy_node()
    rclpy.shutdown()


if __name__ == '__main__':
    main()

```

</details>
