### PR TITLE
Fix suction grasping

### DIFF
--- a/mbzirc_ign/models/mbzirc_suction_gripper/model.sdf.erb
+++ b/mbzirc_ign/models/mbzirc_suction_gripper/model.sdf.erb
@@ -11,7 +11,7 @@ end
   <model name="suction_gripper">
     <link name='end_effector'>
       <inertial>
-        <mass>2</mass>
+        <mass>1</mass>
         <inertia>
           <ixx>0.00166667</ixx>
           <ixy>0</ixy>
@@ -46,7 +46,7 @@ end
     </link>
     <link name='suction'>
       <inertial>
-        <mass>2</mass>
+        <mass>1</mass>
         <inertia>
           <ixx>0.00166667</ixx>
           <ixy>0</ixy>

--- a/mbzirc_ign/src/multicopter_control/LeeVelocityController.cc
+++ b/mbzirc_ign/src/multicopter_control/LeeVelocityController.cc
@@ -86,7 +86,7 @@ bool LeeVelocityController::InitializeParameters()
 
 //////////////////////////////////////////////////
 void LeeVelocityController::CalculateRotorVelocities(
-    const FrameData &_frameData, const EigenTwist &_cmdVel,
+    const FrameData &_frameData, double _payloadMass, const EigenTwist &_cmdVel,
     Eigen::VectorXd &_rotorVelocities) const
 {
   Eigen::Vector3d acceleration =
@@ -96,8 +96,8 @@ void LeeVelocityController::CalculateRotorVelocities(
       this->ComputeDesiredAngularAcc(_frameData, _cmdVel, acceleration);
 
   // Project thrust onto body z axis.
-  double thrust = -this->vehicleParameters.mass *
-                  acceleration.dot(_frameData.pose.linear().col(2));
+  double massWithPayload = this->vehicleParameters.mass + _payloadMass;
+  double thrust = -massWithPayload * acceleration.dot(_frameData.pose.linear().col(2));
 
   Eigen::Vector4d angularAccelerationThrust;
   angularAccelerationThrust.block<3, 1>(0, 0) = angularAcceleration;

--- a/mbzirc_ign/src/multicopter_control/LeeVelocityController.hh
+++ b/mbzirc_ign/src/multicopter_control/LeeVelocityController.hh
@@ -68,6 +68,7 @@ namespace multicopter_control
     /// \param[out] _rotorVelocities Computed rotor velocities.
     public: void CalculateRotorVelocities(
                  const FrameData &_frameData,
+                 double _payloadMass,
                  const EigenTwist &_cmdVel,
                  Eigen::VectorXd &_rotorVelocities) const;
 

--- a/mbzirc_ign/src/multicopter_control/MulticopterVelocityControl.cc
+++ b/mbzirc_ign/src/multicopter_control/MulticopterVelocityControl.cc
@@ -33,6 +33,7 @@
 #include <sdf/sdf.hh>
 
 #include "ignition/gazebo/components/Actuators.hh"
+#include "ignition/gazebo/components/DetachableJoint.hh"
 #include "ignition/gazebo/components/Gravity.hh"
 #include "ignition/gazebo/components/Inertial.hh"
 #include "ignition/gazebo/components/Link.hh"
@@ -405,7 +406,29 @@ void MulticopterVelocityControl::PreUpdate(
     return;
   }
 
-  this->velocityController->CalculateRotorVelocities(*frameData, cmdVel,
+  // Accumulator for the total payload mass
+  double payloadMass = 0.;
+
+  // Check all DetachableJoint components to find connection to the payload
+  _ecm.Each<components::DetachableJoint>([&](const Entity &_entity,
+                                             const components::DetachableJoint* connection) {
+    // Filter those whose parent is our descendant
+    if (_ecm.Descendants(this->model.Entity()).count(connection->Data().parentLink)) {
+      // Get parent model of the attached joint's childLink, which is our payload
+      const auto maybeModel(Link(connection->Data().childLink).ParentModel(_ecm));
+      if (maybeModel) {
+        // Calculate mass of the whole payload model
+        double mass = this->VehicleInertial(_ecm, maybeModel->Entity()).MassMatrix().Mass();
+        // Add current mass to the accumulator
+        payloadMass += mass;
+      }
+    }
+    return true;
+  });
+
+  this->velocityController->CalculateRotorVelocities(*frameData,
+                                                     payloadMass,
+                                                     cmdVel,
                                                      this->rotorVelocities);
 
   this->PublishRotorVelocities(_ecm, this->rotorVelocities);


### PR DESCRIPTION
## Change suction gripper mass

Scales down mbzirc_suction_gripper mass from 2 kg to 1 kg. Full rationale is here: #190

## Fix copter controller to work with attached payloads

The existing design of the controller is definitely not suitable for drones carrying unknown payloads in the first place. Controller needs to know the mass of the drone to calculate the thrust to be applied and then it does not care whether it actually outputs enough thrust or not. Ideal solution would be to just drop the controller altogether and allow users to control attitude and thrust of the drone. However, since we cannot do any significant changes at this stage of the competition we believe our proposal is the best fit to solve the issue.

This change fixes the fact that `LeeVelocityController` uses the mass of the drone, but it does not take into account the mass of the payload object attached with a suction gripper.

- `LeeVelocityController::CalculateRotorVelocities` now takes payload mass, which is taken into account in thrust calculation.
- `MulticopterVelocityControl::PreUpdate` now checks for attached payloads and passes their mass down to the `CalculateRotorVelocities` function.