### PR TITLE
Fix payload bridge mapping when loading from config file

### DIFF
--- a/mbzirc_ign/config/coast/config_team.yaml
+++ b/mbzirc_ign/config/coast/config_team.yaml
@@ -24,7 +24,7 @@
     xyz: [-1500, 2, 4.3]
     rpy: [0, 0, 0]
   payload:
-    slot0:
+    slot3:
       sensor: 'mbzirc_hd_camera'
       rpy: [0, 0, 0]
 

--- a/mbzirc_ign/src/mbzirc_ign/model.py
+++ b/mbzirc_ign/src/mbzirc_ign/model.py
@@ -208,6 +208,7 @@ class Model:
         nodes = []
         payload_launches = []
         for (idx, k) in enumerate(sorted(payloads.keys())):
+            index = int(k[-1])
             p = payloads[k]
             if not p['sensor'] or p['sensor'] == 'None' or p['sensor'] == '':
                 continue
@@ -215,20 +216,20 @@ class Model:
             # check if it is a custom payload
             if self.is_custom_model(p['sensor']):
                 payload_launch = self.custom_payload_launch(world_name, self.model_name,
-                                                            p['sensor'], idx)
+                                                            p['sensor'], index)
                 if payload_launch is not None:
                     payload_launches.append(payload_launch)
 
             # if not custom payload, add our own bridges and nodes
             else:
                 model_prefix = ''
-                ros_slot_prefix = f'slot{idx}'
+                ros_slot_prefix = f'slot{index}'
                 if is_arm:
                     model_prefix = 'arm'
                     ros_slot_prefix = 'arm/' + ros_slot_prefix
                 bridges.extend(
                     mbzirc_ign.payload_bridges.payload_bridges(
-                        world_name, self.model_name, p['sensor'], idx, model_prefix))
+                        world_name, self.model_name, p['sensor'], index, model_prefix))
 
                 if p['sensor'] in mbzirc_ign.payload_bridges.camera_models():
                     nodes.append(Node(

--- a/mbzirc_ign/src/mbzirc_ign/test_model.py
+++ b/mbzirc_ign/src/mbzirc_ign/test_model.py
@@ -146,3 +146,36 @@ class TestModel(unittest.TestCase):
         self.assertIsInstance(team, list)
         self.assertEqual(len(team), 3)
         self.assertIsInstance(team[0], Model)
+        self.assertIsInstance(team[1], Model)
+        self.assertIsInstance(team[2], Model)
+
+        [payload_bridges0, payload_nodes0, launch0] = team[0].payload_bridges('coast')
+        self.assertEqual(len(payload_bridges0), 4)
+        for bridge in payload_bridges0[:2]:
+            mapping = bridge.remapping()
+            self.assertTrue('sensor_0' in mapping[0])
+            self.assertTrue('slot0' in mapping[1])
+        for bridge in payload_bridges0[-2:]:
+            mapping = bridge.remapping()
+            self.assertTrue('sensor_1' in mapping[0])
+            self.assertTrue('slot1' in mapping[1])
+        self.assertEqual(len(payload_nodes0), 1)
+        self.assertEqual(len(launch0), 0)
+
+        [payload_bridges1, payload_nodes1, launch1] = team[1].payload_bridges('coast')
+        self.assertEqual(len(payload_bridges1), 2)
+        for bridge in payload_bridges1:
+            mapping = bridge.remapping()
+            self.assertTrue('sensor_3' in mapping[0])
+            self.assertTrue('slot3' in mapping[1])
+        self.assertEqual(len(payload_nodes1), 1)
+        self.assertEqual(len(launch1), 0)
+
+        [payload_bridges2, payload_nodes2, launch2] = team[2].payload_bridges('coast')
+        self.assertEqual(len(payload_bridges2), 2)
+        for bridge in payload_bridges2:
+            mapping = bridge.remapping()
+            self.assertTrue('sensor_0' in mapping[0])
+            self.assertTrue('slot0' in mapping[1])
+        self.assertEqual(len(payload_nodes2), 0)
+        self.assertEqual(len(launch2), 0)


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

When launching sim with a config file, the payload bridge mapping string was generated incorrectly. This issue does not exist when launching sim and spawning robots manually.


To test, launch coast world with `config_team.yaml`:

```
ros2 launch mbzirc_ign competition.launch.py world:=coast config_file:=`ros2 pkg prefix mbzirc_ign`/share/mbzirc_ign/config/coast/config_team.yaml
```

Verify that you should now be able to see data in  the `/quadrotor_1/slot3/image_raw` topic, e.g using `rqt_image_view`

```
ros2 run rqt_image_view rqt_image_view
```

and select the `/quadrotor_1/slot3/image_raw` topic

Before this change, the slot number in the ros2 topic string was incorrectly generated as `slot0` when it should be `slot3`.
