### PR TITLE
Set log recording period

### DIFF
--- a/mbzirc_ign/worlds/coast.sdf
+++ b/mbzirc_ign/worlds/coast.sdf
@@ -349,6 +349,7 @@
       filename="ignition-gazebo-log-system"
       name="ignition::gazebo::systems::LogRecord">
       <record_path>/tmp/ign/mbzirc/playback</record_path>
+      <record_period>0.008</record_period>
     </plugin>
 
     <scene>

--- a/mbzirc_ign/worlds/coast_cloud.sdf
+++ b/mbzirc_ign/worlds/coast_cloud.sdf
@@ -349,6 +349,7 @@
       filename="ignition-gazebo-log-system"
       name="ignition::gazebo::systems::LogRecord">
       <record_path>/tmp/ign/mbzirc/playback</record_path>
+      <record_period>0.008</record_period>
     </plugin>
 
     <scene>

--- a/mbzirc_ign/worlds/simple_demo.sdf
+++ b/mbzirc_ign/worlds/simple_demo.sdf
@@ -90,6 +90,7 @@
       filename="ignition-gazebo-log-system"
       name="ignition::gazebo::systems::LogRecord">
       <record_path>/tmp/ign/mbzirc/playback</record_path>
+      <record_period>0.008</record_period>
     </plugin>
 
     <scene>


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

Depends on https://github.com/gazebosim/gz-sim/pull/1636

This reduces the rate at which states are being recorded. Main motivation is to reduce log size and and impact on performance during the run. Currently we are getting >18GB log files for a full 60min run.

In my local testing, before this change, for a run of 30s, the state.tlog is roughly ~132MB when testing locally with the mbzirc_seed solution. After changing the recording period to 8ms (double the 4ms step size), the state.tlog is now roughly ~66MB. By just looking at these numbers, a run of 60min equates to 15.8GB -> 7.9GB reduction in log size. 

