### PR TITLE
Remove save image call

### DIFF
--- a/mbzirc_ign/src/GameLogicPlugin.cc
+++ b/mbzirc_ign/src/GameLogicPlugin.cc
@@ -2334,7 +2334,7 @@ void GameLogicPluginPrivate::OnPostRender()
   if (this->camera && !this->targetInStreamReport.type.empty())
   {
     // save image of target report to log dir
-    this->SaveImage(this->targetInStreamReport.type);
+    // this->SaveImage(this->targetInStreamReport.type);
 
     // check if the specified img pos contains the target visual
     // using the FindTargetVisual function below


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

The save image logging feature was added in https://github.com/osrf/mbzirc/pull/204 but seems to cause a crash as seen in the backtrace of this comment: https://github.com/osrf/mbzirc/issues/209#issue-1337969973. Removing the save image functionality in GameLogicPlugin. We should still have the images saved by the [video target relay](https://github.com/osrf/mbzirc/blob/main/mbzirc_ros/src/video_target_relay.cc#L146) bridge.