### PR TITLE
Add light weight suction gripper with updated multicopter velocity controller

### DIFF
--- a/mbzirc_ign/models/mbzirc_hexrotor/model.sdf.erb
+++ b/mbzirc_ign/models/mbzirc_hexrotor/model.sdf.erb
@@ -11,6 +11,7 @@ end
 
 $attitude_gain = '4 4 2'
 $motor_constant = '1.269e-05'
+$thrust_with_payload_mass = '0'
 if defined?($gripper_model)
   if $gripper_model.include?('mbzirc_oberon7_gripper')
     $attitude_gain = '25 25 2'
@@ -18,6 +19,9 @@ if defined?($gripper_model)
   elsif $gripper_model.include?('mbzirc_suction_gripper')
     $attitude_gain = '25 25 2'
     $motor_constant = '1.40e-05'
+  end
+  if $gripper_model.include?('_light')
+    $thrust_with_payload_mass = '1'
   end
 end
 
@@ -435,6 +439,7 @@ end
           <direction>-1</direction>
         </rotor>
       </rotorConfiguration>
+      <thrustWithPayloadMass><%= $thrust_with_payload_mass %></thrustWithPayloadMass>
     </plugin>
     <!-- Battery plugin -->
     <plugin filename="libignition-gazebo-linearbatteryplugin-system.so"

--- a/mbzirc_ign/models/mbzirc_quadrotor/model.sdf.erb
+++ b/mbzirc_ign/models/mbzirc_quadrotor/model.sdf.erb
@@ -11,6 +11,7 @@ end
 
 $attitude_gain = '2 3 0.15'
 $motor_constant = '8.54858e-06'
+$thrust_with_payload_mass = '0'
 if defined?($gripper_model)
   if $gripper_model.include?('mbzirc_oberon7_gripper')
     $attitude_gain = '10 10 0.15'
@@ -18,6 +19,9 @@ if defined?($gripper_model)
   elsif $gripper_model.include?('mbzirc_suction_gripper')
     $attitude_gain = '10 10 0.15'
     $motor_constant = '2.52e-05'
+  end
+  if $gripper_model.include?('_light')
+    $thrust_with_payload_mass = '1'
   end
 end
 
@@ -377,6 +381,7 @@ end
           <direction>-1</direction>
         </rotor>
       </rotorConfiguration>
+      <thrustWithPayloadMass><%= $thrust_with_payload_mass %></thrustWithPayloadMass>
     </plugin>
     <!-- Battery plugin -->
     <!-- Since we are interested in using time as the limiting factor -->

--- a/mbzirc_ign/models/mbzirc_suction_gripper_light/model.config
+++ b/mbzirc_ign/models/mbzirc_suction_gripper_light/model.config
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+
+<model>
+  <name>MBZIRC Suction Gripper Light</name>
+  <version>1.0</version>
+  <sdf version="1.9">model.sdf</sdf>
+
+  <description>
+    Lightweight version of the suction gripper for MBZIRC
+  </description>
+</model>

--- a/mbzirc_ign/models/mbzirc_suction_gripper_light/model.sdf.erb
+++ b/mbzirc_ign/models/mbzirc_suction_gripper_light/model.sdf.erb
@@ -1,0 +1,234 @@
+<%
+if !defined?(topic_prefix) || topic_prefix == nil || topic_prefix.empty?
+  $topic_prefix = ''
+else
+  $topic_prefix = topic_prefix
+end
+%>
+
+<?xml version="1.0" ?>
+<sdf version='1.9'>
+  <model name="suction_gripper">
+    <link name='end_effector'>
+      <inertial>
+        <mass>1</mass>
+        <inertia>
+          <ixx>0.00166667</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>0.00166667</iyy>
+          <iyz>0</iyz>
+          <izz>0.00166667</izz>
+         </inertia>
+      </inertial>
+      <collision name='end_effector_collision'>
+        <pose>0.025 0 0 0 1.57079 0</pose>
+        <geometry>
+          <cylinder>
+            <radius>0.05</radius>
+            <length>0.05</length>
+          </cylinder>
+        </geometry>
+      </collision>
+      <visual name='end_effector_visual'>
+        <pose>0.025 0 0 0 1.57079 0</pose>
+        <geometry>
+          <cylinder>
+            <radius>0.05</radius>
+            <length>0.05</length>
+          </cylinder>
+        </geometry>
+        <material>
+          <diffuse>0.05 0.15 0.05</diffuse>
+          <specular>0.8 0.8 0.8</specular>
+        </material>
+      </visual>
+    </link>
+    <link name='suction'>
+      <inertial>
+        <mass>1</mass>
+        <inertia>
+          <ixx>0.00166667</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>0.00166667</iyy>
+          <iyz>0</iyz>
+          <izz>0.00166667</izz>
+         </inertia>
+      </inertial>
+
+      <collision name='suction_collision_11'>
+        <pose>0.0505 0 0 0 1.57079 0</pose>
+        <geometry>
+          <cylinder>
+            <radius>0.02</radius>
+            <length>0.01</length>
+          </cylinder>
+        </geometry>
+      </collision>
+      <visual name='suction_visual_11'>
+        <pose>0.0505 0 0 0 1.57079 0</pose>
+        <geometry>
+          <cylinder>
+            <radius>0.02</radius>
+            <length>0.01</length>
+          </cylinder>
+        </geometry>
+        <material>
+          <diffuse>0.02 0.02 0.02</diffuse>
+          <specular>0.3 0.3 0.3</specular>
+        </material>
+      </visual>
+      <sensor name='sensor_contact_11' type='contact'>
+        <contact>
+          <collision>suction_collision_11</collision>
+          <topic><%= $topic_prefix %>/gripper/contact_sensor_11</topic>
+        </contact>
+        <always_on>1</always_on>
+        <update_rate>100</update_rate>
+      </sensor>
+
+      <collision name='suction_collision_10'>
+        <pose>0.0505 0 -0.04 0 1.57079 0</pose>
+        <geometry>
+          <cylinder>
+            <radius>0.02</radius>
+            <length>0.01</length>
+          </cylinder>
+        </geometry>
+      </collision>
+      <visual name='suction_visual_10'>
+        <pose>0.0505 0 -0.04 0 1.57079 0</pose>
+        <geometry>
+          <cylinder>
+            <radius>0.02</radius>
+            <length>0.01</length>
+          </cylinder>
+        </geometry>
+        <material>
+          <diffuse>0.02 0.02 0.02</diffuse>
+          <specular>0.3 0.3 0.3</specular>
+        </material>
+      </visual>
+      <sensor name='sensor_contact_10' type='contact'>
+        <contact>
+          <collision>suction_collision_10</collision>
+          <topic><%= $topic_prefix %>/gripper/contact_sensor_10</topic>
+        </contact>
+        <always_on>1</always_on>
+        <update_rate>100</update_rate>
+      </sensor>
+
+      <collision name='suction_collision_12'>
+        <pose>0.0505 0 0.04 0 1.57079 0</pose>
+        <geometry>
+          <cylinder>
+            <radius>0.02</radius>
+            <length>0.01</length>
+          </cylinder>
+        </geometry>
+      </collision>
+      <visual name='suction_visual_12'>
+        <pose>0.0505 0 0.04 0 1.57079 0</pose>
+        <geometry>
+          <cylinder>
+            <radius>0.02</radius>
+            <length>0.01</length>
+          </cylinder>
+        </geometry>
+        <material>
+          <diffuse>0.02 0.02 0.02</diffuse>
+          <specular>0.3 0.3 0.3</specular>
+        </material>
+      </visual>
+      <sensor name='sensor_contact_12' type='contact'>
+        <contact>
+          <collision>suction_collision_12</collision>
+          <topic><%= $topic_prefix %>/gripper/contact_sensor_12</topic>
+        </contact>
+        <always_on>1</always_on>
+        <update_rate>100</update_rate>
+      </sensor>
+
+      <collision name='suction_collision_01'>
+        <pose>0.0505 -0.04 0 0 1.57079 0</pose>
+        <geometry>
+          <cylinder>
+            <radius>0.02</radius>
+            <length>0.01</length>
+          </cylinder>
+        </geometry>
+      </collision>
+      <visual name='suction_visual_01'>
+        <pose>0.0505 -0.04 0 0 1.57079 0</pose>
+        <geometry>
+          <cylinder>
+            <radius>0.02</radius>
+            <length>0.01</length>
+          </cylinder>
+        </geometry>
+        <material>
+          <diffuse>0.02 0.02 0.02</diffuse>
+          <specular>0.3 0.3 0.3</specular>
+        </material>
+      </visual>
+      <sensor name='sensor_contact_01' type='contact'>
+        <contact>
+          <collision>suction_collision_01</collision>
+          <topic><%= $topic_prefix %>/gripper/contact_sensor_01</topic>
+        </contact>
+        <always_on>1</always_on>
+        <update_rate>100</update_rate>
+      </sensor>
+
+      <collision name='suction_collision_21'>
+        <pose>0.0505 0.04 0 0 1.57079 0</pose>
+        <geometry>
+          <cylinder>
+            <radius>0.02</radius>
+            <length>0.01</length>
+          </cylinder>
+        </geometry>
+      </collision>
+      <visual name='suction_visual_21'>
+        <pose>0.0505 0.04 0 0 1.57079 0</pose>
+        <geometry>
+          <cylinder>
+            <radius>0.02</radius>
+            <length>0.01</length>
+          </cylinder>
+        </geometry>
+        <material>
+          <diffuse>0.02 0.02 0.02</diffuse>
+          <specular>0.3 0.3 0.3</specular>
+        </material>
+      </visual>
+      <sensor name='sensor_contact_21' type='contact'>
+        <contact>
+          <collision>suction_collision_21</collision>
+          <topic><%= $topic_prefix %>/gripper/contact_sensor_21</topic>
+        </contact>
+        <always_on>1</always_on>
+        <update_rate>100</update_rate>
+      </sensor>
+
+    </link>
+
+    <joint name='suction_joint' type='fixed'>
+      <parent>end_effector</parent>
+      <child>suction</child>
+    </joint>
+
+    <!-- Controller -->
+    <plugin
+      filename="libSuctionGripper.so"
+      name="mbzirc::SuctionGripperPlugin">
+      <parent_link>suction</parent_link>
+      <contact_sensor_topic_prefix><%= $topic_prefix %>/gripper</contact_sensor_topic_prefix>
+      <command_topic><%= $topic_prefix %>/gripper/suction_on</command_topic>
+    </plugin>
+
+    <frame name="mount_point"/>
+
+  </model>
+</sdf>

--- a/mbzirc_ign/src/mbzirc_ign/model.py
+++ b/mbzirc_ign/src/mbzirc_ign/model.py
@@ -50,7 +50,8 @@ ARMS = [
 
 GRIPPERS = [
     'mbzirc_oberon7_gripper',
-    'mbzirc_suction_gripper'
+    'mbzirc_suction_gripper',
+    'mbzirc_suction_gripper_light',
 ]
 
 WAVEFIELD_SIZE = {'simple_demo': 1000, 'coast': 6000}
@@ -159,7 +160,7 @@ class Model:
         if self.has_valid_gripper():
             isAttachedToArm = self.is_USV()
             # gripper joint pos cmd
-            if self.gripper == 'mbzirc_oberon7_gripper':
+            if 'mbzirc_oberon7_gripper' in self.gripper:
                 # gripper_joint states
                 bridges.append(
                     mbzirc_ign.bridges.gripper_joint_states(world_name, self.model_name,
@@ -175,7 +176,7 @@ class Model:
                         mbzirc_ign.bridges.gripper_joint_force_torque(
                             self.model_name, joint, isAttachedToArm)
                     )
-            elif self.gripper == 'mbzirc_suction_gripper':
+            elif 'mbzirc_suction_gripper' in self.gripper:
                 bridges.append(
                     mbzirc_ign.bridges.gripper_suction_control(self.model_name, isAttachedToArm)
                 )

--- a/mbzirc_ign/src/multicopter_control/LeeVelocityController.cc
+++ b/mbzirc_ign/src/multicopter_control/LeeVelocityController.cc
@@ -86,7 +86,7 @@ bool LeeVelocityController::InitializeParameters()
 
 //////////////////////////////////////////////////
 void LeeVelocityController::CalculateRotorVelocities(
-    const FrameData &_frameData, const EigenTwist &_cmdVel,
+    const FrameData &_frameData, double _payloadMass, const EigenTwist &_cmdVel,
     Eigen::VectorXd &_rotorVelocities) const
 {
   Eigen::Vector3d acceleration =
@@ -96,8 +96,9 @@ void LeeVelocityController::CalculateRotorVelocities(
       this->ComputeDesiredAngularAcc(_frameData, _cmdVel, acceleration);
 
   // Project thrust onto body z axis.
-  double thrust = -this->vehicleParameters.mass *
-                  acceleration.dot(_frameData.pose.linear().col(2));
+  double massWithPayload = this->vehicleParameters.mass + _payloadMass;
+  double thrust = -massWithPayload *
+      acceleration.dot(_frameData.pose.linear().col(2));
 
   Eigen::Vector4d angularAccelerationThrust;
   angularAccelerationThrust.block<3, 1>(0, 0) = angularAcceleration;

--- a/mbzirc_ign/src/multicopter_control/LeeVelocityController.hh
+++ b/mbzirc_ign/src/multicopter_control/LeeVelocityController.hh
@@ -64,10 +64,12 @@ namespace multicopter_control
     /// commanded velocity
     /// \param[in] _frameData Frame data including pose and linear and angular
     /// velocities
+    /// \param[in] _payloadMass Mass of payload
     /// \param[in] _cmdVel Commanded velocity
     /// \param[out] _rotorVelocities Computed rotor velocities.
     public: void CalculateRotorVelocities(
                  const FrameData &_frameData,
+                 double _payloadMass,
                  const EigenTwist &_cmdVel,
                  Eigen::VectorXd &_rotorVelocities) const;
 

--- a/mbzirc_ign/src/multicopter_control/MulticopterVelocityControl.hh
+++ b/mbzirc_ign/src/multicopter_control/MulticopterVelocityControl.hh
@@ -235,6 +235,9 @@ namespace systems
     /// \brief Maximum commanded angular velocity
     private: math::Vector3d maximumAngularVelocity;
 
+    /// \brief Compute thrust by taking into account payload mass
+    private: bool thrustWithPayloadMass = false;
+
     /// \brief Mutex for cmdVelMsg
     private: std::mutex cmdVelMsgMutex;
 


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

Alternative to #194 

In comparison to #194, this PR adds the proposed changes while preserving existing behavior of multicopters with the original suction grippers by

* adding a new `mbzirc_suction_gripper_light` model with the proposed mass changes
* adding a parameter to multicopter velocity controller plugin to enable/disable rotor thrust computation changes
    * the updated controller with the thrust changes is only enabled if a quad / hexrotor is equipped with the lightweight version of the suction gripper

Some minor issues I noticed when testing the lightweight gripper:

* a quadrotor with light weight suction gripper and no payload drifts slowly upwards in z when set to hover, i.e. linear vel set to zero
* a hexrotor with light weight suction gripper is slight more unstable compared to the original suction gripper.

It's possible that we could tune other params to make the flight behavior more stable but at this stage, we prefer not to make more changes. The original gripper has its own caveats. We just give the users an extra option to choose whichever works best for them.

To test:

1. launch the test environment
    ```
    ros2 launch ros_ign_gazebo ign_gazebo.launch.py ign_args:="-v 4 -r test/simple_demo_manip.sdf"
    ```

1. Remove a test model in this environment that is not needed

    ```
    ign service -s /world/simple_demo/remove --reqtype ignition.msgs.Entity --reptype ignition.msgs.Boolean --timeout 300 --req 'name: "box1kg" type: MODEL'
    ```


1. Spawn a quadrotor with the lightweight suction gripper - the new gripper should be green in color

    ```
    ros2 launch mbzirc_ign spawn.launch.py name:=quadrotor_1 world:=simple_demo model:=mbzirc_quadrotor type:=uav x:=-0  y:=2.05 z:=1.92 R:=0 P:=0 Y:=0 gripper:=mbzirc_suction_gripper_light
    ```

1. Enable suction

    ```
    ros2 topic pub --once /quadrotor_1/gripper/suction_on std_msgs/msg/Bool 'data: True'
    ```

1. Take off with the blue small box payload

    ```
    ros2 topic pub --once /quadrotor_1/cmd_vel geometry_msgs/msg/Twist '{linear: {x: 0.0, y: 0.0, z: 5}, angular: {x: 0.0, y: 0.0, z: 0.0}}'
    ```

    the quadrotor should fly upwards in z faster than with the original suction gripper

1. Make the quadrotor hover

    ```
    ros2 topic pub --once /quadrotor_1/cmd_vel geometry_msgs/msg/Twist '{linear: {x: 0.0, y: 0.0, z: 0}, angular: {x: 0.0, y: 0.0, z: 0.0}}'
    ```

    the quadrotor should hover in place with some small drift