### PR TITLE
Remove ROS_LOCALHOST_ONY env var in docker compose file

### DIFF
--- a/docker/compose/gen_docker_compose.py
+++ b/docker/compose/gen_docker_compose.py
@@ -76,7 +76,6 @@ def run_main():
           - XAUTHORITY=/tmp/.docker.xauth
           - IGN_PARTITION=sim
           - IGN_IP=172.28.1.1
-          - ROS_LOCALHOST_ONLY=1
           - ROS_DOMAIN_ID=99
         privileged: true
         runtime: nvidia


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

This is causing ROS issues when many robots are being spawned into simulation. 

The changes does not affect cloud simulation / final evaluation. This is only for testing locally using docker compose.

More info:

When this var is set, cyclonedds adds `LOCALHOST` as a peer and uses the default [max auto participants](https://github.com/eclipse-cyclonedds/cyclonedds/blob/master/docs/manual/options.md#cycloneddsdomaindiscoverymaxautoparticipantindex) value which is 9. This limits the number of ROS nodes that can be launched. We can resolve this issue by setting the `MaxAutoParticipantsIndex` field using a cyclonedds configuration file or simply just remove this var. 