### PR TITLE
Recalculate wavefield values when service call succeeds

### DIFF
--- a/mbzirc_ign/src/Wavefield.cc
+++ b/mbzirc_ign/src/Wavefield.cc
@@ -358,6 +358,7 @@ void Wavefield::Load(const std::shared_ptr<const sdf::Element> &_sdf)
       {
         this->data->gain = gain;
         this->data->period = period;
+        this->data->Recalculate();
       }
     }
   }


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

Follow up to https://github.com/osrf/mbzirc/pull/206 that added a service for requesting global wavefield params. This PR adds a `Recalculate()` call so that the wavefield changes actually take place. This should only affect the `coast_cloud` world which has `wavefield` param specified in `GameLogicPlugin`