### PR TITLE
Save target report images

### DIFF
--- a/mbzirc_ros/CMakeLists.txt
+++ b/mbzirc_ros/CMakeLists.txt
@@ -10,6 +10,8 @@ set(IGN_MATH_VER ${ignition-math6_VERSION_MAJOR})
 find_package(ignition-msgs8 REQUIRED)
 find_package(ignition-transport11 REQUIRED)
 set(IGN_TRANSPORT_VER ${ignition-transport11_VERSION_MAJOR})
+find_package(ignition-common4 REQUIRED)
+set(IGN_COMMON_VER ${ignition-common4_VERSION_MAJOR})
 find_package(mavros_msgs REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(ros_ign_interfaces REQUIRED)
@@ -18,6 +20,7 @@ find_package(sensor_msgs REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(tf2_msgs REQUIRED)
 find_package(tf2_ros REQUIRED)
+find_package(cv_bridge REQUIRED)
 
 add_executable(fixed_wing_bridge src/fixed_wing_bridge.cc)
 ament_target_dependencies(fixed_wing_bridge
@@ -50,10 +53,12 @@ ament_target_dependencies(pose_tf_broadcaster
 
 add_executable(video_target_relay src/video_target_relay.cc)
 ament_target_dependencies(video_target_relay
+  cv_bridge
   rclcpp
   ros_ign_interfaces
   sensor_msgs
   ignition-transport${IGN_TRANSPORT_VER}
+  ignition-common${IGN_COMMON_VER}
 )
 
 add_executable(video_stream_publisher examples/video_stream_publisher.cc)

--- a/mbzirc_ros/package.xml
+++ b/mbzirc_ros/package.xml
@@ -12,6 +12,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <depend>cv_bridge</depend>
   <depend>geometry_msgs</depend>
   <depend>mavros_msgs</depend>
   <depend>rclcpp</depend>


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

The changes enable 2 sets of images to be saved when a target is reported:
1. An image from the image stream transmitted by the user (over comms) is saved.
    * I added a new dependency, `cv_bridge`, for saving `sensor_msgs::msgs::Image` to file. So you'll need to run `rosdep` again or `apt install ros-galactic-cv-bridge` if you don't have this package.
    * This image file is saved  to `~/.ros/mbzirc`. Reason is that the video relay node is run on the bridge container on the cloud, and in this container we are uploading the `.ros` directory to s3. 
    * Only the last image of a particular target type is saved, e.g. if the user reported small target vessel twice, the last one will be saved.
3. An image is saved by the `GameLogicPlugin`. The image is taken from the rendering camera in the simulator when a report is received. This is the original uncompressed image. 
    * The image is saved to `/tmp/ign/mbzirc/logs/target_images`.
    * One image is saved per report, e.g. f the user reported small target vessel twice, there will be 2 images.

To test, follow the same instructions for reporting targets in https://github.com/osrf/mbzirc/pull/195. Make sure to apply the diff for making the drone and vessel static. After each target report, you should see new png files saved in `~/.ros/mbzirc/` and `/tmp/ign/mbzirc/logs/target_images`.