### PR TITLE
Add stall option to cloudsim_bridge docker entrypoint

### DIFF
--- a/docker/cloudsim_bridge/run_bridge.bash
+++ b/docker/cloudsim_bridge/run_bridge.bash
@@ -5,9 +5,9 @@
 
 mkdir -p /tmp/ign/logs
 
-# Optionally stall simulation start to allow configuration files to be populated.
+# Optionally stall this bridge from starting to allow configuration files to be populated.
 # MBZIRC_STALL_START_PATH contains a path to a file.
-# If MBZIRC_STALL_START_PATH is set, stall the simulation start until the file exists.
+# If MBZIRC_STALL_START_PATH is set, stall the bridge from starting until the file exists.
 if [ -n "${MBZIRC_STALL_START_PATH}" ]; then
   echo "Waiting for configuration files to be ready."
   echo "Stalling until ${MBZIRC_STALL_START_PATH} exists."

--- a/docker/cloudsim_bridge/run_bridge.bash
+++ b/docker/cloudsim_bridge/run_bridge.bash
@@ -5,6 +5,21 @@
 
 mkdir -p /tmp/ign/logs
 
+# Optionally stall simulation start to allow configuration files to be populated.
+# MBZIRC_STALL_START_PATH contains a path to a file.
+# If MBZIRC_STALL_START_PATH is set, stall the simulation start until the file exists.
+if [ -n "${MBZIRC_STALL_START_PATH}" ]; then
+  echo "Waiting for configuration files to be ready."
+  echo "Stalling until ${MBZIRC_STALL_START_PATH} exists."
+
+  until [ -f "${MBZIRC_STALL_START_PATH}" ]; do
+     sleep 1
+  done
+
+  echo "Configurations file ready."
+  echo "Proceeding to start simulation."
+fi
+
 # atop process monitoring
 atop -R -w /tmp/ign/logs/atop_log &
 


### PR DESCRIPTION
When launching Cloudsim bridges and field computers (FCs) on networks without multicast, it is necessary to configure the `cyclonedds.xml` file with peer information so that bridges and FCs can discover each other and exchange information.

The `cyclonedds.xml` configuration file requires a `<Peer>` entry with the IP of the peer on both containers looking to communicate using unicast. Each container contains the IP address of the other container it wants to connect to. 

When launching in the cloud, IPs are not fixed, and they are not available until the container starts running, which is problematic due to the inherent cycle in the peer configuration. It is not possible to configure a container before launching, and it is not possible to launch a container before it is configured.

An optional env var `MBZIRC_STALL_START_PATH` was introduced that contains a path to a file, which when set, allows the container to run but stalls it from calling the launchfile until the file path exists. This allows for the configuration of the `cyclonedds.xml` file and any other additional configs before the bridge starts.